### PR TITLE
Add Connections tab, Purposes tab, per-conversation selector (closes #1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ path = "../desktop-assistant/crates/client-common"
 
 [dependencies.desktop-assistant-api-model]
 path = "../desktop-assistant/crates/api-model"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::SignalEvent;
 use desktop_assistant_client_common::{
     AssistantClient, ConnectionConfig, TransportClient, connect_transport,
@@ -57,6 +58,16 @@ pub enum UiMessage {
         conversation_id: String,
         title: String,
     },
+    /// A one-time advisory for a conversation (e.g. the stored model
+    /// selection no longer resolves and was cleared).
+    ConversationWarning {
+        conversation_id: String,
+        warning: api::ConversationWarning,
+    },
+    /// Aggregated model listings (across all healthy connections) from the
+    /// most recent `ListAvailableModels` call — used to repopulate the
+    /// per-conversation model selector.
+    ModelsLoaded(Vec<api::ModelListing>),
     PromptSent {
         request_id: String,
     },
@@ -172,6 +183,27 @@ pub async fn connection_manager(
                     }
                 }
 
+                // Refresh aggregated model list so the per-conversation
+                // selector can populate. Failure is non-fatal — the
+                // dropdown simply stays empty.
+                if let Some(ws) = transport.as_ws() {
+                    match ws
+                        .send_command(api::Command::ListAvailableModels {
+                            connection_id: None,
+                            refresh: false,
+                        })
+                        .await
+                    {
+                        Ok(api::CommandResult::Models(listings)) => {
+                            let _ = ui_tx.send(UiMessage::ModelsLoaded(listings));
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!("Failed to list available models: {e}");
+                        }
+                    }
+                }
+
                 // Forward signals until disconnect
                 while let Some(signal) = signal_rx.recv().await {
                     let msg = match signal {
@@ -201,6 +233,13 @@ pub async fn connection_manager(
                         } => UiMessage::TitleChanged {
                             conversation_id,
                             title,
+                        },
+                        SignalEvent::ConversationWarning {
+                            conversation_id,
+                            warning,
+                        } => UiMessage::ConversationWarning {
+                            conversation_id,
+                            warning,
                         },
                         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
                     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 mod async_bridge;
 mod avatars;
 mod credential_store;
+mod management_client;
 mod markdown;
 mod oauth;
 mod profile;
+mod selection_store;
 #[cfg(feature = "linux")]
 mod webview;
 mod widgets;

--- a/src/management_client.rs
+++ b/src/management_client.rs
@@ -1,0 +1,140 @@
+//! Thin wrapper over the live `TransportClient` for named-connection
+//! management commands.
+//!
+//! Uses the WS connection's raw `send_command` escape hatch (exposed by
+//! `client-common`). Returns typed results so callers don't need to pattern
+//! match the protocol envelope.
+
+use anyhow::{Result, anyhow};
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::TransportClient;
+
+fn ws<'a>(transport: &'a TransportClient) -> Result<&'a desktop_assistant_client_common::ws_client::WsClient> {
+    transport
+        .as_ws()
+        .ok_or_else(|| anyhow!("named-connection management requires a WebSocket transport"))
+}
+
+pub async fn list_connections(transport: &TransportClient) -> Result<Vec<api::ConnectionView>> {
+    let result = ws(transport)?.send_command(api::Command::ListConnections).await?;
+    match result {
+        api::CommandResult::Connections(list) => Ok(list),
+        other => Err(anyhow!("unexpected response for ListConnections: {other:?}")),
+    }
+}
+
+pub async fn create_connection(
+    transport: &TransportClient,
+    id: String,
+    config: api::ConnectionConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::CreateConnection { id, config })
+        .await?;
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for CreateConnection: {other:?}")),
+    }
+}
+
+pub async fn update_connection(
+    transport: &TransportClient,
+    id: String,
+    config: api::ConnectionConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::UpdateConnection { id, config })
+        .await?;
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for UpdateConnection: {other:?}")),
+    }
+}
+
+pub async fn delete_connection(
+    transport: &TransportClient,
+    id: String,
+    force: bool,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::DeleteConnection { id, force })
+        .await?;
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for DeleteConnection: {other:?}")),
+    }
+}
+
+pub async fn list_available_models(
+    transport: &TransportClient,
+    connection_id: Option<String>,
+    refresh: bool,
+) -> Result<Vec<api::ModelListing>> {
+    let result = ws(transport)?
+        .send_command(api::Command::ListAvailableModels {
+            connection_id,
+            refresh,
+        })
+        .await?;
+    match result {
+        api::CommandResult::Models(m) => Ok(m),
+        other => Err(anyhow!("unexpected response for ListAvailableModels: {other:?}")),
+    }
+}
+
+pub async fn get_purposes(transport: &TransportClient) -> Result<api::PurposesView> {
+    let result = ws(transport)?.send_command(api::Command::GetPurposes).await?;
+    match result {
+        api::CommandResult::Purposes(p) => Ok(p),
+        other => Err(anyhow!("unexpected response for GetPurposes: {other:?}")),
+    }
+}
+
+pub async fn set_purpose(
+    transport: &TransportClient,
+    purpose: api::PurposeKindApi,
+    config: api::PurposeConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::SetPurpose { purpose, config })
+        .await?;
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for SetPurpose: {other:?}")),
+    }
+}
+
+pub async fn send_prompt_with_override(
+    transport: &TransportClient,
+    conversation_id: String,
+    content: String,
+    override_selection: Option<api::SendPromptOverride>,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::SendMessage {
+            conversation_id,
+            content,
+            override_selection,
+        })
+        .await?;
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for SendMessage: {other:?}")),
+    }
+}
+
+/// Fetch the raw `api::ConversationView` so callers can inspect warnings
+/// (which the higher-level `ConversationDetail` strips). Falls back to a
+/// view with empty warnings when the transport is not WebSocket.
+pub async fn get_conversation_view(
+    transport: &TransportClient,
+    id: &str,
+) -> Result<api::ConversationView> {
+    let result = ws(transport)?
+        .send_command(api::Command::GetConversation { id: id.to_string() })
+        .await?;
+    match result {
+        api::CommandResult::Conversation(view) => Ok(view),
+        other => Err(anyhow!("unexpected response for GetConversation: {other:?}")),
+    }
+}

