### PR TITLE
feat: filter model dropdown via Select Models dialog

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod credential_store;
 mod markdown;
 mod oauth;
 mod profile;
+mod selected_models;
 #[cfg(feature = "linux")]
 mod webview;
 mod widgets;

--- a/src/selected_models.rs
+++ b/src/selected_models.rs
@@ -1,0 +1,137 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Identifies a single (connection, model) pair the user has chosen to keep
+/// in the model picker dropdown. The set is filtered client-side so the
+/// dropdown stays manageable even when a connector exposes hundreds of
+/// models (e.g. Bedrock).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelectedModel {
+    pub connection_id: String,
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct SelectedModelsFile {
+    #[serde(default)]
+    models: Vec<SelectedModel>,
+}
+
+fn default_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("adele-gtk")
+}
+
+/// Persists the user's curated subset of available models. Stored as JSON
+/// next to the existing profile/last-connection files.
+pub struct SelectedModelsStore {
+    path: PathBuf,
+}
+
+impl SelectedModelsStore {
+    pub fn new() -> Self {
+        Self::with_dir(default_config_dir())
+    }
+
+    pub fn with_dir(dir: PathBuf) -> Self {
+        Self {
+            path: dir.join("selected_models.json"),
+        }
+    }
+
+    /// True when the user has never persisted a selection. Callers use this
+    /// to decide whether to seed the list with a sensible default (typically
+    /// the first non-embedding model from `list_available_models`).
+    pub fn is_initialized(&self) -> bool {
+        self.path.exists()
+    }
+
+    pub fn load(&self) -> Result<Vec<SelectedModel>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let data = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("reading {}", self.path.display()))?;
+        let file: SelectedModelsFile =
+            serde_json::from_str(&data).with_context(|| "parsing selected_models.json")?;
+        Ok(file.models)
+    }
+
+    pub fn save(&self, models: &[SelectedModel]) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = SelectedModelsFile {
+            models: models.to_vec(),
+        };
+        let data = serde_json::to_string_pretty(&file)?;
+        std::fs::write(&self.path, data)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "adele-gtk-test-{}-{}-{}",
+                name,
+                std::process::id(),
+                uuid::Uuid::new_v4(),
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn fresh_store_is_uninitialized_and_loads_empty() {
+        let dir = TempDir::new("selected-fresh");
+        let store = SelectedModelsStore::with_dir(dir.path.clone());
+        assert!(!store.is_initialized());
+        assert!(store.load().unwrap().is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trip() {
+        let dir = TempDir::new("selected-roundtrip");
+        let store = SelectedModelsStore::with_dir(dir.path.clone());
+        let entries = vec![
+            SelectedModel {
+                connection_id: "openai".to_string(),
+                model_id: "gpt-4o".to_string(),
+            },
+            SelectedModel {
+                connection_id: "anthropic".to_string(),
+                model_id: "claude-opus-4-7".to_string(),
+            },
+        ];
+        store.save(&entries).unwrap();
+        assert!(store.is_initialized());
+        assert_eq!(store.load().unwrap(), entries);
+    }
+
+    #[test]
+    fn save_empty_list_marks_initialized() {
+        let dir = TempDir::new("selected-empty");
+        let store = SelectedModelsStore::with_dir(dir.path.clone());
+        store.save(&[]).unwrap();
+        assert!(store.is_initialized());
+        assert!(store.load().unwrap().is_empty());
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -3,5 +3,6 @@ pub mod input_bar;
 pub mod knowledge_browser;
 pub mod login_screen;
 pub mod model_picker;
+pub mod select_models_dialog;
 pub mod setup_dialog;
 pub mod sidebar;

--- a/src/widgets/model_picker.rs
+++ b/src/widgets/model_picker.rs
@@ -3,106 +3,141 @@ use std::rc::Rc;
 
 use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
-use gtk4::{Box as GtkBox, DropDown, Label, Orientation, StringList};
+use gtk4::{Align, Box as GtkBox, Button, Label, MenuButton, Orientation, Popover, Separator, Window};
+
+use crate::selected_models::{SelectedModel, SelectedModelsStore};
+use crate::widgets::select_models_dialog::show_select_models_dialog;
 
 /// Header-bar widget that shows the current model and lets the user pick a
-/// different one for the active conversation. The dropdown is populated from
-/// `ListAvailableModels`; selection state is per-conversation and round-trips
-/// through `ConversationView.model_selection`.
+/// different one for the active conversation. The user curates a subset of
+/// available models via the "Select Models…" entry — the dropdown only
+/// shows that subset, so noisy connectors (Bedrock) don't drown the picker
+/// (#13). Per-conversation selection state still round-trips through the
+/// active conversation's `model_selection`.
 pub struct ModelPicker {
     pub container: GtkBox,
-    dropdown: DropDown,
-    /// Mirror of the dropdown's StringList contents in order. Each entry is
-    /// the (connection_id, model_id) the dropdown's `selected` index resolves
-    /// to. Held in an Rc<RefCell<>> so signal handlers can read it without
-    /// borrowing the picker itself.
-    models: Rc<RefCell<Vec<ModelEntry>>>,
-}
-
-#[derive(Debug, Clone)]
-struct ModelEntry {
-    connection_id: String,
-    model_id: String,
+    menu_button: MenuButton,
+    /// Backs the popover content; rebuilt whenever the selected-models list
+    /// or the daemon-side available-models list changes.
+    popover: Popover,
+    /// Mirror of every model the daemon offers (minus embedding-only ones).
+    /// Used to populate the Select Models dialog and to render display
+    /// labels in the popover.
+    available: Rc<RefCell<Vec<api::ModelListing>>>,
+    /// User's curated subset, mirrored to `selected_models.json`.
+    selected: Rc<RefCell<Vec<SelectedModel>>>,
+    /// Currently active selection. `None` means "use the daemon default" —
+    /// we leave the override field empty and let the daemon fall back to
+    /// the conversation's stored selection or the interactive purpose.
+    active: Rc<RefCell<Option<SelectedModel>>>,
+    store: Rc<SelectedModelsStore>,
 }
 
 impl ModelPicker {
     pub fn new() -> Self {
         let container = GtkBox::new(Orientation::Horizontal, 6);
-        container.set_valign(gtk4::Align::Center);
+        container.set_valign(Align::Center);
 
         let label = Label::new(Some("Model:"));
         label.add_css_class("dim-label");
         container.append(&label);
 
-        let dropdown = DropDown::new(None::<StringList>, None::<gtk4::Expression>);
-        dropdown.set_sensitive(false);
-        dropdown.set_tooltip_text(Some(
+        let menu_button = MenuButton::new();
+        menu_button.set_label("(default)");
+        menu_button.set_tooltip_text(Some(
             "Pick a model for this conversation. The choice is remembered \
              until you change it again.",
         ));
-        container.append(&dropdown);
+        menu_button.set_sensitive(false);
+
+        let popover = Popover::new();
+        popover.add_css_class("context-popover");
+        menu_button.set_popover(Some(&popover));
+
+        container.append(&menu_button);
 
         Self {
             container,
-            dropdown,
-            models: Rc::new(RefCell::new(Vec::new())),
+            menu_button,
+            popover,
+            available: Rc::new(RefCell::new(Vec::new())),
+            selected: Rc::new(RefCell::new(Vec::new())),
+            active: Rc::new(RefCell::new(None)),
+            store: Rc::new(SelectedModelsStore::new()),
         }
     }
 
-    /// Replace the available-models list. Resets the dropdown to "no
-    /// selection"; callers should follow with `set_selection(...)` once the
-    /// active conversation's stored selection is known.
+    /// Replace the daemon's available-models list. Callers should follow
+    /// with `set_selection(...)` to apply the active conversation's stored
+    /// selection.
+    ///
+    /// Embedding-only models are filtered out of both the dropdown and the
+    /// Select Models dialog — they aren't useful for chat. On first launch
+    /// (no persisted selection yet) we seed the user's selected list with
+    /// the first non-embedding model so the dropdown isn't empty.
     pub fn set_models(&self, listings: &[api::ModelListing]) {
-        let labels: Vec<String> = listings.iter().map(format_label).collect();
-        let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
-        let string_list = StringList::new(&label_refs);
-        self.dropdown.set_model(Some(&string_list));
-
-        let entries: Vec<ModelEntry> = listings
+        let chat_capable: Vec<api::ModelListing> = listings
             .iter()
-            .map(|l| ModelEntry {
-                connection_id: l.connection_id.clone(),
-                model_id: l.model.id.clone(),
-            })
+            .filter(|l| !l.model.capabilities.embedding)
+            .cloned()
             .collect();
-        *self.models.borrow_mut() = entries;
+        *self.available.borrow_mut() = chat_capable;
 
-        self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION);
-        self.dropdown.set_sensitive(!listings.is_empty());
+        // Seed the user's selected list on first launch. We only persist a
+        // seed when the file is missing — once the user opens the Select
+        // Models dialog and saves (even with nothing checked), we respect
+        // their explicit choice.
+        if !self.store.is_initialized() {
+            let seed = self
+                .available
+                .borrow()
+                .first()
+                .map(|l| SelectedModel {
+                    connection_id: l.connection_id.clone(),
+                    model_id: l.model.id.clone(),
+                })
+                .into_iter()
+                .collect::<Vec<_>>();
+            *self.selected.borrow_mut() = seed.clone();
+            if let Err(e) = self.store.save(&seed) {
+                tracing::warn!("Failed to seed selected_models.json: {e}");
+            }
+        } else {
+            match self.store.load() {
+                Ok(loaded) => *self.selected.borrow_mut() = loaded,
+                Err(e) => {
+                    tracing::warn!("Failed to load selected_models.json: {e}");
+                    self.selected.borrow_mut().clear();
+                }
+            }
+        }
+
+        self.menu_button
+            .set_sensitive(!self.available.borrow().is_empty());
+        self.rebuild_popover();
+        self.refresh_button_label();
     }
 
-    /// Highlight the dropdown row matching `selection`, or reset to "no
-    /// selection" when `None` or when the selection isn't in the current
-    /// model list.
+    /// Apply the active conversation's stored selection (or clear when the
+    /// argument is `None`). Updates the visible label without rebuilding
+    /// the popover; callers are expected to have already populated the
+    /// available list.
     pub fn set_selection(&self, selection: Option<&api::ConversationModelSelectionView>) {
-        let Some(sel) = selection else {
-            self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION);
-            return;
-        };
-        let idx = self
-            .models
-            .borrow()
-            .iter()
-            .position(|m| m.connection_id == sel.connection_id && m.model_id == sel.model_id);
-        match idx {
-            Some(i) => self.dropdown.set_selected(i as u32),
-            None => self.dropdown.set_selected(gtk4::INVALID_LIST_POSITION),
-        }
+        let active = selection.map(|s| SelectedModel {
+            connection_id: s.connection_id.clone(),
+            model_id: s.model_id.clone(),
+        });
+        *self.active.borrow_mut() = active;
+        self.refresh_button_label();
     }
 
-    /// The override to attach to the next `SendMessage`, or `None` when
-    /// nothing is selected (the daemon falls back to the conversation's
-    /// stored selection or the interactive purpose).
+    /// The override to attach to the next `SendMessage`, or `None` when no
+    /// model is actively selected (the daemon then falls back to the
+    /// conversation's stored selection or the interactive purpose).
     pub fn current_override(&self) -> Option<api::SendPromptOverride> {
-        let idx = self.dropdown.selected();
-        if idx == gtk4::INVALID_LIST_POSITION {
-            return None;
-        }
-        let models = self.models.borrow();
-        let entry = models.get(idx as usize)?;
-        Some(api::SendPromptOverride {
-            connection_id: entry.connection_id.clone(),
-            model_id: entry.model_id.clone(),
+        self.active.borrow().as_ref().map(|sel| api::SendPromptOverride {
+            connection_id: sel.connection_id.clone(),
+            model_id: sel.model_id.clone(),
             effort: None,
         })
     }
@@ -111,6 +146,169 @@ impl ModelPicker {
     /// support per-send overrides (D-Bus today).
     pub fn set_visible(&self, visible: bool) {
         self.container.set_visible(visible);
+    }
+
+    fn refresh_button_label(&self) {
+        let active = self.active.borrow();
+        let label_text = match active.as_ref() {
+            Some(sel) => self.label_for(sel),
+            None => "(default)".to_string(),
+        };
+        self.menu_button.set_label(&label_text);
+    }
+
+    fn label_for(&self, sel: &SelectedModel) -> String {
+        label_for(sel, &self.available)
+    }
+
+    fn rebuild_popover(&self) {
+        rebuild_popover_into(
+            &self.popover,
+            &self.menu_button,
+            &self.available,
+            &self.selected,
+            &self.active,
+            &self.store,
+        );
+    }
+}
+
+/// Rebuild the popover's children. Stand-alone (rather than `&self`) so it
+/// can be invoked from the Select Models save callback without juggling a
+/// borrow of the outer `ModelPicker`.
+fn rebuild_popover_into(
+    popover: &Popover,
+    menu_button: &MenuButton,
+    available: &Rc<RefCell<Vec<api::ModelListing>>>,
+    selected: &Rc<RefCell<Vec<SelectedModel>>>,
+    active: &Rc<RefCell<Option<SelectedModel>>>,
+    store: &Rc<SelectedModelsStore>,
+) {
+    let menu_box = GtkBox::new(Orientation::Vertical, 0);
+
+    let select_btn = Button::with_label("Select Models…");
+    select_btn.add_css_class("context-button");
+    select_btn.set_halign(Align::Fill);
+    let popover_ref = popover.clone();
+    let popover_to_rebuild = popover.clone();
+    let menu_button_ref = menu_button.clone();
+    let available_ref = Rc::clone(available);
+    let selected_ref = Rc::clone(selected);
+    let active_ref = Rc::clone(active);
+    let store_ref = Rc::clone(store);
+    select_btn.connect_clicked(move |btn| {
+        popover_ref.popdown();
+        let Some(parent) = btn.root().and_then(|r| r.downcast::<Window>().ok()) else {
+            return;
+        };
+        let available_snapshot = available_ref.borrow().clone();
+        let currently_selected = selected_ref.borrow().clone();
+        let selected_for_save = Rc::clone(&selected_ref);
+        let active_for_save = Rc::clone(&active_ref);
+        let store_for_save = Rc::clone(&store_ref);
+        let popover_for_save = popover_to_rebuild.clone();
+        let menu_button_for_save = menu_button_ref.clone();
+        let available_for_save = Rc::clone(&available_ref);
+        show_select_models_dialog(
+            &parent,
+            &available_snapshot,
+            &currently_selected,
+            move |chosen| {
+                if let Err(e) = store_for_save.save(&chosen) {
+                    tracing::warn!("Failed to save selected_models.json: {e}");
+                }
+                // Drop the active selection if it's no longer in the
+                // user's curated list — keeping it would mean the
+                // button reflects a row that isn't shown in the popover.
+                // The conversation's stored selection on the daemon is
+                // untouched: we just stop overriding it from the client.
+                {
+                    let mut active = active_for_save.borrow_mut();
+                    if let Some(sel) = active.as_ref()
+                        && !chosen.iter().any(|c| c == sel)
+                    {
+                        *active = None;
+                    }
+                }
+                *selected_for_save.borrow_mut() = chosen;
+                rebuild_popover_into(
+                    &popover_for_save,
+                    &menu_button_for_save,
+                    &available_for_save,
+                    &selected_for_save,
+                    &active_for_save,
+                    &store_for_save,
+                );
+                refresh_menu_button_label(
+                    &menu_button_for_save,
+                    &available_for_save,
+                    &active_for_save,
+                );
+            },
+        );
+    });
+    menu_box.append(&select_btn);
+
+    menu_box.append(&Separator::new(Orientation::Horizontal));
+
+    let selected_list = selected.borrow();
+    if selected_list.is_empty() {
+        let empty = Label::new(Some("No models selected"));
+        empty.add_css_class("dim-label");
+        empty.set_halign(Align::Start);
+        empty.set_margin_start(8);
+        empty.set_margin_end(8);
+        empty.set_margin_top(6);
+        empty.set_margin_bottom(6);
+        menu_box.append(&empty);
+    } else {
+        for sel in selected_list.iter() {
+            let label_text = label_for(sel, available);
+            let btn = Button::with_label(&label_text);
+            btn.add_css_class("context-button");
+            btn.set_halign(Align::Fill);
+
+            let active_ref = Rc::clone(active);
+            let popover_ref = popover.clone();
+            let menu_button_ref = menu_button.clone();
+            let available_ref = Rc::clone(available);
+            let sel_owned = sel.clone();
+            btn.connect_clicked(move |_| {
+                *active_ref.borrow_mut() = Some(sel_owned.clone());
+                refresh_menu_button_label(&menu_button_ref, &available_ref, &active_ref);
+                popover_ref.popdown();
+            });
+            menu_box.append(&btn);
+        }
+    }
+
+    popover.set_child(Some(&menu_box));
+}
+
+fn refresh_menu_button_label(
+    menu_button: &MenuButton,
+    available: &Rc<RefCell<Vec<api::ModelListing>>>,
+    active: &Rc<RefCell<Option<SelectedModel>>>,
+) {
+    let text = match active.borrow().as_ref() {
+        Some(sel) => label_for(sel, available),
+        None => "(default)".to_string(),
+    };
+    menu_button.set_label(&text);
+}
+
+/// Render the popover row label for a selected model. Falls back to a raw
+/// `model_id · connection_id` when the daemon no longer enumerates this
+/// pair (e.g. the connection was removed) — better than hiding the row,
+/// since the daemon may still resolve it.
+fn label_for(sel: &SelectedModel, available: &Rc<RefCell<Vec<api::ModelListing>>>) -> String {
+    let available = available.borrow();
+    match available
+        .iter()
+        .find(|l| l.connection_id == sel.connection_id && l.model.id == sel.model_id)
+    {
+        Some(listing) => format_label(listing),
+        None => format!("{} · {}", sel.model_id, sel.connection_id),
     }
 }
 

--- a/src/widgets/select_models_dialog.rs
+++ b/src/widgets/select_models_dialog.rs
@@ -1,0 +1,166 @@
+use std::collections::HashSet;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, CheckButton, Label, Orientation, ScrolledWindow, Separator,
+    Window,
+};
+
+use crate::selected_models::SelectedModel;
+
+/// Show a modal dialog letting the user pick which (connection, model) pairs
+/// should appear in the per-conversation model dropdown. Embedding-only
+/// models are filtered out — they aren't usable for chat. Selection is
+/// returned to `on_save` in the order the connectors and models appeared in
+/// `available`, which preserves whatever ordering the daemon chose.
+pub fn show_select_models_dialog<F>(
+    parent: &Window,
+    available: &[api::ModelListing],
+    currently_selected: &[SelectedModel],
+    on_save: F,
+) where
+    F: Fn(Vec<SelectedModel>) + 'static,
+{
+    let dialog = Window::builder()
+        .title("Select Models")
+        .transient_for(parent)
+        .modal(true)
+        .default_width(440)
+        .default_height(520)
+        .build();
+
+    let outer = GtkBox::new(Orientation::Vertical, 0);
+
+    let intro = Label::new(Some(
+        "Pick which models appear in the model dropdown. \
+         Embedding-only models are excluded.",
+    ));
+    intro.set_wrap(true);
+    intro.set_xalign(0.0);
+    intro.set_margin_start(16);
+    intro.set_margin_end(16);
+    intro.set_margin_top(16);
+    intro.set_margin_bottom(8);
+    outer.append(&intro);
+
+    let scrolled = ScrolledWindow::new();
+    scrolled.set_vexpand(true);
+    scrolled.set_hexpand(true);
+    scrolled.set_margin_start(16);
+    scrolled.set_margin_end(16);
+
+    let list_box = GtkBox::new(Orientation::Vertical, 8);
+
+    let selected_set: HashSet<(String, String)> = currently_selected
+        .iter()
+        .map(|m| (m.connection_id.clone(), m.model_id.clone()))
+        .collect();
+
+    // Group by connection while preserving the connector order from the
+    // daemon's listing. `BTreeMap` would re-sort by id; we want the daemon's
+    // order so a Bedrock connector with hundreds of models still flows in
+    // the same shape it returned.
+    let mut groups: Vec<(String, String, Vec<&api::ModelListing>)> = Vec::new();
+    for listing in available {
+        if listing.model.capabilities.embedding {
+            continue;
+        }
+        match groups
+            .iter_mut()
+            .find(|(id, _, _)| id == &listing.connection_id)
+        {
+            Some((_, _, items)) => items.push(listing),
+            None => groups.push((
+                listing.connection_id.clone(),
+                listing.connection_label.clone(),
+                vec![listing],
+            )),
+        }
+    }
+
+    let checks: std::rc::Rc<std::cell::RefCell<Vec<(SelectedModel, CheckButton)>>> =
+        std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+
+    if groups.is_empty() {
+        let empty = Label::new(Some(
+            "No chat-capable models are available from the connected daemon.",
+        ));
+        empty.set_wrap(true);
+        empty.add_css_class("dim-label");
+        list_box.append(&empty);
+    } else {
+        for (idx, (conn_id, conn_label, models)) in groups.iter().enumerate() {
+            if idx > 0 {
+                list_box.append(&Separator::new(Orientation::Horizontal));
+            }
+
+            let header = Label::new(Some(conn_label));
+            header.add_css_class("sidebar-header");
+            header.set_halign(Align::Start);
+            list_box.append(&header);
+
+            for listing in models {
+                let label_text = display_label(listing);
+                let check = CheckButton::with_label(&label_text);
+                let key = (conn_id.clone(), listing.model.id.clone());
+                if selected_set.contains(&key) {
+                    check.set_active(true);
+                }
+                list_box.append(&check);
+                checks.borrow_mut().push((
+                    SelectedModel {
+                        connection_id: conn_id.clone(),
+                        model_id: listing.model.id.clone(),
+                    },
+                    check,
+                ));
+            }
+        }
+    }
+
+    scrolled.set_child(Some(&list_box));
+    outer.append(&scrolled);
+
+    let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+    btn_row.set_halign(Align::End);
+    btn_row.set_margin_top(12);
+    btn_row.set_margin_bottom(16);
+    btn_row.set_margin_start(16);
+    btn_row.set_margin_end(16);
+
+    let cancel = Button::with_label("Cancel");
+    let dialog_ref = dialog.clone();
+    cancel.connect_clicked(move |_| {
+        dialog_ref.close();
+    });
+    btn_row.append(&cancel);
+
+    let save = Button::with_label("Save");
+    save.add_css_class("suggested-action");
+    let dialog_ref = dialog.clone();
+    let checks_ref = std::rc::Rc::clone(&checks);
+    save.connect_clicked(move |_| {
+        let chosen: Vec<SelectedModel> = checks_ref
+            .borrow()
+            .iter()
+            .filter_map(|(model, check)| check.is_active().then(|| model.clone()))
+            .collect();
+        dialog_ref.close();
+        on_save(chosen);
+    });
+    btn_row.append(&save);
+
+    outer.append(&btn_row);
+
+    dialog.set_child(Some(&outer));
+    dialog.present();
+}
+
+fn display_label(listing: &api::ModelListing) -> String {
+    if listing.model.display_name.is_empty() {
+        listing.model.id.clone()
+    } else {
+        format!("{} ({})", listing.model.display_name, listing.model.id)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the `DropDown` in `ModelPicker` with a `MenuButton` + `Popover`. Layout, top-down: "Select Models…" entry, separator, then the user's curated subset.
- New modal dialog (`widgets/select_models_dialog.rs`) lists every chat-capable model grouped by connector with checkboxes.
- Embedding-only models are filtered out of both the dropdown and the dialog — they aren't useful for chat.
- New `SelectedModelsStore` persists the curated list to `selected_models.json` next to the existing profile/last-connection files. First launch (no file) seeds with the first non-embedding model so the dropdown isn't empty.
- External `ModelPicker` API unchanged (`new`, `set_models`, `set_selection`, `current_override`, `set_visible`, `container`); per-conversation sticky selection keeps working through the existing `ConversationLoaded` wiring.
- Independent of #12 — builds cleanly off main.

Closes #13
Related: #1

## Test plan

- [ ] First launch: dropdown shows only one model (the daemon's first non-embedding model) plus the Select Models entry + separator above.
- [ ] Open Select Models, tick/untick models, save → dropdown updates and persists across restart.
- [ ] Embedding models never appear in the dropdown or dialog.
- [ ] Per-conversation selection is preserved when switching conversations.
- [ ] Picking a model that's no longer in the curated list (deselected via dialog) clears the active button label, but the conversation's stored selection on the daemon is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)