### PR TITLE
Security: bump rustls-webpki + rand for advisories (Refs #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2459,9 +2459,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3167,7 +3167,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -202,6 +202,12 @@ pub async fn connection_manager(
                             conversation_id,
                             title,
                         },
+                        SignalEvent::ConversationWarning {
+                            conversation_id,
+                            warning,
+                        } => UiMessage::StatusUpdate(format!(
+                            "Conversation {conversation_id}: {warning:?}"
+                        )),
                         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
                     };
                     if ui_tx.send(msg).is_err() {


### PR DESCRIPTION
Refs #3. Issue stays open — some advisories require upstream action.

Two commits:
1. **Build fix** — add a `SignalEvent::ConversationWarning` arm to the match in `src/async_bridge.rs`. The variant was added upstream in the path-dep `desktop-assistant/crates/client-common`, and adele-gtk hadn't synced. For now the warning is forwarded as a `UiMessage::StatusUpdate` with the warning's `Debug` rendering — a future PR can introduce a dedicated `UiMessage` variant if the UI wants special rendering.
2. **Lockfile bumps** — `cargo update --precise`:
   - `rustls-webpki` 0.103.10 → **0.103.13** (RUSTSEC-2026-0098/0099/0104)
   - `rand` 0.9.2 → **0.9.3** (RUSTSEC-2026-0097)

Not in this PR (deferred to upstream):
- `rand 0.8.5` — transitive, blocked by major-version constraint upstream
- `paste`, `rustls-pemfile` — unmaintained, no fixed version exists

`cargo build` and `cargo test` (13 passed) clean locally.