### PR TITLE
Auto-reconnect to last profile + hamburger switch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,12 @@ use clap::Parser;
 use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 use gtk4::Application;
 use gtk4::prelude::*;
+use gtk4::glib;
 use tracing_subscriber::EnvFilter;
+
+use crate::async_bridge::spawn_on_runtime;
+use crate::profile::{LastConnectionStore, ProfileStore};
+use crate::widgets::login_screen::{LoginScreen, connect_to_profile};
 
 const APP_ID: &str = "org.adelie.DesktopAssistant";
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
@@ -103,10 +108,37 @@ fn main() -> Result<()> {
     let app = Application::builder().application_id(APP_ID).build();
 
     app.connect_activate(move |app| {
-        // Always show the login/connection selection screen.
-        // Credentials are obtained interactively and stored in the system keyring.
-        let login = widgets::login_screen::LoginScreen::new(app);
-        login.present();
+        // If a profile was used last time and is still configured, attempt to
+        // silently re-establish that connection. On any failure, fall back to
+        // the connection picker.
+        let app_clone = app.clone();
+        glib::spawn_future_local(async move {
+            if let Some(profile) = last_active_profile() {
+                let profile_id = profile.id.clone();
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                spawn_on_runtime(async move {
+                    let _ = tx.send(connect_to_profile(&profile).await);
+                });
+                match rx.await {
+                    Ok(Ok(config)) => {
+                        if let Err(e) = LastConnectionStore::new().set(&profile_id) {
+                            tracing::warn!("Failed to refresh last-connection marker: {e}");
+                        }
+                        let main_win = window::AdelieWindow::new(&app_clone, config);
+                        main_win.present();
+                        return;
+                    }
+                    Ok(Err(e)) => {
+                        tracing::info!("auto-reconnect failed, showing picker: {e}");
+                    }
+                    Err(_) => {
+                        tracing::info!("auto-reconnect channel dropped, showing picker");
+                    }
+                }
+            }
+            let login = LoginScreen::new(&app_clone);
+            login.present();
+        });
     });
 
     // GTK expects command-line args but we've already parsed them with clap.
@@ -114,4 +146,12 @@ fn main() -> Result<()> {
     app.run_with_args(&empty);
 
     Ok(())
+}
+
+/// Look up the connection profile recorded as the most recently active.
+/// Returns `None` if no marker exists or the profile has since been deleted.
+fn last_active_profile() -> Option<profile::ConnectionProfile> {
+    let id = LastConnectionStore::new().get()?;
+    let profiles = ProfileStore::new().load().ok()?;
+    profiles.into_iter().find(|p| p.id == id)
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -20,17 +20,24 @@ struct ProfilesFile {
     profiles: Vec<ConnectionProfile>,
 }
 
+fn default_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("adele-gtk")
+}
+
 pub struct ProfileStore {
     path: PathBuf,
 }
 
 impl ProfileStore {
     pub fn new() -> Self {
-        let config_dir = dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("adele-gtk");
+        Self::with_dir(default_config_dir())
+    }
+
+    pub fn with_dir(dir: PathBuf) -> Self {
         Self {
-            path: config_dir.join("profiles.json"),
+            path: dir.join("profiles.json"),
         }
     }
 
@@ -75,5 +82,145 @@ impl ProfileStore {
         let mut profiles = self.load()?;
         profiles.retain(|p| p.id != id);
         self.save(&profiles)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct LastConnectionFile {
+    profile_id: Option<String>,
+}
+
+/// Records the most recently connected profile so the app can silently
+/// re-establish that connection on the next launch.
+pub struct LastConnectionStore {
+    path: PathBuf,
+}
+
+impl LastConnectionStore {
+    pub fn new() -> Self {
+        Self::with_dir(default_config_dir())
+    }
+
+    pub fn with_dir(dir: PathBuf) -> Self {
+        Self {
+            path: dir.join("last_connection.json"),
+        }
+    }
+
+    pub fn get(&self) -> Option<String> {
+        let data = std::fs::read_to_string(&self.path).ok()?;
+        let file: LastConnectionFile = serde_json::from_str(&data).ok()?;
+        file.profile_id
+    }
+
+    pub fn set(&self, profile_id: &str) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = LastConnectionFile {
+            profile_id: Some(profile_id.to_string()),
+        };
+        let data = serde_json::to_string_pretty(&file)?;
+        std::fs::write(&self.path, data)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "adele-gtk-test-{}-{}-{}",
+                name,
+                std::process::id(),
+                uuid::Uuid::new_v4(),
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn sample_profile(id: &str) -> ConnectionProfile {
+        ConnectionProfile {
+            id: id.to_string(),
+            name: format!("name-{id}"),
+            ws_url: format!("ws://example.com/{id}"),
+            ws_subject: "desktop-tui".to_string(),
+        }
+    }
+
+    #[test]
+    fn profile_store_round_trip() {
+        let dir = TempDir::new("profiles-roundtrip");
+        let store = ProfileStore::with_dir(dir.path.clone());
+
+        assert!(store.load().unwrap().is_empty());
+
+        store.add(sample_profile("a")).unwrap();
+        store.add(sample_profile("b")).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].id, "a");
+        assert_eq!(loaded[1].id, "b");
+
+        let mut updated = sample_profile("a");
+        updated.name = "renamed".to_string();
+        store.update(&updated).unwrap();
+        assert_eq!(store.load().unwrap()[0].name, "renamed");
+
+        store.delete("a").unwrap();
+        let remaining = store.load().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "b");
+    }
+
+    #[test]
+    fn last_connection_get_returns_none_when_absent() {
+        let dir = TempDir::new("last-absent");
+        let store = LastConnectionStore::with_dir(dir.path.clone());
+        assert_eq!(store.get(), None);
+    }
+
+    #[test]
+    fn last_connection_set_then_get() {
+        let dir = TempDir::new("last-set-get");
+        let store = LastConnectionStore::with_dir(dir.path.clone());
+        store.set("profile-xyz").unwrap();
+        assert_eq!(store.get().as_deref(), Some("profile-xyz"));
+    }
+
+    #[test]
+    fn last_connection_set_overwrites() {
+        let dir = TempDir::new("last-overwrite");
+        let store = LastConnectionStore::with_dir(dir.path.clone());
+        store.set("first").unwrap();
+        store.set("second").unwrap();
+        assert_eq!(store.get().as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn last_connection_get_handles_corrupt_file() {
+        let dir = TempDir::new("last-corrupt");
+        let store = LastConnectionStore::with_dir(dir.path.clone());
+        std::fs::write(store.path(), "not json").unwrap();
+        assert_eq!(store.get(), None);
     }
 }

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -10,7 +10,7 @@ use gtk4::{
 use crate::async_bridge;
 use crate::credential_store::CredentialStore;
 use crate::oauth;
-use crate::profile::{ConnectionProfile, ProfileStore};
+use crate::profile::{ConnectionProfile, LastConnectionStore, ProfileStore};
 use crate::widgets::setup_dialog;
 use crate::window;
 
@@ -330,12 +330,17 @@ impl LoginScreen {
                 // (reqwest needs tokio), then handle the result on the GTK main thread.
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 async_bridge::spawn_on_runtime(async move {
-                    let result = connect_to_profile(&profile).await;
+                    let result = connect_to_profile(&profile)
+                        .await
+                        .map(|config| (profile.id.clone(), config));
                     let _ = tx.send(result);
                 });
                 glib::spawn_future_local(async move {
                     match rx.await {
-                        Ok(Ok(config)) => {
+                        Ok(Ok((profile_id, config))) => {
+                            if let Err(e) = LastConnectionStore::new().set(&profile_id) {
+                                tracing::warn!("Failed to persist last connection: {e}");
+                            }
                             let main_win = window::AdelieWindow::new(&app, config);
                             main_win.present();
                             win.close();
@@ -362,7 +367,7 @@ impl LoginScreen {
 }
 
 /// Attempt to connect to a profile by discovering auth method and obtaining credentials.
-async fn connect_to_profile(
+pub async fn connect_to_profile(
     profile: &ConnectionProfile,
 ) -> anyhow::Result<desktop_assistant_client_common::ConnectionConfig> {
     use desktop_assistant_client_common::{ConnectionConfig, TransportMode};

--- a/src/window.rs
+++ b/src/window.rs
@@ -96,10 +96,10 @@ impl AdelieWindow {
         menu_popover.add_css_class("context-popover");
         let menu_box = GtkBox::new(Orientation::Vertical, 0);
 
-        let new_conn_btn = Button::with_label("New Connection");
-        new_conn_btn.add_css_class("context-button");
-        new_conn_btn.set_halign(Align::Fill);
-        menu_box.append(&new_conn_btn);
+        let switch_conn_btn = Button::with_label("Switch Connection…");
+        switch_conn_btn.add_css_class("context-button");
+        switch_conn_btn.set_halign(Align::Fill);
+        menu_box.append(&switch_conn_btn);
 
         let knowledge_btn = Button::with_label("Knowledge Base");
         knowledge_btn.add_css_class("context-button");
@@ -556,11 +556,13 @@ impl AdelieWindow {
             input_bar.text_view.add_controller(key_controller);
         }
 
-        // Hamburger menu: New Connection → open login screen in a new window
+        // Hamburger menu: Switch Connection → open the picker in a new
+        // window. The current connection's window is intentionally left open;
+        // selecting a profile spawns a fresh AdelieWindow alongside it.
         {
             let app_ref = app.clone();
             let popover_ref = menu_popover.clone();
-            new_conn_btn.connect_clicked(move |_| {
+            switch_conn_btn.connect_clicked(move |_| {
                 popover_ref.popdown();
                 let login = crate::widgets::login_screen::LoginScreen::new(&app_ref);
                 login.present();


### PR DESCRIPTION
Closes #9, closes #10.

## Summary
- Persist the profile ID of the most recent successful connection in `last_connection.json`; on launch attempt that profile silently and only show the picker on failure or when no marker exists.
- Rename the hamburger menu's connection-switch entry from "New Connection" to "Switch Connection…" to match its actual behavior — it opens the picker in a new window and leaves the originating connection's window intact.
- Refactor: \`profile::LastConnectionStore\` (matching the existing \`ProfileStore\` shape) plus a \`with_dir\` constructor on both stores so tests can isolate state.

## Test plan
- [x] \`cargo build\` clean (no new warnings)
- [x] \`cargo test\` — 24 passing including 5 new \`LastConnectionStore\` / \`ProfileStore\` tests
- [ ] Manual: launch with no marker → picker appears; pick + connect; relaunch → main window opens directly
- [ ] Manual: hamburger → Switch Connection… opens picker without closing current window; choosing a profile opens a second window