### PR TITLE
feat: per-conversation model picker in chat header

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::SignalEvent;
 use desktop_assistant_client_common::{
     AssistantClient, ConnectionConfig, TransportClient, connect_transport,
@@ -60,6 +61,9 @@ pub enum UiMessage {
     PromptSent {
         request_id: String,
     },
+    /// Available (connection, model) pairs, fetched once on connect.
+    /// Empty list means the picker should hide (e.g. D-Bus transport).
+    ModelsLoaded(Vec<api::ModelListing>),
     Connected {
         label: String,
     },
@@ -170,6 +174,21 @@ pub async fn connection_manager(
                             return;
                         }
                     }
+                }
+
+                // Fetch available models when the transport supports it
+                // (WS only — the D-Bus interface doesn't expose this command).
+                let listings = match transport.as_ws() {
+                    Some(ws) => ws.list_available_models(None, false).await.unwrap_or_else(
+                        |e| {
+                            tracing::warn!("list_available_models failed: {e}");
+                            Vec::new()
+                        },
+                    ),
+                    None => Vec::new(),
+                };
+                if ui_tx.send(UiMessage::ModelsLoaded(listings)).is_err() {
+                    return;
                 }
 
                 // Forward signals until disconnect

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,5 +1,6 @@
 pub mod chat_view;
 pub mod input_bar;
 pub mod login_screen;
+pub mod model_picker;
 pub mod setup_dialog;
 pub mod sidebar;