--- a/src/selection_store.rs
+++ b/src/selection_store.rs
@@ -1,0 +1,174 @@
+//! Persistence of per-conversation model selections.
+//!
+//! The daemon stores its own `last_model_selection` on the conversation row
+//! and uses it as the implicit override when no per-send override is
+//! supplied. The daemon does not currently echo that stored value back on
+//! `GetConversation` — so for UI hydration (showing *which* model is
+//! "stuck" to a conversation when the user re-opens it) we keep a local
+//! mirror keyed by conversation id. The daemon remains the source of
+//! truth; this mirror is best-effort.
+//!
+//! Layout: `~/.config/adele-gtk/conversation_selections.json`.
+
+use anyhow::{Context, Result};
+use desktop_assistant_api_model as api;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredSelection {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<api::EffortLevel>,
+}
+
+impl StoredSelection {
+    pub fn as_override(&self) -> api::SendPromptOverride {
+        api::SendPromptOverride {
+            connection_id: self.connection_id.clone(),
+            model_id: self.model_id.clone(),
+            effort: self.effort,
+        }
+    }
+}
+
+impl From<api::ConversationModelSelectionView> for StoredSelection {
+    fn from(v: api::ConversationModelSelectionView) -> Self {
+        Self {
+            connection_id: v.connection_id,
+            model_id: v.model_id,
+            effort: v.effort,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct SelectionsFile {
+    #[serde(default)]
+    selections: BTreeMap<String, StoredSelection>,
+}
+
+pub struct SelectionStore {
+    path: PathBuf,
+    cache: RwLock<BTreeMap<String, StoredSelection>>,
+}
+
+impl SelectionStore {
+    pub fn new() -> Self {
+        let path = dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("adele-gtk")
+            .join("conversation_selections.json");
+        let cache = RwLock::new(Self::load_from_disk(&path).unwrap_or_default());
+        Self { path, cache }
+    }
+
+    fn load_from_disk(path: &PathBuf) -> Result<BTreeMap<String, StoredSelection>> {
+        if !path.exists() {
+            return Ok(BTreeMap::new());
+        }
+        let data = std::fs::read_to_string(path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        let file: SelectionsFile =
+            serde_json::from_str(&data).with_context(|| "parsing conversation_selections.json")?;
+        Ok(file.selections)
+    }
+
+    fn save_to_disk(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let map = self.cache.read().expect("selection cache poisoned").clone();
+        let file = SelectionsFile { selections: map };
+        let data = serde_json::to_string_pretty(&file)?;
+        std::fs::write(&self.path, data)?;
+        Ok(())
+    }
+
+    /// Get the last selection for a given conversation, if any.
+    pub fn get(&self, conversation_id: &str) -> Option<StoredSelection> {
+        self.cache
+            .read()
+            .expect("selection cache poisoned")
+            .get(conversation_id)
+            .cloned()
+    }
+
+    /// Persist a selection for a conversation. Errors writing to disk are
+    /// logged but not surfaced — the in-memory cache is always updated.
+    pub fn set(&self, conversation_id: &str, selection: StoredSelection) {
+        self.cache
+            .write()
+            .expect("selection cache poisoned")
+            .insert(conversation_id.to_string(), selection);
+        if let Err(e) = self.save_to_disk() {
+            tracing::warn!("failed to persist conversation selection: {e}");
+        }
+    }
+
+    /// Forget any stored selection for a conversation (e.g. on
+    /// DanglingModelSelection warning the daemon has already cleared its
+    /// side).
+    pub fn clear(&self, conversation_id: &str) {
+        self.cache
+            .write()
+            .expect("selection cache poisoned")
+            .remove(conversation_id);
+        if let Err(e) = self.save_to_disk() {
+            tracing::warn!("failed to persist conversation selection: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_selection_roundtrips_through_override() {
+        let stored = StoredSelection {
+            connection_id: "work".into(),
+            model_id: "gpt-5".into(),
+            effort: Some(api::EffortLevel::Medium),
+        };
+        let o = stored.as_override();
+        assert_eq!(o.connection_id, "work");
+        assert_eq!(o.model_id, "gpt-5");
+        assert_eq!(o.effort, Some(api::EffortLevel::Medium));
+    }
+
+    #[test]
+    fn from_conversation_model_selection_view() {
+        let v = api::ConversationModelSelectionView {
+            connection_id: "aws".into(),
+            model_id: "claude-sonnet-4".into(),
+            effort: Some(api::EffortLevel::High),
+        };
+        let s: StoredSelection = v.into();
+        assert_eq!(s.connection_id, "aws");
+        assert_eq!(s.model_id, "claude-sonnet-4");
+        assert_eq!(s.effort, Some(api::EffortLevel::High));
+    }
+
+    #[test]
+    fn selection_store_set_get_clear_via_tempdir() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let store = SelectionStore {
+            path: tempdir.path().join("sel.json"),
+            cache: RwLock::new(BTreeMap::new()),
+        };
+        let sel = StoredSelection {
+            connection_id: "c".into(),
+            model_id: "m".into(),
+            effort: None,
+        };
+        assert!(store.get("conv1").is_none());
+        store.set("conv1", sel.clone());
+        assert_eq!(store.get("conv1"), Some(sel));
+        store.clear("conv1");
+        assert!(store.get("conv1").is_none());
+    }
+}

--- a/src/widgets/connection_config_dialog.rs
+++ b/src/widgets/connection_config_dialog.rs
@@ -1,0 +1,415 @@
+//! Per-connector-type Configure dialog.
+//!
+//! Each connector variant has its own field set (Anthropic / OpenAI use an
+//! API-key-env-var + base_url; Bedrock uses AWS profile/region and has a
+//! "Refresh models" escape hatch; Ollama is just base_url). The dialog
+//! produces a `(id, ConnectionConfigView)` pair that the caller submits via
+//! `CreateConnection` or `UpdateConnection`.
+//!
+//! Credentials: the API model carries only the *name* of the env var that
+//! holds the API key. Storing the actual secret is out of scope for the
+//! dialog — the user is expected to set the env var externally (or have
+//! their OS keyring forward it). The field is labelled accordingly.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, Entry, Label, Orientation, Separator, Window,
+};
+
+/// Which connector type this dialog is configuring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectorType {
+    Anthropic,
+    OpenAi,
+    Bedrock,
+    Ollama,
+}
+
+impl ConnectorType {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Anthropic => "Anthropic",
+            Self::OpenAi => "OpenAI",
+            Self::Bedrock => "Bedrock",
+            Self::Ollama => "Ollama",
+        }
+    }
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+            Self::Bedrock => "bedrock",
+            Self::Ollama => "ollama",
+        }
+    }
+
+    pub fn from_slug(s: &str) -> Option<Self> {
+        match s {
+            "anthropic" => Some(Self::Anthropic),
+            "openai" => Some(Self::OpenAi),
+            "bedrock" => Some(Self::Bedrock),
+            "ollama" => Some(Self::Ollama),
+            _ => None,
+        }
+    }
+
+    pub fn empty_config(self) -> api::ConnectionConfigView {
+        match self {
+            Self::Anthropic => api::ConnectionConfigView::Anthropic {
+                base_url: None,
+                api_key_env: None,
+            },
+            Self::OpenAi => api::ConnectionConfigView::OpenAi {
+                base_url: None,
+                api_key_env: None,
+            },
+            Self::Bedrock => api::ConnectionConfigView::Bedrock {
+                aws_profile: None,
+                region: None,
+                base_url: None,
+            },
+            Self::Ollama => api::ConnectionConfigView::Ollama { base_url: None },
+        }
+    }
+}
+
+/// Sanitize a text entry into `Option<String>`, trimming and treating the
+/// empty string as `None`.
+fn text_opt(entry: &Entry) -> Option<String> {
+    let t = entry.text().trim().to_string();
+    if t.is_empty() { None } else { Some(t) }
+}
+
+/// Show the Configure dialog. `existing_id` distinguishes edit (Some) from
+/// create (None). `on_save` is called with the final `(id, config)` pair
+/// when the user clicks Save; the dialog closes on its own.
+///
+/// `on_refresh_models` is invoked for Bedrock's "Refresh models" button;
+/// only passed for Bedrock — it's a best-effort affordance and the dialog
+/// doesn't display the returned list.
+pub fn show_configure_dialog<FSave, FRefresh>(
+    parent: &impl IsA<Window>,
+    connector: ConnectorType,
+    existing: Option<(String, api::ConnectionConfigView)>,
+    on_save: FSave,
+    on_refresh_models: FRefresh,
+) where
+    FSave: Fn(String, api::ConnectionConfigView) + 'static,
+    FRefresh: Fn(String) + 'static,
+{
+    let title = match &existing {
+        Some((id, _)) => format!("Edit {} connection: {id}", connector.label()),
+        None => format!("Add {} connection", connector.label()),
+    };
+
+    let dialog = Window::builder()
+        .title(&title)
+        .default_width(440)
+        .default_height(320)
+        .modal(true)
+        .transient_for(parent)
+        .build();
+
+    let content = GtkBox::new(Orientation::Vertical, 10);
+    content.set_margin_start(20);
+    content.set_margin_end(20);
+    content.set_margin_top(20);
+    content.set_margin_bottom(20);
+
+    // Connection id.
+    let id_label = Label::new(Some("Connection id (slug)"));
+    id_label.set_halign(Align::Start);
+    content.append(&id_label);
+
+    let id_entry = Entry::new();
+    id_entry.set_placeholder_text(Some("e.g. work, aws-prod, local"));
+    if let Some((id, _)) = &existing {
+        id_entry.set_text(id);
+        id_entry.set_sensitive(false);
+    }
+    content.append(&id_entry);
+
+    content.append(&Separator::new(Orientation::Horizontal));
+
+    // Per-connector field map: we track entries by name in a Vec so the
+    // save-handler can pick them up regardless of which variant is shown.
+    #[derive(Clone)]
+    struct Field {
+        name: &'static str,
+        entry: Entry,
+    }
+    let fields: Rc<RefCell<Vec<Field>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let add_field = |label_text: &str,
+                         name: &'static str,
+                         placeholder: Option<&str>,
+                         initial: Option<&str>,
+                         secret: bool| {
+        let lab = Label::new(Some(label_text));
+        lab.set_halign(Align::Start);
+        content.append(&lab);
+        let entry = Entry::new();
+        if let Some(p) = placeholder {
+            entry.set_placeholder_text(Some(p));
+        }
+        if secret {
+            entry.set_visibility(false);
+        }
+        if let Some(v) = initial {
+            entry.set_text(v);
+        }
+        content.append(&entry);
+        fields.borrow_mut().push(Field {
+            name,
+            entry: entry.clone(),
+        });
+    };
+
+    let existing_config = existing.as_ref().map(|(_, c)| c.clone());
+    match connector {
+        ConnectorType::Anthropic => {
+            let (base_url, api_key_env) = match &existing_config {
+                Some(api::ConnectionConfigView::Anthropic {
+                    base_url,
+                    api_key_env,
+                }) => (base_url.clone(), api_key_env.clone()),
+                _ => (None, None),
+            };
+            add_field(
+                "Base URL (optional override)",
+                "base_url",
+                Some("https://api.anthropic.com"),
+                base_url.as_deref(),
+                false,
+            );
+            add_field(
+                "API key env var (e.g. ANTHROPIC_API_KEY)",
+                "api_key_env",
+                Some("ANTHROPIC_API_KEY"),
+                api_key_env.as_deref(),
+                false,
+            );
+            let hint = Label::new(Some(
+                "The daemon reads the API key from the named env var. Set it in your daemon environment (systemd unit, shell, etc.).",
+            ));
+            hint.set_halign(Align::Start);
+            hint.set_wrap(true);
+            hint.add_css_class("dim-label");
+            content.append(&hint);
+        }
+        ConnectorType::OpenAi => {
+            let (base_url, api_key_env) = match &existing_config {
+                Some(api::ConnectionConfigView::OpenAi {
+                    base_url,
+                    api_key_env,
+                }) => (base_url.clone(), api_key_env.clone()),
+                _ => (None, None),
+            };
+            add_field(
+                "Base URL (for OpenAI-compatible providers)",
+                "base_url",
+                Some("https://api.openai.com/v1"),
+                base_url.as_deref(),
+                false,
+            );
+            add_field(
+                "API key env var (e.g. OPENAI_API_KEY)",
+                "api_key_env",
+                Some("OPENAI_API_KEY"),
+                api_key_env.as_deref(),
+                false,
+            );
+            let hint = Label::new(Some(
+                "The daemon reads the API key from the named env var. Set it in your daemon environment.",
+            ));
+            hint.set_halign(Align::Start);
+            hint.set_wrap(true);
+            hint.add_css_class("dim-label");
+            content.append(&hint);
+        }
+        ConnectorType::Bedrock => {
+            let (aws_profile, region, base_url) = match &existing_config {
+                Some(api::ConnectionConfigView::Bedrock {
+                    aws_profile,
+                    region,
+                    base_url,
+                }) => (aws_profile.clone(), region.clone(), base_url.clone()),
+                _ => (None, None, None),
+            };
+            add_field(
+                "AWS profile (optional)",
+                "aws_profile",
+                Some("default"),
+                aws_profile.as_deref(),
+                false,
+            );
+            add_field(
+                "Region",
+                "region",
+                Some("us-west-2"),
+                region.as_deref(),
+                false,
+            );
+            add_field(
+                "Base URL override (optional)",
+                "base_url",
+                None,
+                base_url.as_deref(),
+                false,
+            );
+        }
+        ConnectorType::Ollama => {
+            let base_url = match &existing_config {
+                Some(api::ConnectionConfigView::Ollama { base_url }) => base_url.clone(),
+                _ => None,
+            };
+            add_field(
+                "Base URL",
+                "base_url",
+                Some("http://localhost:11434"),
+                base_url.as_deref(),
+                false,
+            );
+        }
+    }
+
+    // Bedrock-only: "Refresh models" button. Only enabled when editing
+    // (we need a valid id) and the handler is supplied.
+    if connector == ConnectorType::Bedrock {
+        content.append(&Separator::new(Orientation::Horizontal));
+        let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+        let refresh_btn = Button::with_label("Refresh models");
+        refresh_btn.set_tooltip_text(Some(
+            "Re-query Bedrock's ListFoundationModels and update the cached model list.",
+        ));
+        let note = Label::new(Some("(Saves first, then refreshes.)"));
+        note.add_css_class("dim-label");
+        btn_row.append(&refresh_btn);
+        btn_row.append(&note);
+        content.append(&btn_row);
+
+        let id_entry_ref = id_entry.clone();
+        let refresh_cb = Rc::new(on_refresh_models);
+        refresh_btn.connect_clicked(move |_| {
+            let id = id_entry_ref.text().trim().to_string();
+            if id.is_empty() {
+                return;
+            }
+            refresh_cb(id);
+        });
+    }
+
+    content.append(&Separator::new(Orientation::Horizontal));
+
+    let status = Label::new(None);
+    status.add_css_class("status-bar");
+    status.set_halign(Align::Start);
+    content.append(&status);
+
+    let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+    btn_box.set_halign(Align::End);
+    btn_box.set_margin_top(4);
+
+    let cancel_btn = Button::with_label("Cancel");
+    btn_box.append(&cancel_btn);
+
+    let save_btn = Button::with_label("Save");
+    save_btn.add_css_class("suggested-action");
+    btn_box.append(&save_btn);
+
+    content.append(&btn_box);
+    dialog.set_child(Some(&content));
+
+    let dialog_ref = dialog.clone();
+    cancel_btn.connect_clicked(move |_| dialog_ref.close());
+
+    let save_cb = Rc::new(on_save);
+    let dialog_ref = dialog.clone();
+    let fields_for_save = Rc::clone(&fields);
+    save_btn.connect_clicked(move |_| {
+        let id = id_entry.text().trim().to_string();
+        if id.is_empty() {
+            status.set_text("Connection id is required");
+            return;
+        }
+        if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+            status.set_text("Id may only contain letters, digits, '-', and '_'");
+            return;
+        }
+
+        let by_name = |n: &str| -> Option<String> {
+            fields_for_save
+                .borrow()
+                .iter()
+                .find(|f| f.name == n)
+                .and_then(|f| text_opt(&f.entry))
+        };
+
+        let config = match connector {
+            ConnectorType::Anthropic => api::ConnectionConfigView::Anthropic {
+                base_url: by_name("base_url"),
+                api_key_env: by_name("api_key_env"),
+            },
+            ConnectorType::OpenAi => api::ConnectionConfigView::OpenAi {
+                base_url: by_name("base_url"),
+                api_key_env: by_name("api_key_env"),
+            },
+            ConnectorType::Bedrock => api::ConnectionConfigView::Bedrock {
+                aws_profile: by_name("aws_profile"),
+                region: by_name("region"),
+                base_url: by_name("base_url"),
+            },
+            ConnectorType::Ollama => api::ConnectionConfigView::Ollama {
+                base_url: by_name("base_url"),
+            },
+        };
+
+        save_cb(id, config);
+        dialog_ref.close();
+    });
+
+    dialog.present();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connector_slug_roundtrip() {
+        for c in [
+            ConnectorType::Anthropic,
+            ConnectorType::OpenAi,
+            ConnectorType::Bedrock,
+            ConnectorType::Ollama,
+        ] {
+            assert_eq!(ConnectorType::from_slug(c.slug()), Some(c));
+        }
+        assert_eq!(ConnectorType::from_slug("unknown"), None);
+    }
+
+    #[test]
+    fn empty_config_has_correct_variant() {
+        assert!(matches!(
+            ConnectorType::Anthropic.empty_config(),
+            api::ConnectionConfigView::Anthropic { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::Bedrock.empty_config(),
+            api::ConnectionConfigView::Bedrock { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::Ollama.empty_config(),
+            api::ConnectionConfigView::Ollama { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::OpenAi.empty_config(),
+            api::ConnectionConfigView::OpenAi { .. }
+        ));
+    }
+}

--- a/src/widgets/connections_tab.rs
+++ b/src/widgets/connections_tab.rs
@@ -1,0 +1,219 @@
+//! Connections tab of the Settings dialog.
+//!
+//! Shows the live list of configured connections (`ListConnections`) with
+//! Add / Configure / Remove. The tab is a passive view — it asks the
+//! parent to perform the actual RPC work via callbacks. The parent (the
+//! Settings dialog) owns the `TransportClient` and the async bridge.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, MenuButton, Orientation, Popover,
+    ScrolledWindow, SelectionMode, Separator,
+};
+
+use super::connection_config_dialog::ConnectorType;
+
+type AddConnectionCb = Box<dyn Fn(ConnectorType)>;
+type ConnectionActionCb = Box<dyn Fn(String)>;
+
+pub struct ConnectionsTab {
+    pub container: GtkBox,
+    list_box: ListBox,
+    connections: Rc<RefCell<Vec<api::ConnectionView>>>,
+    on_add: Rc<RefCell<Option<AddConnectionCb>>>,
+    on_configure: Rc<RefCell<Option<ConnectionActionCb>>>,
+    on_remove: Rc<RefCell<Option<ConnectionActionCb>>>,
+}
+
+impl ConnectionsTab {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 8);
+        container.set_margin_start(12);
+        container.set_margin_end(12);
+        container.set_margin_top(12);
+        container.set_margin_bottom(12);
+
+        // Header row: title + Add menu.
+        let header = GtkBox::new(Orientation::Horizontal, 6);
+        let title = Label::new(Some("Connections"));
+        title.add_css_class("heading");
+        title.set_halign(Align::Start);
+        title.set_hexpand(true);
+        header.append(&title);
+
+        let add_button = MenuButton::new();
+        add_button.set_label("Add");
+        add_button.add_css_class("suggested-action");
+
+        let popover = Popover::new();
+        popover.add_css_class("context-popover");
+        let popover_box = GtkBox::new(Orientation::Vertical, 0);
+
+        let on_add: Rc<RefCell<Option<AddConnectionCb>>> = Rc::new(RefCell::new(None));
+        for connector in [
+            ConnectorType::Anthropic,
+            ConnectorType::OpenAi,
+            ConnectorType::Bedrock,
+            ConnectorType::Ollama,
+        ] {
+            let btn = Button::with_label(connector.label());
+            btn.add_css_class("context-button");
+            btn.set_halign(Align::Fill);
+            let on_add_inner = Rc::clone(&on_add);
+            let popover_ref = popover.clone();
+            btn.connect_clicked(move |_| {
+                popover_ref.popdown();
+                if let Some(ref cb) = *on_add_inner.borrow() {
+                    cb(connector);
+                }
+            });
+            popover_box.append(&btn);
+        }
+        popover.set_child(Some(&popover_box));
+        add_button.set_popover(Some(&popover));
+        header.append(&add_button);
+
+        container.append(&header);
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        let scrolled = ScrolledWindow::new();
+        scrolled.set_vexpand(true);
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(SelectionMode::None);
+        list_box.add_css_class("connections-list");
+        scrolled.set_child(Some(&list_box));
+        container.append(&scrolled);
+
+        Self {
+            container,
+            list_box,
+            connections: Rc::new(RefCell::new(Vec::new())),
+            on_add,
+            on_configure: Rc::new(RefCell::new(None)),
+            on_remove: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    pub fn connect_add<F>(&self, f: F)
+    where
+        F: Fn(ConnectorType) + 'static,
+    {
+        *self.on_add.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_configure<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_configure.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_remove<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_remove.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Fetch the live view for a given id, if currently loaded.
+    pub fn find(&self, id: &str) -> Option<api::ConnectionView> {
+        self.connections
+            .borrow()
+            .iter()
+            .find(|c| c.id == id)
+            .cloned()
+    }
+
+    /// Replace the list contents.
+    pub fn set_connections(&self, connections: &[api::ConnectionView]) {
+        while let Some(child) = self.list_box.first_child() {
+            self.list_box.remove(&child);
+        }
+        *self.connections.borrow_mut() = connections.to_vec();
+
+        if connections.is_empty() {
+            let row = ListBoxRow::new();
+            row.set_selectable(false);
+            let placeholder = Label::new(Some("No connections configured. Click Add to create one."));
+            placeholder.add_css_class("dim-label");
+            placeholder.set_margin_start(12);
+            placeholder.set_margin_end(12);
+            placeholder.set_margin_top(12);
+            placeholder.set_margin_bottom(12);
+            row.set_child(Some(&placeholder));
+            self.list_box.append(&row);
+            return;
+        }
+
+        for conn in connections {
+            let row = self.build_row(conn);
+            self.list_box.append(&row);
+        }
+    }
+
+    fn build_row(&self, conn: &api::ConnectionView) -> ListBoxRow {
+        let row = ListBoxRow::new();
+        row.set_selectable(false);
+
+        let hbox = GtkBox::new(Orientation::Horizontal, 12);
+        hbox.set_margin_start(10);
+        hbox.set_margin_end(10);
+        hbox.set_margin_top(8);
+        hbox.set_margin_bottom(8);
+
+        let text_col = GtkBox::new(Orientation::Vertical, 2);
+        text_col.set_hexpand(true);
+
+        let title = Label::new(Some(&format!("{}  ({})", conn.id, conn.connector_type)));
+        title.set_halign(Align::Start);
+        title.add_css_class("heading");
+        text_col.append(&title);
+
+        let availability_text = match &conn.availability {
+            api::ConnectionAvailability::Ok => "Available".to_string(),
+            api::ConnectionAvailability::Unavailable { reason } => {
+                format!("Unavailable: {reason}")
+            }
+        };
+        let creds_text = if conn.has_credentials {
+            "credentials: present"
+        } else {
+            "credentials: missing"
+        };
+        let subtitle = Label::new(Some(&format!("{availability_text} · {creds_text}")));
+        subtitle.set_halign(Align::Start);
+        subtitle.add_css_class("dim-label");
+        text_col.append(&subtitle);
+
+        hbox.append(&text_col);
+
+        let configure_btn = Button::with_label("Configure");
+        let on_configure = Rc::clone(&self.on_configure);
+        let id_for_configure = conn.id.clone();
+        configure_btn.connect_clicked(move |_| {
+            if let Some(ref cb) = *on_configure.borrow() {
+                cb(id_for_configure.clone());
+            }
+        });
+        hbox.append(&configure_btn);
+
+        let remove_btn = Button::with_label("Remove");
+        remove_btn.add_css_class("destructive-action");
+        let on_remove = Rc::clone(&self.on_remove);
+        let id_for_remove = conn.id.clone();
+        remove_btn.connect_clicked(move |_| {
+            if let Some(ref cb) = *on_remove.borrow() {
+                cb(id_for_remove.clone());
+            }
+        });
+        hbox.append(&remove_btn);
+
+        row.set_child(Some(&hbox));
+        row
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod chat_view;
 pub mod connection_config_dialog;
+pub mod connections_tab;
 pub mod input_bar;
 pub mod login_screen;
 pub mod model_selector;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -5,5 +5,6 @@ pub mod input_bar;
 pub mod login_screen;
 pub mod model_selector;
 pub mod purposes_tab;
+pub mod settings_dialog;
 pub mod setup_dialog;
 pub mod sidebar;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -4,5 +4,6 @@ pub mod connections_tab;
 pub mod input_bar;
 pub mod login_screen;
 pub mod model_selector;
+pub mod purposes_tab;
 pub mod setup_dialog;
 pub mod sidebar;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat_view;
+pub mod connection_config_dialog;
 pub mod input_bar;
 pub mod login_screen;
 pub mod model_selector;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod chat_view;
 pub mod input_bar;
 pub mod login_screen;
+pub mod model_selector;
 pub mod setup_dialog;
 pub mod sidebar;

--- a/src/widgets/model_selector.rs
+++ b/src/widgets/model_selector.rs
@@ -1,0 +1,257 @@
+//! Per-conversation model selector (next to the chat input).
+//!
+//! Shows a flat `Connection · Model` list aggregated across every healthy
+//! connection the daemon reports, plus a pinned, disabled `Auto (coming
+//! soon)` entry at the top. Selection is communicated back to the window
+//! via a callback; the window combines it with the per-conversation
+//! selection store and attaches the resulting override to each
+//! `SendMessage`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{Box as GtkBox, DropDown, Label, Orientation, StringList};
+
+type SelectCallback = Box<dyn Fn(Option<api::SendPromptOverride>)>;
+
+/// One row in the selector.
+#[derive(Debug, Clone)]
+enum Entry {
+    /// Pinned top row: `Auto (coming soon)` — disabled.
+    AutoPlaceholder,
+    /// Aggregated `Connection · Model` entry.
+    Model {
+        connection_id: String,
+        connection_label: String,
+        model_id: String,
+        model_label: String,
+    },
+}
+
+impl Entry {
+    fn display(&self) -> String {
+        match self {
+            Self::AutoPlaceholder => "Auto (coming soon)".to_string(),
+            Self::Model {
+                connection_label,
+                model_label,
+                ..
+            } => format!("{connection_label} · {model_label}"),
+        }
+    }
+}
+
+pub struct ModelSelector {
+    pub container: GtkBox,
+    dropdown: DropDown,
+    string_list: StringList,
+    entries: Rc<RefCell<Vec<Entry>>>,
+    on_select: Rc<RefCell<Option<SelectCallback>>>,
+    /// When true, setting the active index from code suppresses the user-driven callback.
+    suppress_callback: Rc<RefCell<bool>>,
+}
+
+impl ModelSelector {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Horizontal, 6);
+        container.set_margin_start(8);
+        container.set_margin_end(8);
+        container.set_margin_top(2);
+        container.set_margin_bottom(2);
+        container.set_valign(gtk4::Align::Center);
+
+        let label = Label::new(Some("Model:"));
+        label.add_css_class("dim-label");
+        container.append(&label);
+
+        let string_list = StringList::new(&[]);
+        let dropdown = DropDown::new(Some(string_list.clone()), gtk4::Expression::NONE);
+        dropdown.set_hexpand(true);
+        container.append(&dropdown);
+
+        let entries: Rc<RefCell<Vec<Entry>>> = Rc::new(RefCell::new(Vec::new()));
+        // Seed with the Auto placeholder.
+        entries.borrow_mut().push(Entry::AutoPlaceholder);
+        string_list.append("Auto (coming soon)");
+
+        let on_select: Rc<RefCell<Option<SelectCallback>>> = Rc::new(RefCell::new(None));
+        let suppress_callback = Rc::new(RefCell::new(false));
+
+        // Dispatch user changes.
+        {
+            let entries = Rc::clone(&entries);
+            let on_select = Rc::clone(&on_select);
+            let suppress = Rc::clone(&suppress_callback);
+            dropdown.connect_selected_notify(move |dd| {
+                if *suppress.borrow() {
+                    return;
+                }
+                let idx = dd.selected() as usize;
+                let selection = {
+                    let entries = entries.borrow();
+                    match entries.get(idx) {
+                        Some(Entry::Model {
+                            connection_id,
+                            model_id,
+                            ..
+                        }) => Some(api::SendPromptOverride {
+                            connection_id: connection_id.clone(),
+                            model_id: model_id.clone(),
+                            effort: None,
+                        }),
+                        // Auto placeholder (disabled): treat as no override.
+                        _ => None,
+                    }
+                };
+                if let Some(ref cb) = *on_select.borrow() {
+                    cb(selection);
+                }
+            });
+        }
+
+        Self {
+            container,
+            dropdown,
+            string_list,
+            entries,
+            on_select,
+            suppress_callback,
+        }
+    }
+
+    /// Register a callback for user-driven selection changes. The callback
+    /// receives `None` when the user picks the `Auto` placeholder (in
+    /// which case `SendMessage` should be issued without an override).
+    pub fn connect_changed<F>(&self, f: F)
+    where
+        F: Fn(Option<api::SendPromptOverride>) + 'static,
+    {
+        *self.on_select.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Replace the contents of the dropdown with a new set of models.
+    /// Keeps the previously-selected `(connection_id, model_id)` selected
+    /// when still present; otherwise falls back to the Auto placeholder.
+    pub fn set_models(&self, listings: &[api::ModelListing]) {
+        let previous = self.current_override();
+
+        // Rebuild the string list.
+        while self.string_list.n_items() > 0 {
+            self.string_list.remove(0);
+        }
+        self.string_list.append("Auto (coming soon)");
+
+        let mut entries = vec![Entry::AutoPlaceholder];
+        for listing in listings {
+            let e = Entry::Model {
+                connection_id: listing.connection_id.clone(),
+                connection_label: listing.connection_label.clone(),
+                model_id: listing.model.id.clone(),
+                model_label: listing.model.display_name.clone(),
+            };
+            self.string_list.append(&e.display());
+            entries.push(e);
+        }
+        *self.entries.borrow_mut() = entries;
+
+        // Reselect previous if present, else leave on Auto.
+        match previous {
+            Some(prev) => self.select_override(Some(&prev)),
+            None => self.select_override(None),
+        }
+    }
+
+    /// Programmatically select an override. Passing `None` selects the
+    /// `Auto` placeholder. Suppresses the change callback (this is a
+    /// code-driven update, not a user action).
+    pub fn select_override(&self, target: Option<&api::SendPromptOverride>) {
+        let idx = match target {
+            None => 0,
+            Some(target) => self
+                .entries
+                .borrow()
+                .iter()
+                .position(|e| match e {
+                    Entry::Model {
+                        connection_id,
+                        model_id,
+                        ..
+                    } => connection_id == &target.connection_id && model_id == &target.model_id,
+                    _ => false,
+                })
+                .unwrap_or(0),
+        };
+        *self.suppress_callback.borrow_mut() = true;
+        self.dropdown.set_selected(idx as u32);
+        *self.suppress_callback.borrow_mut() = false;
+    }
+
+    /// Return the currently selected override, or `None` if the user has
+    /// not picked an explicit model.
+    pub fn current_override(&self) -> Option<api::SendPromptOverride> {
+        let idx = self.dropdown.selected() as usize;
+        match self.entries.borrow().get(idx) {
+            Some(Entry::Model {
+                connection_id,
+                model_id,
+                ..
+            }) => Some(api::SendPromptOverride {
+                connection_id: connection_id.clone(),
+                model_id: model_id.clone(),
+                effort: None,
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_listing(conn: &str, conn_label: &str, model: &str, model_label: &str) -> api::ModelListing {
+        api::ModelListing {
+            connection_id: conn.to_string(),
+            connection_label: conn_label.to_string(),
+            model: api::ModelInfoView {
+                id: model.to_string(),
+                display_name: model_label.to_string(),
+                context_limit: None,
+                capabilities: api::ModelCapabilitiesView::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn entry_display_for_auto() {
+        assert_eq!(Entry::AutoPlaceholder.display(), "Auto (coming soon)");
+    }
+
+    #[test]
+    fn entry_display_for_model() {
+        let e = Entry::Model {
+            connection_id: "work".into(),
+            connection_label: "Work".into(),
+            model_id: "gpt-5".into(),
+            model_label: "GPT-5".into(),
+        };
+        assert_eq!(e.display(), "Work · GPT-5");
+    }
+
+    #[test]
+    fn builds_override_from_listing() {
+        // This test does not require a GTK runtime — it only validates the
+        // mapping from a ModelListing to a SendPromptOverride.
+        let listing = mk_listing("work", "Work", "gpt-5", "GPT-5");
+        let o = api::SendPromptOverride {
+            connection_id: listing.connection_id.clone(),
+            model_id: listing.model.id.clone(),
+            effort: None,
+        };
+        assert_eq!(o.connection_id, "work");
+        assert_eq!(o.model_id, "gpt-5");
+        assert_eq!(o.effort, None);
+    }
+}

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -1,0 +1,429 @@
+//! Purposes tab of the Settings dialog.
+//!
+//! Flat list of `(Purpose) (Connection ▾) (Model ▾) (Effort ▾)` for every
+//! configured purpose. Interactive must bind to a real connection and
+//! model; non-interactive purposes may use the sentinel string `"primary"`
+//! to inherit from the interactive purpose.
+//!
+//! The tab owns the dropdown rows. The parent (Settings dialog) supplies
+//! the list of connections, the per-connection models, and is called back
+//! on `SetPurpose` writes. Re-hydration after a write is the parent's
+//! job — the tab simply re-binds whenever `set_state` is invoked.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, DropDown, Label, Orientation, Separator, StringList,
+};
+
+type SetPurposeCb = Box<dyn Fn(api::PurposeKindApi, api::PurposeConfigView)>;
+type RequestModelsCb = Box<dyn Fn(String)>;
+
+const PRIMARY_SENTINEL: &str = "primary";
+
+/// Purposes ordered as the UI shows them.
+const PURPOSES: &[api::PurposeKindApi] = &[
+    api::PurposeKindApi::Interactive,
+    api::PurposeKindApi::Dreaming,
+    api::PurposeKindApi::Embedding,
+    api::PurposeKindApi::Titling,
+];
+
+fn purpose_label(p: api::PurposeKindApi) -> &'static str {
+    match p {
+        api::PurposeKindApi::Interactive => "Interactive",
+        api::PurposeKindApi::Dreaming => "Dreaming",
+        api::PurposeKindApi::Embedding => "Embedding",
+        api::PurposeKindApi::Titling => "Titling",
+    }
+}
+
+/// Ephemeral UI state for each row.
+struct Row {
+    connection_dd: DropDown,
+    connection_list: StringList,
+    /// Mirror of the dropdown's string list in the same index order:
+    /// `(value, is_primary_sentinel)` where value is either a connection id
+    /// or "primary". Kept separately so we can map dropdown index → value
+    /// without re-reading the gtk model.
+    connection_values: Rc<RefCell<Vec<String>>>,
+    model_dd: DropDown,
+    model_list: StringList,
+    model_values: Rc<RefCell<Vec<String>>>,
+    effort_dd: DropDown,
+}
+
+pub struct PurposesTab {
+    pub container: GtkBox,
+    rows: Rc<RefCell<BTreeMap<String, Row>>>,
+    connections: Rc<RefCell<Vec<api::ConnectionView>>>,
+    purposes: Rc<RefCell<api::PurposesView>>,
+    /// Model lists keyed by connection id.
+    models_by_connection: Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>>,
+    on_set_purpose: Rc<RefCell<Option<SetPurposeCb>>>,
+    on_request_models: Rc<RefCell<Option<RequestModelsCb>>>,
+    /// When true, we're reconciling the UI to state — suppress
+    /// `set_purpose` callbacks on change notifications.
+    suppress: Rc<RefCell<bool>>,
+}
+
+impl PurposesTab {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 8);
+        container.set_margin_start(12);
+        container.set_margin_end(12);
+        container.set_margin_top(12);
+        container.set_margin_bottom(12);
+
+        let header = Label::new(Some("Purposes"));
+        header.add_css_class("heading");
+        header.set_halign(Align::Start);
+        container.append(&header);
+
+        let blurb = Label::new(Some(
+            "Each purpose maps to a connection and model. Non-interactive purposes may inherit from Interactive by choosing \"primary\".",
+        ));
+        blurb.set_wrap(true);
+        blurb.set_halign(Align::Start);
+        blurb.add_css_class("dim-label");
+        container.append(&blurb);
+
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        let rows: Rc<RefCell<BTreeMap<String, Row>>> = Rc::new(RefCell::new(BTreeMap::new()));
+        let connections: Rc<RefCell<Vec<api::ConnectionView>>> = Rc::new(RefCell::new(Vec::new()));
+        let purposes: Rc<RefCell<api::PurposesView>> = Rc::new(RefCell::new(api::PurposesView::default()));
+        let models_by_connection: Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>> =
+            Rc::new(RefCell::new(BTreeMap::new()));
+        let on_set_purpose: Rc<RefCell<Option<SetPurposeCb>>> = Rc::new(RefCell::new(None));
+        let on_request_models: Rc<RefCell<Option<RequestModelsCb>>> = Rc::new(RefCell::new(None));
+        let suppress = Rc::new(RefCell::new(false));
+
+        for &purpose in PURPOSES {
+            let row_widget = GtkBox::new(Orientation::Horizontal, 8);
+            row_widget.set_margin_top(6);
+            row_widget.set_margin_bottom(6);
+
+            let label = Label::new(Some(purpose_label(purpose)));
+            label.set_width_chars(12);
+            label.set_halign(Align::Start);
+            row_widget.append(&label);
+
+            let connection_list = StringList::new(&[]);
+            let connection_dd = DropDown::new(Some(connection_list.clone()), gtk4::Expression::NONE);
+            connection_dd.set_hexpand(true);
+            row_widget.append(&connection_dd);
+
+            let model_list = StringList::new(&[]);
+            let model_dd = DropDown::new(Some(model_list.clone()), gtk4::Expression::NONE);
+            model_dd.set_hexpand(true);
+            row_widget.append(&model_dd);
+
+            let effort_list = StringList::new(&["None", "Low", "Medium", "High"]);
+            let effort_dd = DropDown::new(Some(effort_list.clone()), gtk4::Expression::NONE);
+            row_widget.append(&effort_dd);
+
+            container.append(&row_widget);
+
+            let row = Row {
+                connection_dd: connection_dd.clone(),
+                connection_list,
+                connection_values: Rc::new(RefCell::new(Vec::new())),
+                model_dd: model_dd.clone(),
+                model_list,
+                model_values: Rc::new(RefCell::new(Vec::new())),
+                effort_dd: effort_dd.clone(),
+            };
+
+            // When connection changes: rebuild models dropdown and emit a
+            // write if we're not currently reconciling.
+            {
+                let rows = Rc::clone(&rows);
+                let connections = Rc::clone(&connections);
+                let models_by_connection = Rc::clone(&models_by_connection);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let on_request_models = Rc::clone(&on_request_models);
+                let suppress = Rc::clone(&suppress);
+                connection_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    // Rebuild model dropdown to reflect the new connection.
+                    let _ = repopulate_models_for_purpose(
+                        purpose,
+                        &rows,
+                        &connections,
+                        &models_by_connection,
+                        &on_request_models,
+                        &suppress,
+                    );
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            {
+                let rows = Rc::clone(&rows);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let suppress = Rc::clone(&suppress);
+                model_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            {
+                let rows = Rc::clone(&rows);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let suppress = Rc::clone(&suppress);
+                effort_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            rows.borrow_mut().insert(purpose.as_key().to_string(), row);
+        }
+
+        Self {
+            container,
+            rows,
+            connections,
+            purposes,
+            models_by_connection,
+            on_set_purpose,
+            on_request_models,
+            suppress,
+        }
+    }
+
+    pub fn connect_set_purpose<F>(&self, f: F)
+    where
+        F: Fn(api::PurposeKindApi, api::PurposeConfigView) + 'static,
+    {
+        *self.on_set_purpose.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_request_models<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_request_models.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Replace the connection list. Resets dropdowns.
+    pub fn set_connections(&self, connections: &[api::ConnectionView]) {
+        *self.connections.borrow_mut() = connections.to_vec();
+        self.reconcile();
+    }
+
+    pub fn set_purposes(&self, purposes: api::PurposesView) {
+        *self.purposes.borrow_mut() = purposes;
+        self.reconcile();
+    }
+
+    pub fn set_models(&self, connection_id: &str, listings: Vec<api::ModelListing>) {
+        self.models_by_connection
+            .borrow_mut()
+            .insert(connection_id.to_string(), listings);
+        self.reconcile();
+    }
+
+    fn reconcile(&self) {
+        *self.suppress.borrow_mut() = true;
+        for &purpose in PURPOSES {
+            let _ = repopulate_models_for_purpose(
+                purpose,
+                &self.rows,
+                &self.connections,
+                &self.models_by_connection,
+                &self.on_request_models,
+                &self.suppress,
+            );
+            apply_purpose_config(purpose, &self.rows, &self.connections, &self.purposes);
+        }
+        *self.suppress.borrow_mut() = false;
+    }
+}
+
+/// Rebuild the connection/effort dropdowns and request models for the
+/// currently-selected connection if not already cached.
+fn repopulate_models_for_purpose(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    connections: &Rc<RefCell<Vec<api::ConnectionView>>>,
+    models_by_connection: &Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>>,
+    on_request_models: &Rc<RefCell<Option<RequestModelsCb>>>,
+    suppress: &Rc<RefCell<bool>>,
+) -> Option<()> {
+    let was_suppressed = *suppress.borrow();
+    *suppress.borrow_mut() = true;
+
+    let rows_borrow = rows.borrow();
+    let row = rows_borrow.get(purpose.as_key())?;
+
+    // Rebuild connection list. Interactive may not inherit from itself,
+    // so only non-interactive purposes see the "primary" sentinel.
+    let prev_conn_idx = row.connection_dd.selected() as usize;
+    let prev_conn_value = row.connection_values.borrow().get(prev_conn_idx).cloned();
+
+    while row.connection_list.n_items() > 0 {
+        row.connection_list.remove(0);
+    }
+    let mut conn_values: Vec<String> = Vec::new();
+    if !matches!(purpose, api::PurposeKindApi::Interactive) {
+        row.connection_list.append("primary (inherit)");
+        conn_values.push(PRIMARY_SENTINEL.to_string());
+    }
+    for conn in connections.borrow().iter() {
+        row.connection_list.append(&format!("{}  ({})", conn.id, conn.connector_type));
+        conn_values.push(conn.id.clone());
+    }
+    *row.connection_values.borrow_mut() = conn_values.clone();
+
+    // Restore previous selection if still present.
+    if let Some(prev) = prev_conn_value {
+        if let Some(idx) = conn_values.iter().position(|v| v == &prev) {
+            row.connection_dd.set_selected(idx as u32);
+        }
+    }
+
+    // Which connection's models should we display in the model dropdown?
+    let selected_idx = row.connection_dd.selected() as usize;
+    let selected_conn = conn_values.get(selected_idx).cloned();
+    let cache = models_by_connection.borrow();
+    let (models, need_request): (Vec<api::ModelListing>, Option<String>) = match selected_conn.as_deref() {
+        Some(PRIMARY_SENTINEL) | None => (Vec::new(), None),
+        Some(id) => match cache.get(id) {
+            Some(list) => (list.clone(), None),
+            None => (Vec::new(), Some(id.to_string())),
+        },
+    };
+    drop(cache);
+
+    // Rebuild model dropdown.
+    let prev_model_idx = row.model_dd.selected() as usize;
+    let prev_model_value = row.model_values.borrow().get(prev_model_idx).cloned();
+
+    while row.model_list.n_items() > 0 {
+        row.model_list.remove(0);
+    }
+    let mut model_values: Vec<String> = Vec::new();
+    if !matches!(purpose, api::PurposeKindApi::Interactive) {
+        row.model_list.append("primary (inherit)");
+        model_values.push(PRIMARY_SENTINEL.to_string());
+    }
+    for m in &models {
+        row.model_list.append(&m.model.display_name);
+        model_values.push(m.model.id.clone());
+    }
+    *row.model_values.borrow_mut() = model_values.clone();
+
+    if let Some(prev) = prev_model_value {
+        if let Some(idx) = model_values.iter().position(|v| v == &prev) {
+            row.model_dd.set_selected(idx as u32);
+        }
+    }
+
+    *suppress.borrow_mut() = was_suppressed;
+
+    // Kick off a model fetch for the newly-selected connection if we don't
+    // have it yet.
+    if let Some(id) = need_request {
+        if let Some(ref cb) = *on_request_models.borrow() {
+            cb(id);
+        }
+    }
+    Some(())
+}
+
+/// Apply the server-side `PurposesView` to the dropdowns. Non-existent
+/// purpose entries leave the dropdowns on their defaults.
+fn apply_purpose_config(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    _connections: &Rc<RefCell<Vec<api::ConnectionView>>>,
+    purposes: &Rc<RefCell<api::PurposesView>>,
+) {
+    let rows_borrow = rows.borrow();
+    let Some(row) = rows_borrow.get(purpose.as_key()) else {
+        return;
+    };
+    let purposes = purposes.borrow();
+    let cfg = match purpose {
+        api::PurposeKindApi::Interactive => purposes.interactive.as_ref(),
+        api::PurposeKindApi::Dreaming => purposes.dreaming.as_ref(),
+        api::PurposeKindApi::Embedding => purposes.embedding.as_ref(),
+        api::PurposeKindApi::Titling => purposes.titling.as_ref(),
+    };
+    let Some(cfg) = cfg else {
+        return;
+    };
+
+    if let Some(idx) = row
+        .connection_values
+        .borrow()
+        .iter()
+        .position(|v| v == &cfg.connection)
+    {
+        row.connection_dd.set_selected(idx as u32);
+    }
+    if let Some(idx) = row
+        .model_values
+        .borrow()
+        .iter()
+        .position(|v| v == &cfg.model)
+    {
+        row.model_dd.set_selected(idx as u32);
+    }
+    let effort_idx = match cfg.effort {
+        None => 0,
+        Some(api::EffortLevel::Low) => 1,
+        Some(api::EffortLevel::Medium) => 2,
+        Some(api::EffortLevel::High) => 3,
+    };
+    row.effort_dd.set_selected(effort_idx as u32);
+}
+
+/// Assemble a `PurposeConfigView` from the current dropdown state and
+/// emit a write callback.
+fn emit_current(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    on_set_purpose: &Rc<RefCell<Option<SetPurposeCb>>>,
+) {
+    let rows_borrow = rows.borrow();
+    let Some(row) = rows_borrow.get(purpose.as_key()) else {
+        return;
+    };
+    let conn_idx = row.connection_dd.selected() as usize;
+    let Some(connection) = row.connection_values.borrow().get(conn_idx).cloned() else {
+        return;
+    };
+    let model_idx = row.model_dd.selected() as usize;
+    let Some(model) = row.model_values.borrow().get(model_idx).cloned() else {
+        return;
+    };
+    let effort = match row.effort_dd.selected() {
+        0 => None,
+        1 => Some(api::EffortLevel::Low),
+        2 => Some(api::EffortLevel::Medium),
+        3 => Some(api::EffortLevel::High),
+        _ => None,
+    };
+    let config = api::PurposeConfigView {
+        connection,
+        model,
+        effort,
+    };
+    if let Some(ref cb) = *on_set_purpose.borrow() {
+        cb(purpose, config);
+    }
+}

--- a/src/widgets/settings_dialog.rs
+++ b/src/widgets/settings_dialog.rs
@@ -1,0 +1,565 @@
+//! Top-level Settings dialog (Notebook with Connections + Purposes tabs).
+//!
+//! Owns the live transport handle and wires tab callbacks to async
+//! management RPCs. The dialog is transient to the parent window and
+//! refreshes its data every time it is presented (it is cheap: a couple
+//! of RPCs).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::TransportClient;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, Label, Notebook, Orientation, Window, glib,
+};
+use tokio::sync::mpsc;
+
+use crate::async_bridge::{UiMessage, spawn_on_runtime};
+use crate::management_client;
+
+use super::connection_config_dialog::{ConnectorType, show_configure_dialog};
+use super::connections_tab::ConnectionsTab;
+use super::purposes_tab::PurposesTab;
+
+/// Minimal yes/no confirmation dialog. We avoid GTK4's `AlertDialog`
+/// (gated behind the `v4_10` feature) to keep the feature floor low.
+/// `on_confirm` is called when the user clicks the affirmative button.
+fn confirm<F>(
+    parent: &impl IsA<Window>,
+    title: &str,
+    detail: &str,
+    affirmative: &str,
+    destructive: bool,
+    on_confirm: F,
+) where
+    F: Fn() + 'static,
+{
+    let dialog = Window::builder()
+        .title(title)
+        .default_width(420)
+        .modal(true)
+        .resizable(false)
+        .transient_for(parent)
+        .build();
+
+    let content = GtkBox::new(Orientation::Vertical, 12);
+    content.set_margin_start(20);
+    content.set_margin_end(20);
+    content.set_margin_top(20);
+    content.set_margin_bottom(20);
+
+    let message = Label::new(Some(detail));
+    message.set_wrap(true);
+    message.set_halign(Align::Start);
+    content.append(&message);
+
+    let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+    btn_row.set_halign(Align::End);
+    let cancel = Button::with_label("Cancel");
+    let confirm_btn = Button::with_label(affirmative);
+    if destructive {
+        confirm_btn.add_css_class("destructive-action");
+    } else {
+        confirm_btn.add_css_class("suggested-action");
+    }
+    btn_row.append(&cancel);
+    btn_row.append(&confirm_btn);
+    content.append(&btn_row);
+
+    dialog.set_child(Some(&content));
+
+    let dialog_ref = dialog.clone();
+    cancel.connect_clicked(move |_| dialog_ref.close());
+
+    let dialog_ref = dialog.clone();
+    confirm_btn.connect_clicked(move |_| {
+        dialog_ref.close();
+        on_confirm();
+    });
+
+    dialog.present();
+}
+
+/// Present the Settings dialog modally against `parent`, using `client`
+/// for all RPC traffic. `ui_tx` is the shared ui-message channel so that
+/// errors propagate back to the window status bar.
+pub fn show_settings_dialog(
+    parent: &impl IsA<Window>,
+    client: Rc<RefCell<Option<Arc<TransportClient>>>>,
+    ui_tx: mpsc::UnboundedSender<UiMessage>,
+) {
+    let dialog = Window::builder()
+        .title("Settings")
+        .default_width(720)
+        .default_height(520)
+        .modal(true)
+        .transient_for(parent)
+        .build();
+
+    let vbox = GtkBox::new(Orientation::Vertical, 0);
+    vbox.set_vexpand(true);
+
+    let notebook = Notebook::new();
+    notebook.set_vexpand(true);
+
+    let connections_tab = Rc::new(ConnectionsTab::new());
+    let purposes_tab = Rc::new(PurposesTab::new());
+
+    notebook.append_page(
+        &connections_tab.container,
+        Some(&Label::new(Some("Connections"))),
+    );
+    notebook.append_page(
+        &purposes_tab.container,
+        Some(&Label::new(Some("Purposes"))),
+    );
+
+    vbox.append(&notebook);
+
+    // Status row + close.
+    let footer = GtkBox::new(Orientation::Horizontal, 8);
+    footer.set_margin_start(12);
+    footer.set_margin_end(12);
+    footer.set_margin_top(6);
+    footer.set_margin_bottom(8);
+
+    let status_label = Rc::new(Label::new(None));
+    status_label.set_halign(Align::Start);
+    status_label.set_hexpand(true);
+    status_label.add_css_class("dim-label");
+    footer.append(&*status_label);
+
+    let close_btn = Button::with_label("Close");
+    let dialog_ref = dialog.clone();
+    close_btn.connect_clicked(move |_| dialog_ref.close());
+    footer.append(&close_btn);
+
+    vbox.append(&footer);
+    dialog.set_child(Some(&vbox));
+
+    // ---------------------------------------------------------------
+    // Data-refresh helper: re-fetches connections + purposes and
+    // repopulates the tabs. Called on present and after any mutation.
+    // ---------------------------------------------------------------
+    let refresh: Rc<dyn Fn()> = {
+        let client = Rc::clone(&client);
+        let connections_tab = Rc::clone(&connections_tab);
+        let purposes_tab = Rc::clone(&purposes_tab);
+        let status_label = Rc::clone(&status_label);
+        Rc::new(move || {
+            let Some(transport) = client.borrow().clone() else {
+                status_label.set_text("Not connected to the daemon.");
+                return;
+            };
+            let connections_tab = Rc::clone(&connections_tab);
+            let purposes_tab = Rc::clone(&purposes_tab);
+            let status_label = Rc::clone(&status_label);
+
+            let (tx_conn, mut rx_conn) =
+                mpsc::unbounded_channel::<Result<Vec<api::ConnectionView>, String>>();
+            let (tx_purposes, mut rx_purposes) =
+                mpsc::unbounded_channel::<Result<api::PurposesView, String>>();
+            let (tx_models, mut rx_models) =
+                mpsc::unbounded_channel::<Result<Vec<api::ModelListing>, String>>();
+
+            let transport_for_task = Arc::clone(&transport);
+            spawn_on_runtime(async move {
+                let conns = management_client::list_connections(&transport_for_task)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = tx_conn.send(conns);
+
+                let purposes = management_client::get_purposes(&transport_for_task)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = tx_purposes.send(purposes);
+
+                // Aggregated list (None connection_id) populates model
+                // caches for every healthy connection at once.
+                let models = management_client::list_available_models(&transport_for_task, None, false)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = tx_models.send(models);
+            });
+
+            let connections_tab_a = Rc::clone(&connections_tab);
+            let purposes_tab_a = Rc::clone(&purposes_tab);
+            let status_a = Rc::clone(&status_label);
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx_conn.recv().await {
+                    match result {
+                        Ok(list) => {
+                            connections_tab_a.set_connections(&list);
+                            purposes_tab_a.set_connections(&list);
+                        }
+                        Err(e) => status_a.set_text(&format!("List connections: {e}")),
+                    }
+                }
+                if let Some(result) = rx_purposes.recv().await {
+                    match result {
+                        Ok(p) => purposes_tab_a.set_purposes(p),
+                        Err(e) => status_a.set_text(&format!("Get purposes: {e}")),
+                    }
+                }
+                if let Some(result) = rx_models.recv().await {
+                    match result {
+                        Ok(listings) => {
+                            // Group by connection id and hand each slice
+                            // to the purposes tab so per-connection
+                            // dropdowns can populate without firing extra
+                            // requests.
+                            let mut by_conn: std::collections::BTreeMap<
+                                String,
+                                Vec<api::ModelListing>,
+                            > = std::collections::BTreeMap::new();
+                            for listing in listings {
+                                by_conn
+                                    .entry(listing.connection_id.clone())
+                                    .or_default()
+                                    .push(listing);
+                            }
+                            for (id, list) in by_conn {
+                                purposes_tab_a.set_models(&id, list);
+                            }
+                        }
+                        Err(e) => status_a.set_text(&format!("List models: {e}")),
+                    }
+                }
+            });
+        })
+    };
+
+    // ---------------------------------------------------------------
+    // Connections tab wiring.
+    // ---------------------------------------------------------------
+    {
+        let client = Rc::clone(&client);
+        let refresh = Rc::clone(&refresh);
+        let ui_tx = ui_tx.clone();
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_add(move |connector| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let client = Rc::clone(&client);
+            let refresh = Rc::clone(&refresh);
+            let ui_tx = ui_tx.clone();
+            show_configure_dialog(
+                &parent,
+                connector,
+                None,
+                move |id, config| {
+                    let Some(transport) = client.borrow().clone() else {
+                        let _ = ui_tx.send(UiMessage::Error("Not connected".into()));
+                        return;
+                    };
+                    let refresh = Rc::clone(&refresh);
+                    let ui_tx = ui_tx.clone();
+                    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+                    let transport_for_task = Arc::clone(&transport);
+                    let id_for_task = id.clone();
+                    spawn_on_runtime(async move {
+                        let r = management_client::create_connection(
+                            &transport_for_task,
+                            id_for_task,
+                            config,
+                        )
+                        .await
+                        .map_err(|e| e.to_string());
+                        let _ = tx.send(r);
+                    });
+                    glib::spawn_future_local(async move {
+                        if let Some(result) = rx.recv().await {
+                            match result {
+                                Ok(()) => refresh(),
+                                Err(e) => {
+                                    let _ =
+                                        ui_tx.send(UiMessage::Error(format!("Create connection: {e}")));
+                                }
+                            }
+                        }
+                    });
+                },
+                // Add-flow never has a connection to refresh yet.
+                |_id| {},
+            );
+        });
+    }
+
+    {
+        let client_cfg = Rc::clone(&client);
+        let connections_tab_cfg = Rc::clone(&connections_tab);
+        let refresh = Rc::clone(&refresh);
+        let ui_tx = ui_tx.clone();
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_configure(move |id| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let Some(existing) = connections_tab_cfg.find(&id) else {
+                return;
+            };
+            let connector = match ConnectorType::from_slug(&existing.connector_type) {
+                Some(c) => c,
+                None => {
+                    let _ = ui_tx.send(UiMessage::Error(format!(
+                        "Unknown connector type: {}",
+                        existing.connector_type
+                    )));
+                    return;
+                }
+            };
+            // We don't have the raw config from the daemon in ConnectionView.
+            // Pass an empty config of the right variant; the user re-enters
+            // fields on edit. (ConnectionConfigView fields aren't echoed
+            // back from the server — credentials are never surfaced.)
+            let existing_pair = Some((existing.id.clone(), connector.empty_config()));
+
+            let client = Rc::clone(&client_cfg);
+            let refresh_inner = Rc::clone(&refresh);
+            let ui_tx_inner = ui_tx.clone();
+            let client_for_refresh = Rc::clone(&client);
+            let ui_tx_for_refresh = ui_tx.clone();
+
+            show_configure_dialog(
+                &parent,
+                connector,
+                existing_pair,
+                move |id, config| {
+                    let Some(transport) = client.borrow().clone() else {
+                        let _ = ui_tx_inner.send(UiMessage::Error("Not connected".into()));
+                        return;
+                    };
+                    let refresh = Rc::clone(&refresh_inner);
+                    let ui_tx = ui_tx_inner.clone();
+                    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+                    let transport_for_task = Arc::clone(&transport);
+                    let id_for_task = id.clone();
+                    spawn_on_runtime(async move {
+                        let r = management_client::update_connection(
+                            &transport_for_task,
+                            id_for_task,
+                            config,
+                        )
+                        .await
+                        .map_err(|e| e.to_string());
+                        let _ = tx.send(r);
+                    });
+                    glib::spawn_future_local(async move {
+                        if let Some(result) = rx.recv().await {
+                            match result {
+                                Ok(()) => refresh(),
+                                Err(e) => {
+                                    let _ = ui_tx.send(UiMessage::Error(format!(
+                                        "Update connection: {e}"
+                                    )));
+                                }
+                            }
+                        }
+                    });
+                },
+                move |id_for_refresh| {
+                    // Refresh Bedrock models cache.
+                    let Some(transport) = client_for_refresh.borrow().clone() else {
+                        return;
+                    };
+                    let ui_tx = ui_tx_for_refresh.clone();
+                    spawn_on_runtime(async move {
+                        let r = management_client::list_available_models(
+                            &transport,
+                            Some(id_for_refresh),
+                            true,
+                        )
+                        .await;
+                        if let Err(e) = r {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Refresh models: {e}")));
+                        }
+                    });
+                },
+            );
+        });
+    }
+
+    {
+        let client = Rc::clone(&client);
+        let refresh = Rc::clone(&refresh);
+        let ui_tx = ui_tx.clone();
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_remove(move |id| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let client_for_confirm = Rc::clone(&client);
+            let refresh_for_confirm = Rc::clone(&refresh);
+            let ui_tx_for_confirm = ui_tx.clone();
+            let parent_for_retry = parent.clone();
+            let id_for_confirm = id.clone();
+            confirm(
+                &parent,
+                &format!("Remove connection \"{id}\"?"),
+                "This will fail if any purpose still references the connection. You will be offered a force-remove on the retry dialog, which re-assigns referencing purposes to the interactive purpose.",
+                "Remove",
+                true,
+                move || {
+                    do_remove_connection(
+                        &parent_for_retry,
+                        client_for_confirm.clone(),
+                        refresh_for_confirm.clone(),
+                        ui_tx_for_confirm.clone(),
+                        id_for_confirm.clone(),
+                        false,
+                    );
+                },
+            );
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // Purposes tab wiring.
+    // ---------------------------------------------------------------
+    {
+        let client = Rc::clone(&client);
+        let refresh = Rc::clone(&refresh);
+        let ui_tx = ui_tx.clone();
+        purposes_tab.connect_set_purpose(move |purpose, config| {
+            let Some(transport) = client.borrow().clone() else {
+                let _ = ui_tx.send(UiMessage::Error("Not connected".into()));
+                return;
+            };
+            let refresh = Rc::clone(&refresh);
+            let ui_tx = ui_tx.clone();
+            let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+            let transport_for_task = Arc::clone(&transport);
+            spawn_on_runtime(async move {
+                let r =
+                    management_client::set_purpose(&transport_for_task, purpose, config).await;
+                let _ = tx.send(r.map_err(|e| e.to_string()));
+            });
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx.recv().await {
+                    match result {
+                        Ok(()) => refresh(),
+                        Err(e) => {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Set purpose: {e}")));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    {
+        let client = Rc::clone(&client);
+        let purposes_tab_for_cb = Rc::clone(&purposes_tab);
+        let ui_tx = ui_tx.clone();
+        purposes_tab.connect_request_models(move |connection_id| {
+            let Some(transport) = client.borrow().clone() else {
+                return;
+            };
+            let ui_tx = ui_tx.clone();
+            let purposes_tab = Rc::clone(&purposes_tab_for_cb);
+            let (tx, mut rx) =
+                mpsc::unbounded_channel::<Result<Vec<api::ModelListing>, String>>();
+            let transport_for_task = Arc::clone(&transport);
+            let connection_id_for_task = connection_id.clone();
+            spawn_on_runtime(async move {
+                let r = management_client::list_available_models(
+                    &transport_for_task,
+                    Some(connection_id_for_task),
+                    false,
+                )
+                .await
+                .map_err(|e| e.to_string());
+                let _ = tx.send(r);
+            });
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx.recv().await {
+                    match result {
+                        Ok(listings) => {
+                            purposes_tab.set_models(&connection_id, listings);
+                        }
+                        Err(e) => {
+                            let _ =
+                                ui_tx.send(UiMessage::Error(format!("List models: {e}")));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    // First refresh.
+    refresh();
+
+    dialog.present();
+}
+
+/// Issue a `DeleteConnection` call. On refusal (purposes still reference
+/// it), prompt the user to retry with `force: true`. On force success,
+/// the daemon rewires referencing purposes to fall back to interactive.
+fn do_remove_connection(
+    parent: &impl IsA<Window>,
+    client: Rc<RefCell<Option<Arc<TransportClient>>>>,
+    refresh: Rc<dyn Fn()>,
+    ui_tx: mpsc::UnboundedSender<UiMessage>,
+    id: String,
+    force: bool,
+) {
+    let Some(transport) = client.borrow().clone() else {
+        let _ = ui_tx.send(UiMessage::Error("Not connected".into()));
+        return;
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+    let transport_for_task = Arc::clone(&transport);
+    let id_for_task = id.clone();
+    spawn_on_runtime(async move {
+        let r =
+            management_client::delete_connection(&transport_for_task, id_for_task, force).await;
+        let _ = tx.send(r.map_err(|e| e.to_string()));
+    });
+
+    let parent = parent.clone();
+    let client_for_retry = client.clone();
+    let refresh_outer = Rc::clone(&refresh);
+    let ui_tx_outer = ui_tx.clone();
+    glib::spawn_future_local(async move {
+        if let Some(result) = rx.recv().await {
+            match result {
+                Ok(()) => refresh_outer(),
+                Err(e) if !force => {
+                    let id_for_retry = id.clone();
+                    let parent_inner = parent.clone();
+                    let client_inner = client_for_retry.clone();
+                    let refresh_inner = Rc::clone(&refresh_outer);
+                    let ui_tx_inner = ui_tx_outer.clone();
+                    let parent_for_confirm = parent.clone();
+                    confirm(
+                        &parent_for_confirm,
+                        &format!("Cannot remove \"{id}\""),
+                        &format!(
+                            "{e}\n\nForce-remove will re-assign any referencing purpose to the interactive purpose."
+                        ),
+                        "Force remove",
+                        true,
+                        move || {
+                            do_remove_connection(
+                                &parent_inner,
+                                client_inner.clone(),
+                                refresh_inner.clone(),
+                                ui_tx_inner.clone(),
+                                id_for_retry.clone(),
+                                true,
+                            );
+                        },
+                    );
+                }
+                Err(e) => {
+                    let _ = ui_tx_outer.send(UiMessage::Error(format!("Delete connection: {e}")));
+                }
+            }
+        }
+    });
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{
     AssistantClient, ChatMessage, ConnectionConfig, ConversationDetail, ConversationSummary,
     TransportClient,
@@ -9,13 +10,18 @@ use desktop_assistant_client_common::{
 use gtk4::prelude::*;
 use gtk4::{
     Align, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton, Entry, Label,
-    MenuButton, Orientation, Paned, Popover, Separator, Window, gdk, glib,
+    MenuButton, Orientation, Paned, Popover, Revealer, RevealerTransitionType, Separator, Window,
+    gdk, glib,
 };
 use tokio::sync::mpsc;
 
-use crate::async_bridge::{AsyncBridge, InternalMsg, UiMessage, connection_manager};
+use crate::async_bridge::{AsyncBridge, InternalMsg, UiMessage, connection_manager, spawn_on_runtime};
+use crate::management_client;
+use crate::selection_store::{SelectionStore, StoredSelection};
 use crate::widgets::chat_view::ChatView;
 use crate::widgets::input_bar::InputBar;
+use crate::widgets::model_selector::ModelSelector;
+use crate::widgets::settings_dialog;
 use crate::widgets::sidebar::Sidebar;
 
 /// Shared mutable state for the window.
@@ -90,6 +96,11 @@ impl AdelieWindow {
         menu_popover.add_css_class("context-popover");
         let menu_box = GtkBox::new(Orientation::Vertical, 0);
 
+        let settings_btn = Button::with_label("Settings");
+        settings_btn.add_css_class("context-button");
+        settings_btn.set_halign(Align::Fill);
+        menu_box.append(&settings_btn);
+
         let new_conn_btn = Button::with_label("New Connection");
         new_conn_btn.add_css_class("context-button");
         new_conn_btn.set_halign(Align::Fill);
@@ -112,8 +123,38 @@ impl AdelieWindow {
         let chat_view = ChatView::new();
         right_box.append(&chat_view.container);
 
+        // Passive toast for advisory warnings (e.g. dangling model
+        // selection). The revealer is always in the layout; we reveal it
+        // with a message when something needs attention.
+        let toast_revealer = Revealer::new();
+        toast_revealer.set_transition_type(RevealerTransitionType::SlideUp);
+        toast_revealer.set_reveal_child(false);
+        let toast_row = GtkBox::new(Orientation::Horizontal, 8);
+        toast_row.add_css_class("toast-row");
+        toast_row.set_margin_start(12);
+        toast_row.set_margin_end(12);
+        toast_row.set_margin_top(6);
+        toast_row.set_margin_bottom(6);
+        let toast_label = Label::new(None);
+        toast_label.set_halign(Align::Start);
+        toast_label.set_hexpand(true);
+        toast_label.set_wrap(true);
+        toast_row.append(&toast_label);
+        let toast_dismiss = Button::from_icon_name("window-close-symbolic");
+        toast_dismiss.add_css_class("flat");
+        {
+            let revealer_ref = toast_revealer.clone();
+            toast_dismiss.connect_clicked(move |_| revealer_ref.set_reveal_child(false));
+        }
+        toast_row.append(&toast_dismiss);
+        toast_revealer.set_child(Some(&toast_row));
+        right_box.append(&toast_revealer);
+
         let input_sep = Separator::new(Orientation::Horizontal);
         right_box.append(&input_sep);
+
+        let model_selector = ModelSelector::new();
+        right_box.append(&model_selector.container);
 
         let input_bar = InputBar::new();
         input_bar.send_button.set_sensitive(false); // disabled until connected
@@ -153,11 +194,17 @@ impl AdelieWindow {
             debug_enabled: false,
         }));
 
+        // Per-conversation model selection mirror (disk-backed).
+        let selection_store = Rc::new(SelectionStore::new());
+
         // Wrap widgets in Rc for closures
         let sidebar = Rc::new(sidebar);
         let chat_view = Rc::new(RefCell::new(chat_view));
         let input_bar = Rc::new(input_bar);
         let status_label = Rc::new(status_label);
+        let model_selector = Rc::new(model_selector);
+        let toast_revealer = Rc::new(toast_revealer);
+        let toast_label = Rc::new(toast_label);
 
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
@@ -173,6 +220,10 @@ impl AdelieWindow {
             let status_label = Rc::clone(&status_label);
             let client = Rc::clone(&client);
             let input_bar = Rc::clone(&input_bar);
+            let model_selector = Rc::clone(&model_selector);
+            let toast_revealer = Rc::clone(&toast_revealer);
+            let toast_label = Rc::clone(&toast_label);
+            let selection_store = Rc::clone(&selection_store);
 
             AsyncBridge::new(move |msg| {
                 handle_ui_message(
@@ -183,6 +234,10 @@ impl AdelieWindow {
                     &status_label,
                     &client,
                     &input_bar,
+                    &model_selector,
+                    &toast_revealer,
+                    &toast_label,
+                    &selection_store,
                 );
             })
         };
@@ -208,7 +263,9 @@ impl AdelieWindow {
             bridge.spawn(connection_manager(config.clone(), ui_tx, internal_tx));
         }
 
-        // Sidebar row activation → load conversation
+        // Sidebar row activation → load conversation (with warnings via
+        // the raw ConversationView, so dangling selection advisories are
+        // surfaced).
         {
             let client_ref = Rc::clone(&client);
             let state = Rc::clone(&state);
@@ -223,9 +280,29 @@ impl AdelieWindow {
                     if let Some(client) = client_ref.borrow().clone() {
                         let tx = bridge.ui_sender();
                         bridge.spawn(async move {
-                            match client.get_conversation(&conv_id).await {
-                                Ok(detail) => {
+                            match management_client::get_conversation_view(&client, &conv_id).await
+                            {
+                                Ok(view) => {
+                                    let warnings = view.warnings.clone();
+                                    let detail = desktop_assistant_client_common::ConversationDetail {
+                                        id: view.id.clone(),
+                                        title: view.title,
+                                        messages: view
+                                            .messages
+                                            .into_iter()
+                                            .map(|m| desktop_assistant_client_common::ChatMessage {
+                                                role: m.role,
+                                                content: m.content,
+                                            })
+                                            .collect(),
+                                    };
                                     let _ = tx.send(UiMessage::ConversationLoaded(detail));
+                                    for w in warnings {
+                                        let _ = tx.send(UiMessage::ConversationWarning {
+                                            conversation_id: view.id.clone(),
+                                            warning: w,
+                                        });
+                                    }
                                 }
                                 Err(e) => {
                                     let _ = tx
@@ -454,13 +531,16 @@ impl AdelieWindow {
             });
         }
 
-        // Send button / Enter key → send prompt
+        // Send button / Enter key → send prompt (with optional per-send
+        // model override).
         {
             let client_ref = Rc::clone(&client);
             let bridge_ref = Rc::clone(&bridge);
             let state = Rc::clone(&state);
             let input_bar_ref = Rc::clone(&input_bar);
             let chat_view_ref = Rc::clone(&chat_view);
+            let model_selector_ref = Rc::clone(&model_selector);
+            let selection_store_ref = Rc::clone(&selection_store);
 
             let send_action = Rc::new(move || {
                 let text = input_bar_ref.take_text();
@@ -474,6 +554,12 @@ impl AdelieWindow {
                     None => return,
                 };
                 drop(state_borrow);
+
+                // Resolve the override: prefer the live dropdown selection;
+                // fall back to the conversation's stored selection.
+                let override_selection = model_selector_ref
+                    .current_override()
+                    .or_else(|| selection_store_ref.get(&conv_id).map(|s| s.as_override()));
 
                 // Show user message immediately
                 chat_view_ref.borrow_mut().add_user_message(&text);
@@ -493,9 +579,21 @@ impl AdelieWindow {
                     let tx = bridge_ref.ui_sender();
                     let text = text.clone();
                     bridge_ref.spawn(async move {
-                        match client.send_prompt(&conv_id, &text).await {
-                            Ok(request_id) => {
-                                let _ = tx.send(UiMessage::PromptSent { request_id });
+                        let r = management_client::send_prompt_with_override(
+                            &client,
+                            conv_id,
+                            text,
+                            override_selection,
+                        )
+                        .await;
+                        match r {
+                            Ok(()) => {
+                                // WS ack doesn't carry a request id; use
+                                // the sentinel to claim the next stream
+                                // event.
+                                let _ = tx.send(UiMessage::PromptSent {
+                                    request_id: String::new(),
+                                });
                             }
                             Err(e) => {
                                 let _ = tx.send(UiMessage::Error(format!("Send error: {e}")));
@@ -526,6 +624,70 @@ impl AdelieWindow {
                 }
             });
             input_bar.text_view.add_controller(key_controller);
+        }
+
+        // Model selector: persist selection locally whenever the user
+        // changes it. The daemon side is updated implicitly on the next
+        // `SendMessage` call (which carries the override).
+        {
+            let state = Rc::clone(&state);
+            let selection_store = Rc::clone(&selection_store);
+            model_selector.connect_changed(move |override_selection| {
+                let Some(conv_id) = state.borrow().current_conversation_id.clone() else {
+                    return;
+                };
+                match override_selection {
+                    Some(o) => {
+                        selection_store.set(
+                            &conv_id,
+                            StoredSelection {
+                                connection_id: o.connection_id,
+                                model_id: o.model_id,
+                                effort: o.effort,
+                            },
+                        );
+                    }
+                    None => {
+                        selection_store.clear(&conv_id);
+                    }
+                }
+            });
+        }
+
+        // Hamburger menu: Settings → Connections / Purposes tabs.
+        {
+            let client_ref = Rc::clone(&client);
+            let bridge_ref = Rc::clone(&bridge);
+            let window_ref = window.clone();
+            let popover_ref = menu_popover.clone();
+            let model_selector_ref = Rc::clone(&model_selector);
+            settings_btn.connect_clicked(move |_| {
+                popover_ref.popdown();
+                settings_dialog::show_settings_dialog(
+                    &window_ref,
+                    Rc::clone(&client_ref),
+                    bridge_ref.ui_sender(),
+                );
+                // After the user potentially changes connections, refresh
+                // the model selector so it reflects the new set. Fire-and-
+                // forget — errors are non-fatal.
+                if let Some(transport) = client_ref.borrow().clone() {
+                    let tx = bridge_ref.ui_sender();
+                    let _ = &model_selector_ref; // captured for symmetry
+                    spawn_on_runtime(async move {
+                        match management_client::list_available_models(&transport, None, false)
+                            .await
+                        {
+                            Ok(listings) => {
+                                let _ = tx.send(UiMessage::ModelsLoaded(listings));
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to refresh models after settings: {e}");
+                            }
+                        }
+                    });
+                }
+            });
         }
 
         // Hamburger menu: New Connection → open login screen in a new window
@@ -596,6 +758,10 @@ fn handle_ui_message(
     status_label: &Rc<Label>,
     client: &Rc<RefCell<Option<Arc<TransportClient>>>>,
     input_bar: &Rc<InputBar>,
+    model_selector: &Rc<ModelSelector>,
+    toast_revealer: &Rc<Revealer>,
+    toast_label: &Rc<Label>,
+    selection_store: &Rc<SelectionStore>,
 ) {
     match msg {
         UiMessage::ConversationsLoaded(convs) => {
@@ -608,9 +774,18 @@ fn handle_ui_message(
             let filtered = filter_messages(&detail, debug);
             let mut s = state.borrow_mut();
             s.current_conversation = Some(detail);
-            s.current_conversation_id = Some(id);
+            s.current_conversation_id = Some(id.clone());
             drop(s);
             chat_view.borrow_mut().load_conversation(&filtered);
+
+            // Hydrate the model selector from the locally-persisted
+            // per-conversation selection (if any). The daemon doesn't
+            // currently echo its own `last_model_selection` on
+            // GetConversation — we mirror it client-side and the daemon
+            // falls back to the interactive purpose when our override is
+            // absent.
+            let stored_override = selection_store.get(&id).map(|s| s.as_override());
+            model_selector.select_override(stored_override.as_ref());
         }
         UiMessage::ConversationCreated { id } => {
             state.borrow_mut().current_conversation_id = Some(id);
@@ -729,6 +904,49 @@ fn handle_ui_message(
             let convs = s.conversations.clone();
             drop(s);
             sidebar.set_conversations(&convs);
+        }
+        UiMessage::ConversationWarning {
+            conversation_id,
+            warning,
+        } => {
+            // Single variant today — DanglingModelSelection. The daemon
+            // has already cleared its side; clear ours too and surface a
+            // passive toast so the user knows why their "stuck" model is
+            // no longer stuck.
+            match &warning {
+                api::ConversationWarning::DanglingModelSelection {
+                    previous_selection,
+                    fallback_to,
+                } => {
+                    selection_store.clear(&conversation_id);
+                    // If this is the currently-open conversation, also
+                    // reset the selector so it doesn't show stale state.
+                    let is_current = state.borrow().current_conversation_id.as_deref()
+                        == Some(conversation_id.as_str());
+                    if is_current {
+                        model_selector.select_override(None);
+                    }
+                    let message = format!(
+                        "The model \"{}\" on connection \"{}\" is no longer available — falling back to \"{}\" on \"{}\".",
+                        previous_selection.model_id,
+                        previous_selection.connection_id,
+                        fallback_to.model_id,
+                        fallback_to.connection_id,
+                    );
+                    toast_label.set_text(&message);
+                    toast_revealer.set_reveal_child(true);
+                }
+            }
+        }
+        UiMessage::ModelsLoaded(listings) => {
+            model_selector.set_models(&listings);
+            // Re-hydrate from the current conversation's stored
+            // selection so that a freshly-populated dropdown still
+            // reflects user intent.
+            if let Some(conv_id) = state.borrow().current_conversation_id.clone() {
+                let stored_override = selection_store.get(&conv_id).map(|s| s.as_override());
+                model_selector.select_override(stored_override.as_ref());
+            }
         }
         UiMessage::StatusUpdate(text) => {
             status_label.set_text(&text);


### PR DESCRIPTION
## Summary

Implements the full UI surface for daemon-side multi-connection support
(desktop-assistant #11 / adele-gtk #1).

- **Connections tab** (Settings → Connections): list configured
  connections with availability and credential status, Add menu with
  per-connector picker, per-type Configure dialog, force-remove fallback
  on delete-refused-by-purpose-reference.
- **Purposes tab** (Settings → Purposes): flat list of
  `(Purpose) (Connection ▾) (Model ▾) (Effort ▾)` for interactive /
  dreaming / embedding / titling. Non-interactive purposes show the
  `"primary"` inherit sentinel in the connection/model dropdowns.
- **Per-conversation model selector** next to the chat input: aggregated
  `Connection · Model` list from `ListAvailableModels` with a pinned
  `Auto (coming soon)` placeholder. Selection is hydrated from a local
  mirror on conversation load and the daemon's override is attached to
  every `SendMessage`. Survives app restart via
  `~/.config/adele-gtk/conversation_selections.json`.
- **Passive toast** for `ConversationWarning::DanglingModelSelection` —
  the daemon emits this once when a stored selection no longer resolves;
  the UI clears its mirror and surfaces the advisory in a dismissible
  revealer row.

## Per-tab / per-widget breakdown

| File | What it owns |
|------|--------------|
| `src/selection_store.rs` | Disk-backed mirror of per-conversation model selections. Daemon persists server-side; client mirrors locally because `ConversationView` does not echo `last_model_selection` on `GetConversation`. |
| `src/management_client.rs` | Typed wrappers over `TransportClient::as_ws` for the new multi-connection commands. |
| `src/widgets/connection_config_dialog.rs` | Per-connector-type Configure modal (Anthropic / OpenAI / Bedrock / Ollama). Bedrock has a "Refresh models" button. |
| `src/widgets/connections_tab.rs` | Connections list + Add menu + per-row Configure / Remove. |
| `src/widgets/purposes_tab.rs` | Flat purposes rows with live dropdowns; per-connection model cache with on-demand refill. |
| `src/widgets/settings_dialog.rs` | Notebook dialog wiring the tabs to `management_client` RPCs. |
| `src/widgets/model_selector.rs` | Per-conversation DropDown, sits above the input bar. |
| `src/window.rs` | Wires Settings menu entry, toast revealer, selector hydration, override on send. |
| `src/async_bridge.rs` | New `UiMessage::{ConversationWarning, ModelsLoaded}` variants + initial `ListAvailableModels` fetch on connect. |

## Notes / follow-ups

- **Depends on desktop-assistant `feat/multi-connection`** — specifically
  the `Expose new multi-connection plumbing on client-common WsClient`
  commit. That commit is additive (public `send_command`, a new
  `SignalEvent::ConversationWarning` variant, `TransportClient::as_ws`)
  and does not alter existing call sites.
- **Backend behavior deferred** per issue #18 on desktop-assistant: the
  daemon currently accepts `override_selection` / `effort` on the wire
  but doesn't yet route them into connector request bodies. The UI sends
  the right values today; once #18 lands the full end-to-end "pick
  model, see it used" flow will work without UI changes.
- **Auto mode** is intentionally a disabled placeholder — the daemon
  heuristic that routes "Auto" to a connection is deferred. The dropdown
  keeps it pinned so the UI is already shaped for when it lands.
- The per-conversation selection mirror is a client-side workaround for
  the daemon not yet echoing `last_model_selection` on `GetConversation`.
  Once the daemon does echo it, hydration can switch to the server value
  and the local file can be removed — but the file-based approach
  already satisfies the "survives app restart" acceptance criterion.
- `GetLlmSettings` / `SetLlmSettings` call sites: searched — none in this
  codebase. No single-LLM settings panel existed to remove/redirect.

## Test plan

Unit tests (covered in this PR):
- [x] `selection_store` roundtrip / tempdir persistence / clear
- [x] `connection_config_dialog::ConnectorType` slug roundtrip, empty_config variant
- [x] `model_selector::Entry` display formatting + override construction

Manual (against a live daemon on desktop-assistant `feat/multi-connection`):
- [ ] Start daemon, launch adele-gtk, log in.
- [ ] Open Settings → Connections: list appears with existing connections,
      availability and credential badges correct.
- [ ] Add connection → pick Anthropic → fill env var + base URL → Save →
      new row appears.
- [ ] Add connection → pick Bedrock → fill region → Save → click
      Configure → Refresh models → no error in status bar.
- [ ] Add connection → pick Ollama / OpenAI similarly.
- [ ] Configure an existing connection → edit base URL → Save → row
      still listed.
- [ ] Remove a connection that isn't referenced → confirm → row
      disappears.
- [ ] Bind a purpose to a connection (e.g. Dreaming → new Anthropic
      connection), try to remove that connection → see refusal → click
      Force remove → succeeds → Purposes tab shows Dreaming back on
      primary.
- [ ] Open Purposes tab: rows for Interactive / Dreaming / Embedding /
      Titling. Interactive dropdowns do not include `"primary"`;
      non-interactive rows do. Changing any dropdown immediately writes
      via `SetPurpose` (watch daemon logs).
- [ ] Chat window: the model selector below the chat lists Auto +
      aggregated `Connection · Model` entries.
- [ ] Pick a model → send a message → stream works. (Routing to that
      specific model is deferred behind desktop-assistant #18.)
- [ ] Restart the app → reopen the same conversation → selector shows
      the previously-picked model (local mirror).
- [ ] Open a different conversation → selector resets / shows that
      conversation's mirror (or Auto if none).
- [ ] Delete the connection referenced by an open conversation's stored
      selection → reopen the conversation → `DanglingModelSelection`
      toast appears, selector resets to Auto.

closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)