--- a/src/widgets/model_picker.rs
+++ b/src/widgets/model_picker.rs
@@ -1,0 +1,124 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{Box as GtkBox, DropDown, Label, Orientation, StringList};
+
+/// Header-bar widget that shows the current model and lets the user pick a
+/// different one for the active conversation. The dropdown is populated from
+/// `ListAvailableModels`; selection state is per-conversation and round-trips
+/// through `ConversationView.model_selection`.
+pub struct ModelPicker {
+    pub container: GtkBox,
+    dropdown: DropDown,
+    /// Mirror of the dropdown's StringList contents in order. Each entry is
+    /// the (connection_id, model_id) the dropdown's `selected` index resolves
+    /// to. Held in an Rc<RefCell<>> so signal handlers can read it without
+    /// borrowing the picker itself.
+    models: Rc<RefCell<Vec<ModelEntry>>>,
+}
+
+#[derive(Debug, Clone)]
+struct ModelEntry {
+    connection_id: String,
+    model_id: String,
+}
+
+impl ModelPicker {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Horizontal, 6);
+        container.set_valign(gtk4::Align::Center);
+
+        let label = Label::new(Some("Model:"));
+        label.add_css_class("dim-label");
+        container.append(&label);
+
+        let dropdown = DropDown::new(None::<StringList>, None::<gtk4::Expression>);
+        dropdown.set_sensitive(false);
+        dropdown.set_tooltip_text(Some(
+            "Pick a model for this conversation. The choice is remembered \
+             until you change it again.",
+        ));
+        container.append(&dropdown);
+
+        Self {
+            container,
+            dropdown,
+            models: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    /// Replace the available-models list. Resets the dropdown to "no
+    /// selection"; callers should follow with `set_selection(...)` once the
+    /// active conversation's stored selection is known.
+    pub fn set_models(&self, listings: &[api::ModelListing]) {
+        let labels: Vec<String> = listings.iter().map(format_label).collect();
+        let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
+        let string_list = StringList::new(&label_refs);
+        self.dropdown.set_model(Some(&string_list));
+
+        let entries: Vec<ModelEntry> = listings
+            .iter()
+            .map(|l| ModelEntry {
+                connection_id: l.connection_id.clone(),
+                model_id: l.model.id.clone(),
+            })
+            .collect();
+        *self.models.borrow_mut() = entries;
+
+        self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION);
+        self.dropdown.set_sensitive(!listings.is_empty());
+    }
+
+    /// Highlight the dropdown row matching `selection`, or reset to "no
+    /// selection" when `None` or when the selection isn't in the current
+    /// model list.
+    pub fn set_selection(&self, selection: Option<&api::ConversationModelSelectionView>) {
+        let Some(sel) = selection else {
+            self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION);
+            return;
+        };
+        let idx = self
+            .models
+            .borrow()
+            .iter()
+            .position(|m| m.connection_id == sel.connection_id && m.model_id == sel.model_id);
+        match idx {
+            Some(i) => self.dropdown.set_selected(i as u32),
+            None => self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION),
+        }
+    }
+
+    /// The override to attach to the next `SendMessage`, or `None` when
+    /// nothing is selected (the daemon falls back to the conversation's
+    /// stored selection or the interactive purpose).
+    pub fn current_override(&self) -> Option<api::SendPromptOverride> {
+        let idx = self.dropdown.selected();
+        if idx == gtk4::INVALID_LIST_POSITION {
+            return None;
+        }
+        let models = self.models.borrow();
+        let entry = models.get(idx as usize)?;
+        Some(api::SendPromptOverride {
+            connection_id: entry.connection_id.clone(),
+            model_id: entry.model_id.clone(),
+            effort: None,
+        })
+    }
+
+    /// Hide the entire picker — used when the active transport doesn't
+    /// support per-send overrides (D-Bus today).
+    pub fn set_visible(&self, visible: bool) {
+        self.container.set_visible(visible);
+    }
+}
+
+fn format_label(listing: &api::ModelListing) -> String {
+    let model_label = if listing.model.display_name.is_empty() {
+        listing.model.id.as_str()
+    } else {
+        listing.model.display_name.as_str()
+    };
+    format!("{} · {}", model_label, listing.connection_label)
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use crate::async_bridge::{AsyncBridge, InternalMsg, UiMessage, connection_manager};
 use crate::widgets::chat_view::ChatView;
 use crate::widgets::input_bar::InputBar;
+use crate::widgets::model_picker::ModelPicker;
 use crate::widgets::sidebar::Sidebar;
 
 /// Shared mutable state for the window.
@@ -70,11 +71,16 @@ impl AdelieWindow {
         right_box.set_vexpand(true);
 
         // Header bar with hamburger menu
-        let header_bar = GtkBox::new(Orientation::Horizontal, 0);
+        let header_bar = GtkBox::new(Orientation::Horizontal, 8);
         header_bar.set_margin_start(8);
         header_bar.set_margin_end(8);
         header_bar.set_margin_top(4);
         header_bar.set_margin_bottom(4);
+
+        // Per-conversation model picker — populated on connect, selection
+        // tracks `ConversationView.model_selection` after each load.
+        let model_picker = ModelPicker::new();
+        header_bar.append(&model_picker.container);
 
         // Spacer to push menu button to the right
         let spacer = GtkBox::new(Orientation::Horizontal, 0);
@@ -158,6 +164,7 @@ impl AdelieWindow {
         let chat_view = Rc::new(RefCell::new(chat_view));
         let input_bar = Rc::new(input_bar);
         let status_label = Rc::new(status_label);
+        let model_picker = Rc::new(model_picker);
 
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
@@ -173,6 +180,7 @@ impl AdelieWindow {
             let status_label = Rc::clone(&status_label);
             let client = Rc::clone(&client);
             let input_bar = Rc::clone(&input_bar);
+            let model_picker = Rc::clone(&model_picker);
 
             AsyncBridge::new(move |msg| {
                 handle_ui_message(
@@ -183,6 +191,7 @@ impl AdelieWindow {
                     &status_label,
                     &client,
                     &input_bar,
+                    &model_picker,
                 );
             })
         };
@@ -461,6 +470,7 @@ impl AdelieWindow {
             let state = Rc::clone(&state);
             let input_bar_ref = Rc::clone(&input_bar);
             let chat_view_ref = Rc::clone(&chat_view);
+            let model_picker_ref = Rc::clone(&model_picker);
 
             let send_action = Rc::new(move || {
                 let text = input_bar_ref.take_text();
@@ -489,11 +499,24 @@ impl AdelieWindow {
                     }
                 }
 
+                let override_selection = model_picker_ref.current_override();
+
                 if let Some(client) = client_ref.borrow().clone() {
                     let tx = bridge_ref.ui_sender();
                     let text = text.clone();
                     bridge_ref.spawn(async move {
-                        match client.send_prompt(&conv_id, &text).await {
+                        // Use the WS-specific override path when available so
+                        // the picker's selection is honoured. The shared
+                        // AssistantClient trait can't carry the override
+                        // because the D-Bus surface doesn't expose it; on
+                        // D-Bus we fall through to the plain send_prompt.
+                        let result = match (client.as_ws(), override_selection) {
+                            (Some(ws), Some(over)) => {
+                                ws.send_prompt_with_override(&conv_id, &text, Some(over)).await
+                            }
+                            _ => client.send_prompt(&conv_id, &text).await,
+                        };
+                        match result {
                             Ok(request_id) => {
                                 let _ = tx.send(UiMessage::PromptSent { request_id });
                             }
@@ -596,6 +619,7 @@ fn handle_ui_message(
     status_label: &Rc<Label>,
     client: &Rc<RefCell<Option<Arc<TransportClient>>>>,
     input_bar: &Rc<InputBar>,
+    model_picker: &Rc<ModelPicker>,
 ) {
     match msg {
         UiMessage::ConversationsLoaded(convs) => {
@@ -606,6 +630,7 @@ fn handle_ui_message(
             let id = detail.id.clone();
             let debug = state.borrow().debug_enabled;
             let filtered = filter_messages(&detail, debug);
+            model_picker.set_selection(detail.model_selection.as_ref());
             let mut s = state.borrow_mut();
             s.current_conversation = Some(detail);
             s.current_conversation_id = Some(id);
@@ -736,6 +761,16 @@ fn handle_ui_message(
         UiMessage::Error(text) => {
             status_label.set_text(&format!("Error: {text}"));
         }
+        UiMessage::ModelsLoaded(listings) => {
+            let visible = !listings.is_empty();
+            model_picker.set_models(&listings);
+            // Re-apply the active conversation's stored selection (if any)
+            // since `set_models` resets the dropdown.
+            if let Some(ref detail) = state.borrow().current_conversation {
+                model_picker.set_selection(detail.model_selection.as_ref());
+            }
+            model_picker.set_visible(visible);
+        }
         UiMessage::Connected { label } => {
             status_label.set_text(&label);
             input_bar.send_button.set_sensitive(true);
@@ -840,5 +875,6 @@ fn filter_messages(detail: &ConversationDetail, debug: bool) -> ConversationDeta
             })
             .cloned()
             .collect(),
+        model_selection: detail.model_selection.clone(),
     }
 }


### PR DESCRIPTION
## Summary

- Adds a model picker to the chat header bar so users can see and change the model in use for the active conversation. Closes #6.
- Picker is populated once on connect via `WsClient::list_available_models`; selection is per-conversation, sourced from `ConversationView.model_selection` on load and attached as a `SendPromptOverride` on send.
- Hidden when the transport is D-Bus (no override path exposed there today).

Depends on adelie-ai/desktop-assistant#55 — already merged.

### Known limitation

Once a model has been picked, the daemon persists it. The UI has no affordance yet to revert to "use the interactive purpose default" — that would need a server-side `Command::ClearConversationModelSelection` or an explicit "auto" sentinel. Tracked in #6 as out-of-scope follow-up.

## Test plan

- [x] `cargo check` clean
- [x] `cargo build` clean
- [ ] Manual: connect to a daemon that exposes multiple models, switch model in the picker, send a message, confirm subsequent sends in the same conversation reuse the chosen model without re-picking.
- [ ] Manual: open a second conversation and confirm the picker tracks that conversation's stored selection (not the previous one).
- [ ] Manual: verify the picker is hidden on D-Bus transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)