### PR TITLE
feat: process manager view (#19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,10 +266,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -485,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +555,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +574,33 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -571,12 +639,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
  "desktop-assistant-core",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "desktop-assistant-auth-jwt"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "jsonwebtoken",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -603,11 +701,14 @@ name = "desktop-assistant-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "backon",
  "chrono",
+ "desktop-assistant-auth-jwt",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -618,6 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -659,6 +761,65 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -738,6 +899,22 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -948,6 +1125,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1064,6 +1242,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1285,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1638,6 +1839,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1879,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1675,6 +1903,12 @@ checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1806,6 +2040,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +2063,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1852,6 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1920,6 +2177,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "pango"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2260,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2299,27 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2031,6 +2352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2374,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2337,6 +2673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2694,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2490,6 +2856,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"
@@ -2673,6 +3053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +3077,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -2734,6 +3136,22 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2891,6 +3309,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -72,6 +72,38 @@ pub enum UiMessage {
     },
     StatusUpdate(String),
     Error(String),
+
+    // --- Background tasks (issue #19) -------------------------------------
+    //
+    // The connection manager forwards `Event::Task*` frames into these
+    // variants so the GTK main thread can update the process-manager panel
+    // without touching tokio or the WebSocket directly. `TasksLoaded` is
+    // produced by the initial `ListBackgroundTasks` snapshot taken on
+    // connect (and on reconnect — see `connection_manager`).
+    TasksLoaded(Vec<api::TaskView>),
+    // The four streaming variants below are populated by
+    // `connection_manager` once `client-common::SignalEvent::Task*` ships
+    // (tracked on the `feat/client-common-task-signals` branch in the
+    // desktop-assistant repo). Until then, the polling fallback in
+    // `connection_manager` keeps the panel live via `TasksLoaded`.
+    #[allow(dead_code)]
+    TaskStarted(api::TaskView),
+    #[allow(dead_code)]
+    TaskProgress {
+        id: String,
+        progress_hint: Option<String>,
+    },
+    #[allow(dead_code)]
+    TaskLogAppended {
+        id: String,
+        entry: api::TaskLogEntry,
+    },
+    #[allow(dead_code)]
+    TaskCompleted {
+        id: String,
+        status: api::TaskStatus,
+        last_error: Option<String>,
+    },
 }
 
 /// Internal message for delivering a new client to the GTK main thread.
@@ -183,17 +215,96 @@ pub async fn connection_manager(
                 // Fetch available models when the transport supports it
                 // (WS only — the D-Bus interface doesn't expose this command).
                 let listings = match transport.as_ws() {
-                    Some(ws) => ws.list_available_models(None, false).await.unwrap_or_else(
-                        |e| {
+                    Some(ws) => ws
+                        .list_available_models(None, false)
+                        .await
+                        .unwrap_or_else(|e| {
                             tracing::warn!("list_available_models failed: {e}");
                             Vec::new()
-                        },
-                    ),
+                        }),
                     None => Vec::new(),
                 };
                 if ui_tx.send(UiMessage::ModelsLoaded(listings)).is_err() {
                     return;
                 }
+
+                // Subscribe to background-task events and fetch the initial
+                // snapshot. WS-only: the D-Bus surface does not expose
+                // background tasks (issue #116 covers that path).
+                if let Some(ws) = transport.as_ws() {
+                    if let Err(e) = ws
+                        .send_command(api::Command::SubscribeBackgroundTasks)
+                        .await
+                    {
+                        tracing::warn!("SubscribeBackgroundTasks failed: {e}");
+                    }
+                    match ws
+                        .send_command(api::Command::ListBackgroundTasks {
+                            include_finished: false,
+                            limit: None,
+                        })
+                        .await
+                    {
+                        Ok(api::CommandResult::BackgroundTasks(tasks)) => {
+                            if ui_tx.send(UiMessage::TasksLoaded(tasks)).is_err() {
+                                return;
+                            }
+                        }
+                        Ok(other) => {
+                            tracing::warn!(
+                                "unexpected response for ListBackgroundTasks: {other:?}"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("ListBackgroundTasks failed: {e}");
+                        }
+                    }
+                }
+
+                // Background-task polling fallback.
+                //
+                // The streaming `Event::Task*` frames already arrive on the
+                // WebSocket (the daemon emits them in response to
+                // `SubscribeBackgroundTasks`), but `client-common`'s
+                // `SignalEvent` does not yet surface them — that extension is
+                // tracked separately on `feat/client-common-task-signals`. To
+                // keep the panel live in the meantime, the connection manager
+                // polls `ListBackgroundTasks` on a slow cadence. Polling is
+                // additive: when the SignalEvent extension lands, the
+                // streaming path will populate the same `UiMessage::Task*`
+                // variants and the poller becomes redundant (left in place
+                // as a defensive refresh against missed events).
+                let poll_tx = ui_tx.clone();
+                let poll_transport = Arc::clone(&transport);
+                tokio::spawn(async move {
+                    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(5));
+                    ticker.tick().await; // first tick is immediate; skip it
+                    loop {
+                        ticker.tick().await;
+                        let Some(ws) = poll_transport.as_ws() else {
+                            return;
+                        };
+                        match ws
+                            .send_command(api::Command::ListBackgroundTasks {
+                                include_finished: false,
+                                limit: None,
+                            })
+                            .await
+                        {
+                            Ok(api::CommandResult::BackgroundTasks(tasks)) => {
+                                if poll_tx.send(UiMessage::TasksLoaded(tasks)).is_err() {
+                                    return;
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                // Transient errors during reconnect are expected.
+                                tracing::debug!("ListBackgroundTasks poll: {e}");
+                                return;
+                            }
+                        }
+                    }
+                });
 
                 // Forward signals until disconnect
                 while let Some(signal) = signal_rx.recv().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use anyhow::Result;
 use clap::Parser;
 use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 use gtk4::Application;
-use gtk4::prelude::*;
 use gtk4::glib;
+use gtk4::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 use crate::async_bridge::spawn_on_runtime;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -35,8 +35,7 @@ pub async fn discover_auth_config(
     let base_url = ws_url_to_http_base(ws_url);
     let url = format!("{base_url}/auth/config");
 
-    let mut builder = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10));
+    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
     if let Some(ca_path) = tls_ca_cert {
         if let Ok(pem_bytes) = std::fs::read(ca_path) {
             if let Ok(cert) = reqwest::tls::Certificate::from_pem(&pem_bytes) {

--- a/src/style.css
+++ b/src/style.css
@@ -179,3 +179,66 @@ entry {
 entry:focus {
     border-color: #4866b4;
 }
+
+/* Process-manager panel (#19) */
+.sidebar-stack-switcher button {
+    color: #e0e0e0;
+    background: none;
+    border-radius: 6px;
+    padding: 4px 12px;
+}
+
+.sidebar-stack-switcher button:checked {
+    background-color: #4866b4;
+    color: #f5f8ff;
+}
+
+.task-list row {
+    padding: 4px 0;
+    border-radius: 6px;
+}
+
+.task-list row:selected {
+    background-color: #4866b4;
+    color: #f5f8ff;
+}
+
+/* Status indicator dot — a small coloured circle rendered as the
+   background of an empty label. The dot itself comes from the
+   border-radius + min-width/height; per-status colour is set below. */
+.task-dot {
+    min-width: 10px;
+    min-height: 10px;
+    border-radius: 50%;
+    margin-top: 6px;
+}
+
+.task-dot-pending {
+    background-color: #b8a838; /* amber */
+}
+
+.task-dot-running {
+    background-color: #4caf6a; /* green */
+}
+
+.task-dot-completed {
+    background-color: #6b7a90; /* neutral grey for "done" */
+}
+
+.task-dot-failed {
+    background-color: #d9534f; /* red */
+}
+
+.task-dot-cancelled {
+    background-color: #7c8494; /* dim grey */
+}
+
+.task-log-view {
+    background-color: #181b29;
+    color: #cfd6e4;
+}
+
+.task-log-view text {
+    background-color: #181b29;
+    color: #cfd6e4;
+}

--- a/src/widgets/knowledge_browser.rs
+++ b/src/widgets/knowledge_browser.rs
@@ -17,9 +17,9 @@ use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{AssistantClient, TransportClient};
 use gtk4::prelude::*;
 use gtk4::{
-    Align, ApplicationWindow, Box as GtkBox, Button, Entry, HeaderBar, Label, ListBox,
-    ListBoxRow, Orientation, Paned, ScrolledWindow, SearchEntry, SelectionMode, TextView,
-    Window, WrapMode, glib,
+    Align, ApplicationWindow, Box as GtkBox, Button, Entry, HeaderBar, Label, ListBox, ListBoxRow,
+    Orientation, Paned, ScrolledWindow, SearchEntry, SelectionMode, TextView, Window, WrapMode,
+    glib,
 };
 use tokio::sync::mpsc;
 
@@ -240,9 +240,7 @@ impl KnowledgeBrowser {
                 let msg_tx = msg_tx.clone();
                 bridge.spawn(async move {
                     let result = if query.trim().is_empty() {
-                        transport
-                            .list_knowledge_entries(LIST_LIMIT, 0, None)
-                            .await
+                        transport.list_knowledge_entries(LIST_LIMIT, 0, None).await
                     } else {
                         transport
                             .search_knowledge_entries(&query, None, SEARCH_LIMIT)
@@ -548,9 +546,9 @@ impl KnowledgeBrowser {
                         bridge.spawn(async move {
                             let result = transport.delete_knowledge_entry(&id_for_async).await;
                             let _ = match result {
-                                Ok(()) => msg_tx.send(BrowserMsg::EntryDeleted {
-                                    id: id_for_async,
-                                }),
+                                Ok(()) => {
+                                    msg_tx.send(BrowserMsg::EntryDeleted { id: id_for_async })
+                                }
                                 Err(e) => msg_tx.send(BrowserMsg::Error(e.to_string())),
                             };
                         });

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -6,3 +6,4 @@ pub mod model_picker;
 pub mod select_models_dialog;
 pub mod setup_dialog;
 pub mod sidebar;
+pub mod tasks_panel;

--- a/src/widgets/model_picker.rs
+++ b/src/widgets/model_picker.rs
@@ -3,7 +3,9 @@ use std::rc::Rc;
 
 use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Button, Label, MenuButton, Orientation, Popover, Separator, Window};
+use gtk4::{
+    Align, Box as GtkBox, Button, Label, MenuButton, Orientation, Popover, Separator, Window,
+};
 
 use crate::selected_models::{SelectedModel, SelectedModelsStore};
 use crate::widgets::select_models_dialog::show_select_models_dialog;
@@ -135,11 +137,14 @@ impl ModelPicker {
     /// model is actively selected (the daemon then falls back to the
     /// conversation's stored selection or the interactive purpose).
     pub fn current_override(&self) -> Option<api::SendPromptOverride> {
-        self.active.borrow().as_ref().map(|sel| api::SendPromptOverride {
-            connection_id: sel.connection_id.clone(),
-            model_id: sel.model_id.clone(),
-            effort: None,
-        })
+        self.active
+            .borrow()
+            .as_ref()
+            .map(|sel| api::SendPromptOverride {
+                connection_id: sel.connection_id.clone(),
+                model_id: sel.model_id.clone(),
+                effort: None,
+            })
     }
 
     /// Hide the entire picker — used when the active transport doesn't

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -1,15 +1,550 @@
 //! Process-manager panel: list of background tasks + per-task log view.
 //!
-//! Issue #19. This file currently exists only to host the failing tests
-//! that drive the implementation. The next commit fills in the model
-//! types and the GTK widget.
+//! Issue #19. The panel listens for `UiMessage::Task*` events delivered by
+//! `async_bridge::connection_manager` and drives a `gio::ListStore`-backed
+//! `GtkListView` (rows) plus a `GtkTextView` (logs for the selected row).
+//!
+//! The unit-testable model lives in this file (`TasksModel`, `view_model_for`)
+//! so the business outcomes are exercised without spinning up GTK.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, ScrolledWindow,
+    SelectionMode, TextBuffer, TextView, WrapMode,
+};
+
+// --- Pure-Rust model (no GTK types) ---------------------------------------
+
+/// View-model for a single row in the tasks list. Pure data — formatting
+/// decisions live here so the model layer is unit-testable without GTK.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskRowViewModel {
+    pub id: String,
+    pub title: String,
+    /// CSS class for the status indicator dot. One of `task-dot-pending`,
+    /// `task-dot-running`, `task-dot-completed`, `task-dot-failed`,
+    /// `task-dot-cancelled`.
+    pub status_class: String,
+    /// Human-readable elapsed time, e.g. `"3s"`, `"4m 12s"`, `"1h 2m"`.
+    pub age_text: String,
+    /// Conversation id the task is associated with, if any. Drives the
+    /// `Open Conversation` toolbar button.
+    pub conversation_id: Option<String>,
+}
+
+/// Convert a `TaskView` into the row's display values given the current
+/// wall-clock in epoch ms.
+///
+/// `now_ms` is injected (rather than read from the clock) so tests stay
+/// deterministic.
+pub fn view_model_for(task: &api::TaskView, now_ms: i64) -> TaskRowViewModel {
+    TaskRowViewModel {
+        id: task.id.0.clone(),
+        title: task.title.clone(),
+        status_class: status_class_for(task.status),
+        age_text: format_age(task.started_at, task.ended_at, now_ms),
+        conversation_id: conversation_id_for(&task.kind),
+    }
+}
+
+fn status_class_for(status: api::TaskStatus) -> String {
+    match status {
+        api::TaskStatus::Pending => "task-dot-pending",
+        api::TaskStatus::Running => "task-dot-running",
+        api::TaskStatus::Completed => "task-dot-completed",
+        api::TaskStatus::Failed => "task-dot-failed",
+        api::TaskStatus::Cancelled => "task-dot-cancelled",
+    }
+    .to_string()
+}
+
+fn conversation_id_for(kind: &api::TaskKind) -> Option<String> {
+    match kind {
+        api::TaskKind::Conversation { conversation_id }
+        | api::TaskKind::Subagent {
+            conversation_id, ..
+        }
+        | api::TaskKind::Standalone {
+            conversation_id, ..
+        } => Some(conversation_id.clone()),
+    }
+}
+
+/// Format the elapsed time between `started_at` and either `ended_at` or
+/// `now_ms`. Negative values are clamped to `0s` defensively so a wonky
+/// clock from the daemon doesn't crash the row renderer.
+fn format_age(started_at: i64, ended_at: Option<i64>, now_ms: i64) -> String {
+    let end = ended_at.unwrap_or(now_ms);
+    let mut secs = ((end - started_at) / 1000).max(0);
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    let mut mins = secs / 60;
+    secs %= 60;
+    if mins < 60 {
+        return format!("{mins}m {secs}s");
+    }
+    let hours = mins / 60;
+    mins %= 60;
+    format!("{hours}h {mins}m")
+}
+
+/// Pure-Rust model layer: list of tasks + per-task log buffers.
+///
+/// The GTK panel reads from this model and re-renders on change; tests
+/// exercise the model directly without GTK.
+#[derive(Debug, Default)]
+pub struct TasksModel {
+    tasks: Vec<api::TaskView>,
+    /// Per-task append-only log buffer keyed by task id. Bounded by
+    /// `LOG_BUFFER_MAX` to keep memory tame on long-running tasks.
+    logs: std::collections::HashMap<String, Vec<api::TaskLogEntry>>,
+}
+
+/// Cap on log entries retained per task on the client. Mirrors the
+/// daemon-side bounded buffer order of magnitude; the client only needs
+/// enough scrollback for the panel.
+const LOG_BUFFER_MAX: usize = 500;
+
+impl TasksModel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of tracked tasks. Used by tests; the GTK panel queries
+    /// `is_empty` to toggle the empty-state label.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &api::TaskView> {
+        self.tasks.iter()
+    }
+
+    pub fn get(&self, idx: usize) -> Option<&api::TaskView> {
+        self.tasks.get(idx)
+    }
+
+    pub fn position_of(&self, id: &str) -> Option<usize> {
+        self.tasks.iter().position(|t| t.id.0 == id)
+    }
+
+    /// Replace the entire task list (used on `ListBackgroundTasks` reply).
+    /// Resets logs for tasks that are no longer present so memory doesn't
+    /// grow without bound across reconnects.
+    pub fn replace_all(&mut self, tasks: Vec<api::TaskView>) {
+        let live: std::collections::HashSet<String> =
+            tasks.iter().map(|t| t.id.0.clone()).collect();
+        self.logs.retain(|id, _| live.contains(id));
+        self.tasks = tasks;
+    }
+
+    /// Insert (or replace) a task. Newest tasks go to the front of the
+    /// list so a freshly-started task is immediately visible.
+    pub fn upsert(&mut self, task: api::TaskView) {
+        let id = task.id.0.clone();
+        if let Some(idx) = self.position_of(&id) {
+            self.tasks[idx] = task;
+        } else {
+            self.tasks.insert(0, task);
+        }
+    }
+
+    /// Apply a progress-hint update to an existing task. No-op if the
+    /// task id is unknown (the registry may have garbage-collected it).
+    pub fn apply_progress(&mut self, id: &str, progress_hint: Option<String>) {
+        if let Some(idx) = self.position_of(id) {
+            self.tasks[idx].progress_hint = progress_hint;
+        }
+    }
+
+    /// Append a log entry to a task's buffer. Drops the oldest entry once
+    /// the buffer exceeds `LOG_BUFFER_MAX` so a chatty task can't blow up
+    /// client memory.
+    pub fn append_log(&mut self, id: &str, entry: api::TaskLogEntry) {
+        let buf = self.logs.entry(id.to_string()).or_default();
+        // Preserve seq ordering — registry sends in order; defensive insert
+        // protects against rapid event bursts arriving slightly out of order.
+        let pos = buf.iter().position(|e| e.seq > entry.seq);
+        match pos {
+            Some(i) if buf[i].seq != entry.seq => buf.insert(i, entry),
+            Some(_) => { /* duplicate seq — keep the existing entry */ }
+            None => {
+                if buf.last().map(|e| e.seq) != Some(entry.seq) {
+                    buf.push(entry);
+                }
+            }
+        }
+        if buf.len() > LOG_BUFFER_MAX {
+            let drop = buf.len() - LOG_BUFFER_MAX;
+            buf.drain(0..drop);
+        }
+    }
+
+    pub fn logs_for(&self, id: &str) -> &[api::TaskLogEntry] {
+        self.logs.get(id).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Apply a `TaskCompleted` event to the matching task.
+    pub fn apply_completion(
+        &mut self,
+        id: &str,
+        status: api::TaskStatus,
+        last_error: Option<String>,
+        ended_at: i64,
+    ) {
+        if let Some(idx) = self.position_of(id) {
+            let t = &mut self.tasks[idx];
+            t.status = status;
+            t.last_error = last_error;
+            t.ended_at = Some(ended_at);
+        }
+    }
+}
+
+/// Format a single log entry for the text view. Pure function — kept here
+/// so the formatting is unit-testable.
+pub fn format_log_line(entry: &api::TaskLogEntry) -> String {
+    let level = match entry.level {
+        api::LogLevel::Info => "INFO",
+        api::LogLevel::Warn => "WARN",
+        api::LogLevel::Error => "ERROR",
+    };
+    let category = match entry.category {
+        api::LogCategory::ModelTurn => "model",
+        api::LogCategory::ToolCall => "tool",
+        api::LogCategory::ToolResult => "result",
+        api::LogCategory::Status => "status",
+        api::LogCategory::Lifecycle => "lifecycle",
+    };
+    format!("[{level} {category}] {}", entry.message)
+}
+
+// --- GTK widget ----------------------------------------------------------
+
+type StringCallback = Box<dyn Fn(String)>;
+
+/// Process-manager panel widget.
+pub struct TasksPanel {
+    pub container: GtkBox,
+    pub list_box: ListBox,
+    /// Held to keep the GTK widget alive even though the panel writes
+    /// through `log_buffer`; dropping the view would unparent it.
+    #[allow(dead_code)]
+    pub log_view: TextView,
+    pub log_buffer: TextBuffer,
+    pub cancel_button: Button,
+    pub open_conversation_button: Button,
+    pub empty_label: Label,
+    model: Rc<RefCell<TasksModel>>,
+    on_cancel: Rc<RefCell<Option<StringCallback>>>,
+    on_open_conversation: Rc<RefCell<Option<StringCallback>>>,
+}
+
+impl TasksPanel {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 0);
+        container.set_hexpand(true);
+        container.set_vexpand(true);
+
+        // Toolbar: Cancel | Open Conversation
+        let toolbar = GtkBox::new(Orientation::Horizontal, 8);
+        toolbar.set_margin_start(8);
+        toolbar.set_margin_end(8);
+        toolbar.set_margin_top(8);
+        toolbar.set_margin_bottom(4);
+
+        let cancel_button = Button::with_label("Cancel");
+        cancel_button.add_css_class("destructive-action");
+        cancel_button.set_sensitive(false);
+        toolbar.append(&cancel_button);
+
+        let open_conversation_button = Button::with_label("Open Conversation");
+        open_conversation_button.set_sensitive(false);
+        toolbar.append(&open_conversation_button);
+
+        container.append(&toolbar);
+
+        // Task list
+        let list_scrolled = ScrolledWindow::new();
+        list_scrolled.set_vexpand(true);
+        list_scrolled.set_min_content_height(120);
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(SelectionMode::Single);
+        list_box.add_css_class("task-list");
+        list_scrolled.set_child(Some(&list_box));
+        container.append(&list_scrolled);
+
+        // Empty-state label hidden until the list is empty.
+        let empty_label = Label::new(Some("No background tasks"));
+        empty_label.add_css_class("dim-label");
+        empty_label.set_halign(Align::Center);
+        empty_label.set_margin_top(8);
+        empty_label.set_margin_bottom(8);
+        empty_label.set_visible(true);
+        container.append(&empty_label);
+
+        // Log view (selected task)
+        let log_scrolled = ScrolledWindow::new();
+        log_scrolled.set_vexpand(true);
+        log_scrolled.set_min_content_height(120);
+
+        let log_buffer = TextBuffer::new(None);
+        let log_view = TextView::with_buffer(&log_buffer);
+        log_view.set_editable(false);
+        log_view.set_monospace(true);
+        log_view.set_wrap_mode(WrapMode::WordChar);
+        log_view.set_top_margin(8);
+        log_view.set_bottom_margin(8);
+        log_view.set_left_margin(12);
+        log_view.set_right_margin(12);
+        log_view.add_css_class("task-log-view");
+        log_scrolled.set_child(Some(&log_view));
+        container.append(&log_scrolled);
+
+        let panel = Self {
+            container,
+            list_box,
+            log_view,
+            log_buffer,
+            cancel_button,
+            open_conversation_button,
+            empty_label,
+            model: Rc::new(RefCell::new(TasksModel::new())),
+            on_cancel: Rc::new(RefCell::new(None)),
+            on_open_conversation: Rc::new(RefCell::new(None)),
+        };
+
+        panel.wire_selection();
+        panel.wire_toolbar();
+        panel
+    }
+
+    fn wire_selection(&self) {
+        let model = Rc::clone(&self.model);
+        let log_buffer = self.log_buffer.clone();
+        let cancel_button = self.cancel_button.clone();
+        let open_btn = self.open_conversation_button.clone();
+        self.list_box.connect_row_selected(move |_, row| {
+            let Some(row) = row else {
+                log_buffer.set_text("");
+                cancel_button.set_sensitive(false);
+                open_btn.set_sensitive(false);
+                return;
+            };
+            let idx = row.index() as usize;
+            let m = model.borrow();
+            let Some(task) = m.get(idx) else {
+                cancel_button.set_sensitive(false);
+                open_btn.set_sensitive(false);
+                return;
+            };
+            // Cancel only applies to non-terminal states.
+            let cancellable = matches!(
+                task.status,
+                api::TaskStatus::Pending | api::TaskStatus::Running
+            );
+            cancel_button.set_sensitive(cancellable);
+            open_btn.set_sensitive(conversation_id_for(&task.kind).is_some());
+
+            let text = m
+                .logs_for(&task.id.0)
+                .iter()
+                .map(format_log_line)
+                .collect::<Vec<_>>()
+                .join("\n");
+            log_buffer.set_text(&text);
+        });
+    }
+
+    fn wire_toolbar(&self) {
+        let model = Rc::clone(&self.model);
+        let list_box = self.list_box.clone();
+        let on_cancel = Rc::clone(&self.on_cancel);
+        self.cancel_button.connect_clicked(move |_| {
+            let Some(row) = list_box.selected_row() else {
+                return;
+            };
+            let idx = row.index() as usize;
+            let id = match model.borrow().get(idx) {
+                Some(t) => t.id.0.clone(),
+                None => return,
+            };
+            if let Some(ref cb) = *on_cancel.borrow() {
+                cb(id);
+            }
+        });
+
+        let model = Rc::clone(&self.model);
+        let list_box = self.list_box.clone();
+        let on_open = Rc::clone(&self.on_open_conversation);
+        self.open_conversation_button.connect_clicked(move |_| {
+            let Some(row) = list_box.selected_row() else {
+                return;
+            };
+            let idx = row.index() as usize;
+            let conv_id = match model.borrow().get(idx) {
+                Some(t) => conversation_id_for(&t.kind),
+                None => None,
+            };
+            let Some(conv_id) = conv_id else { return };
+            if let Some(ref cb) = *on_open.borrow() {
+                cb(conv_id);
+            }
+        });
+    }
+
+    pub fn connect_cancel<F: Fn(String) + 'static>(&self, f: F) {
+        *self.on_cancel.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_open_conversation<F: Fn(String) + 'static>(&self, f: F) {
+        *self.on_open_conversation.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Apply a `UiMessage::TaskStarted` event to the panel.
+    pub fn handle_task_started(&self, task: api::TaskView, now_ms: i64) {
+        self.model.borrow_mut().upsert(task);
+        self.refresh_rows(now_ms);
+    }
+
+    /// Apply a `UiMessage::TaskProgress` event.
+    pub fn handle_task_progress(&self, id: String, progress_hint: Option<String>, now_ms: i64) {
+        self.model.borrow_mut().apply_progress(&id, progress_hint);
+        self.refresh_rows(now_ms);
+    }
+
+    /// Apply a `UiMessage::TaskLogAppended` event.
+    pub fn handle_task_log_appended(&self, id: String, entry: api::TaskLogEntry) {
+        self.model.borrow_mut().append_log(&id, entry);
+        // If the appended entry belongs to the currently-selected task, repaint
+        // the log buffer so the user sees new lines without re-clicking.
+        if let Some(row) = self.list_box.selected_row() {
+            let idx = row.index() as usize;
+            let m = self.model.borrow();
+            if let Some(t) = m.get(idx)
+                && t.id.0 == id
+            {
+                let text = m
+                    .logs_for(&id)
+                    .iter()
+                    .map(format_log_line)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.log_buffer.set_text(&text);
+            }
+        }
+    }
+
+    /// Apply a `UiMessage::TaskCompleted` event.
+    pub fn handle_task_completed(
+        &self,
+        id: String,
+        status: api::TaskStatus,
+        last_error: Option<String>,
+        now_ms: i64,
+    ) {
+        self.model
+            .borrow_mut()
+            .apply_completion(&id, status, last_error, now_ms);
+        self.refresh_rows(now_ms);
+    }
+
+    /// Replace the entire task list (used on initial `ListBackgroundTasks`
+    /// reply and on reconnect).
+    pub fn replace_all(&self, tasks: Vec<api::TaskView>, now_ms: i64) {
+        self.model.borrow_mut().replace_all(tasks);
+        self.refresh_rows(now_ms);
+    }
+
+    fn refresh_rows(&self, now_ms: i64) {
+        // Preserve selection by id.
+        let selected_id = self.list_box.selected_row().and_then(|row| {
+            let idx = row.index() as usize;
+            self.model.borrow().get(idx).map(|t| t.id.0.clone())
+        });
+
+        while let Some(child) = self.list_box.first_child() {
+            self.list_box.remove(&child);
+        }
+
+        let m = self.model.borrow();
+        for task in m.iter() {
+            let vm = view_model_for(task, now_ms);
+            let row = build_row(&vm, task.progress_hint.as_deref());
+            self.list_box.append(&row);
+        }
+        drop(m);
+
+        self.empty_label.set_visible(self.model.borrow().is_empty());
+
+        if let Some(id) = selected_id
+            && let Some(idx) = self.model.borrow().position_of(&id)
+            && let Some(row) = self.list_box.row_at_index(idx as i32)
+        {
+            self.list_box.select_row(Some(&row));
+        }
+    }
+
+    /// Test/integration accessor for the underlying model. Public so smoke
+    /// tests can inspect state without poking the widget tree.
+    #[allow(dead_code)]
+    pub fn model(&self) -> std::cell::Ref<'_, TasksModel> {
+        self.model.borrow()
+    }
+}
+
+fn build_row(vm: &TaskRowViewModel, progress_hint: Option<&str>) -> ListBoxRow {
+    let row = ListBoxRow::new();
+    let hbox = GtkBox::new(Orientation::Horizontal, 8);
+    hbox.set_margin_start(12);
+    hbox.set_margin_end(12);
+    hbox.set_margin_top(6);
+    hbox.set_margin_bottom(6);
+
+    // Status dot — empty label whose colour is driven entirely by CSS.
+    let dot = Label::new(None);
+    dot.add_css_class("task-dot");
+    dot.add_css_class(&vm.status_class);
+    dot.set_width_chars(2);
+    hbox.append(&dot);
+
+    let vbox = GtkBox::new(Orientation::Vertical, 2);
+    vbox.set_hexpand(true);
+
+    let title_label = Label::new(Some(&vm.title));
+    title_label.set_halign(Align::Start);
+    title_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+    vbox.append(&title_label);
+
+    if let Some(hint) = progress_hint {
+        let hint_label = Label::new(Some(hint));
+        hint_label.add_css_class("dim-label");
+        hint_label.set_halign(Align::Start);
+        hint_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        vbox.append(&hint_label);
+    }
+    hbox.append(&vbox);
+
+    let age_label = Label::new(Some(&vm.age_text));
+    age_label.add_css_class("dim-label");
+    hbox.append(&age_label);
+
+    row.set_child(Some(&hbox));
+    row
+}
 
 // --- Tests ---------------------------------------------------------------
-//
-// Spec-driven TDD: these tests reference symbols (`TasksModel`,
-// `view_model_for`, `TasksPanel`, …) that do not exist yet. The
-// failing-tests commit captures the contract; the implementation commit
-// makes them pass.
 
 #[cfg(test)]
 mod tests {
@@ -48,7 +583,7 @@ mod tests {
     #[test]
     fn task_row_view_model_from_task_view() {
         let t = running_task("t-1", "conv-9");
-        let now = t.started_at + 12_345;
+        let now = t.started_at + 12_345; // ~12 seconds later
         let vm = view_model_for(&t, now);
 
         assert_eq!(vm.id, "t-1");
@@ -63,7 +598,7 @@ mod tests {
         let mut t = running_task("t-end", "c");
         t.status = api::TaskStatus::Completed;
         t.ended_at = Some(t.started_at + 5_000);
-        let now = t.started_at + 9_999_000;
+        let now = t.started_at + 9_999_000; // far in the future
         let vm = view_model_for(&t, now);
         assert_eq!(vm.status_class, "task-dot-completed");
         assert_eq!(vm.age_text, "5s");
@@ -71,9 +606,10 @@ mod tests {
 
     #[test]
     fn task_row_view_model_clamps_negative_age() {
+        // Defensive: a daemon with a clock skew shouldn't crash the panel.
         let mut t = running_task("t-clock", "c");
         t.started_at = 1_000_000;
-        let now = 999_000;
+        let now = 999_000; // earlier than started_at
         let vm = view_model_for(&t, now);
         assert_eq!(vm.age_text, "0s");
     }
@@ -88,6 +624,8 @@ mod tests {
 
     #[test]
     fn internal_msg_task_started_inserts_row_in_store() {
+        // Business outcome: a TaskStarted event lands in the model and the
+        // row count goes from 0 to 1 without any GTK widget involvement.
         let mut model = TasksModel::new();
         assert_eq!(model.len(), 0);
         model.upsert(running_task("t-1", "c"));
@@ -97,6 +635,8 @@ mod tests {
 
     #[test]
     fn business_outcome_user_can_see_their_running_standalone_agent_appear_in_real_time() {
+        // Acceptance criterion (issue #19): launching a standalone agent
+        // surfaces a new row in the panel without manual refresh.
         let mut model = TasksModel::new();
         model.upsert(running_task("agent-1", "conv-1"));
         let view = model.iter().collect::<Vec<_>>();
@@ -119,6 +659,9 @@ mod tests {
 
     #[test]
     fn rapid_event_burst_preserves_seq_ordering() {
+        // Unhappy path: events arrive out of order during a burst — the
+        // model must store them sorted by seq so the log view doesn't
+        // show stale rewinds.
         let mut model = TasksModel::new();
         model.append_log("t", log_entry(3, "third"));
         model.append_log("t", log_entry(1, "first"));
@@ -132,6 +675,8 @@ mod tests {
 
     #[test]
     fn duplicate_log_seq_does_not_duplicate_entries() {
+        // Unhappy path: a transient that resends the same seq must not
+        // double up the buffer.
         let mut model = TasksModel::new();
         model.append_log("t", log_entry(1, "first"));
         model.append_log("t", log_entry(1, "first"));
@@ -145,6 +690,7 @@ mod tests {
             model.append_log("t", log_entry(i, "x"));
         }
         assert_eq!(model.logs_for("t").len(), LOG_BUFFER_MAX);
+        // Oldest entries dropped — the buffer keeps the highest-seq tail.
         let logs = model.logs_for("t");
         assert!(logs.first().unwrap().seq >= 50);
     }
@@ -162,6 +708,8 @@ mod tests {
 
     #[test]
     fn apply_progress_for_unknown_task_is_noop() {
+        // Unhappy path: a stray TaskProgress for an id we never saw must
+        // not crash and must not introduce a phantom row.
         let mut model = TasksModel::new();
         model.apply_progress("ghost", Some("hint".into()));
         assert_eq!(model.len(), 0);
@@ -185,6 +733,9 @@ mod tests {
 
     #[test]
     fn replace_all_clears_orphan_log_buffers() {
+        // Unhappy path: after reconnect, ListBackgroundTasks returns a new
+        // snapshot. Per-task log buffers for tasks no longer in the list
+        // should be reclaimed so memory doesn't grow without bound.
         let mut model = TasksModel::new();
         model.upsert(running_task("old", "c"));
         model.append_log("old", log_entry(1, "x"));
@@ -217,6 +768,8 @@ mod tests {
 
     #[test]
     fn malformed_task_kind_does_not_crash_view_model() {
+        // Unhappy path: a Conversation-kind task with empty conv id is
+        // still surfaced as a row — the model should not panic on edge data.
         let t = api::TaskView {
             id: api::TaskId("t".into()),
             kind: api::TaskKind::Conversation {
@@ -246,10 +799,22 @@ mod tests {
         assert!(line.contains("calling search"));
     }
 
+    // --- Controller tests ------------------------------------------------
+    //
+    // The GTK widget itself can't easily be instantiated under `cargo test`
+    // (no display, no GTK init). These tests target the small controller
+    // helpers the widget delegates to so the business logic — "Cancel
+    // emits the right id" / "Open Conversation routes to the right id" —
+    // is verifiable without a display.
+
+    /// Mirror of the controller logic in `TasksPanel::wire_toolbar` for the
+    /// cancel button. Pulled into a free function so it can be unit-tested
+    /// without instantiating a GTK widget.
     fn cancel_id_for_selection(model: &TasksModel, selected: Option<usize>) -> Option<String> {
         selected.and_then(|i| model.get(i)).map(|t| t.id.0.clone())
     }
 
+    /// Mirror of the open-conversation controller logic.
     fn open_conversation_id_for_selection(
         model: &TasksModel,
         selected: Option<usize>,
@@ -264,6 +829,7 @@ mod tests {
         let mut model = TasksModel::new();
         model.upsert(running_task("first", "c1"));
         model.upsert(running_task("second", "c2"));
+        // newest is at index 0
         assert_eq!(
             cancel_id_for_selection(&model, Some(0)).as_deref(),
             Some("second")
@@ -282,6 +848,8 @@ mod tests {
 
     #[test]
     fn cancel_with_stale_index_is_noop() {
+        // Unhappy path: the selected row index could be beyond the current
+        // model (e.g. a TaskCompleted just shrank the list).
         let model = TasksModel::new();
         assert_eq!(cancel_id_for_selection(&model, Some(42)), None);
     }

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -1,0 +1,304 @@
+//! Process-manager panel: list of background tasks + per-task log view.
+//!
+//! Issue #19. This file currently exists only to host the failing tests
+//! that drive the implementation. The next commit fills in the model
+//! types and the GTK widget.
+
+// --- Tests ---------------------------------------------------------------
+//
+// Spec-driven TDD: these tests reference symbols (`TasksModel`,
+// `view_model_for`, `TasksPanel`, …) that do not exist yet. The
+// failing-tests commit captures the contract; the implementation commit
+// makes them pass.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_api_model as api;
+
+    fn running_task(id: &str, conv: &str) -> api::TaskView {
+        api::TaskView {
+            id: api::TaskId(id.into()),
+            kind: api::TaskKind::Standalone {
+                name: "agent".into(),
+                conversation_id: conv.into(),
+            },
+            status: api::TaskStatus::Running,
+            started_at: 1_700_000_000_000,
+            ended_at: None,
+            last_error: None,
+            parent: None,
+            children: vec![],
+            title: format!("Task {id}"),
+            progress_hint: None,
+        }
+    }
+
+    fn log_entry(seq: u64, message: &str) -> api::TaskLogEntry {
+        api::TaskLogEntry {
+            seq,
+            timestamp: 1_700_000_000_000,
+            level: api::LogLevel::Info,
+            category: api::LogCategory::Status,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    #[test]
+    fn task_row_view_model_from_task_view() {
+        let t = running_task("t-1", "conv-9");
+        let now = t.started_at + 12_345;
+        let vm = view_model_for(&t, now);
+
+        assert_eq!(vm.id, "t-1");
+        assert_eq!(vm.title, "Task t-1");
+        assert_eq!(vm.status_class, "task-dot-running");
+        assert_eq!(vm.age_text, "12s");
+        assert_eq!(vm.conversation_id.as_deref(), Some("conv-9"));
+    }
+
+    #[test]
+    fn task_row_view_model_completed_uses_ended_at_not_now() {
+        let mut t = running_task("t-end", "c");
+        t.status = api::TaskStatus::Completed;
+        t.ended_at = Some(t.started_at + 5_000);
+        let now = t.started_at + 9_999_000;
+        let vm = view_model_for(&t, now);
+        assert_eq!(vm.status_class, "task-dot-completed");
+        assert_eq!(vm.age_text, "5s");
+    }
+
+    #[test]
+    fn task_row_view_model_clamps_negative_age() {
+        let mut t = running_task("t-clock", "c");
+        t.started_at = 1_000_000;
+        let now = 999_000;
+        let vm = view_model_for(&t, now);
+        assert_eq!(vm.age_text, "0s");
+    }
+
+    #[test]
+    fn task_row_view_model_formats_minutes_and_hours() {
+        let mut t = running_task("t-mins", "c");
+        t.started_at = 0;
+        assert_eq!(view_model_for(&t, 90_000).age_text, "1m 30s");
+        assert_eq!(view_model_for(&t, 3_725_000).age_text, "1h 2m");
+    }
+
+    #[test]
+    fn internal_msg_task_started_inserts_row_in_store() {
+        let mut model = TasksModel::new();
+        assert_eq!(model.len(), 0);
+        model.upsert(running_task("t-1", "c"));
+        assert_eq!(model.len(), 1);
+        assert_eq!(model.get(0).unwrap().id.0, "t-1");
+    }
+
+    #[test]
+    fn business_outcome_user_can_see_their_running_standalone_agent_appear_in_real_time() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("agent-1", "conv-1"));
+        let view = model.iter().collect::<Vec<_>>();
+        assert_eq!(view.len(), 1);
+        assert_eq!(view[0].title, "Task agent-1");
+        assert_eq!(view[0].status, api::TaskStatus::Running);
+    }
+
+    #[test]
+    fn internal_msg_task_log_appended_appends_to_buffer() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-log", "c"));
+        model.append_log("t-log", log_entry(1, "step 1"));
+        model.append_log("t-log", log_entry(2, "step 2"));
+        let logs = model.logs_for("t-log");
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].message, "step 1");
+        assert_eq!(logs[1].message, "step 2");
+    }
+
+    #[test]
+    fn rapid_event_burst_preserves_seq_ordering() {
+        let mut model = TasksModel::new();
+        model.append_log("t", log_entry(3, "third"));
+        model.append_log("t", log_entry(1, "first"));
+        model.append_log("t", log_entry(2, "second"));
+        let logs = model.logs_for("t");
+        assert_eq!(
+            logs.iter().map(|e| e.seq).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn duplicate_log_seq_does_not_duplicate_entries() {
+        let mut model = TasksModel::new();
+        model.append_log("t", log_entry(1, "first"));
+        model.append_log("t", log_entry(1, "first"));
+        assert_eq!(model.logs_for("t").len(), 1);
+    }
+
+    #[test]
+    fn log_buffer_is_bounded() {
+        let mut model = TasksModel::new();
+        for i in 0..(LOG_BUFFER_MAX as u64 + 50) {
+            model.append_log("t", log_entry(i, "x"));
+        }
+        assert_eq!(model.logs_for("t").len(), LOG_BUFFER_MAX);
+        let logs = model.logs_for("t");
+        assert!(logs.first().unwrap().seq >= 50);
+    }
+
+    #[test]
+    fn apply_progress_updates_existing_task() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-1", "c"));
+        model.apply_progress("t-1", Some("step 2/4".into()));
+        assert_eq!(
+            model.get(0).unwrap().progress_hint.as_deref(),
+            Some("step 2/4")
+        );
+    }
+
+    #[test]
+    fn apply_progress_for_unknown_task_is_noop() {
+        let mut model = TasksModel::new();
+        model.apply_progress("ghost", Some("hint".into()));
+        assert_eq!(model.len(), 0);
+    }
+
+    #[test]
+    fn apply_completion_transitions_status() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-end", "c"));
+        model.apply_completion(
+            "t-end",
+            api::TaskStatus::Failed,
+            Some("boom".into()),
+            1_700_000_999_000,
+        );
+        let t = model.get(0).unwrap();
+        assert_eq!(t.status, api::TaskStatus::Failed);
+        assert_eq!(t.last_error.as_deref(), Some("boom"));
+        assert_eq!(t.ended_at, Some(1_700_000_999_000));
+    }
+
+    #[test]
+    fn replace_all_clears_orphan_log_buffers() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("old", "c"));
+        model.append_log("old", log_entry(1, "x"));
+        assert_eq!(model.logs_for("old").len(), 1);
+
+        model.replace_all(vec![running_task("new", "c")]);
+        assert_eq!(model.len(), 1);
+        assert_eq!(model.logs_for("old").len(), 0);
+    }
+
+    #[test]
+    fn upsert_replaces_existing_task_in_place() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-1", "c"));
+        let mut updated = running_task("t-1", "c");
+        updated.title = "renamed".into();
+        model.upsert(updated);
+        assert_eq!(model.len(), 1);
+        assert_eq!(model.get(0).unwrap().title, "renamed");
+    }
+
+    #[test]
+    fn newest_task_appears_at_top_of_list() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("older", "c"));
+        model.upsert(running_task("newer", "c"));
+        assert_eq!(model.get(0).unwrap().id.0, "newer");
+        assert_eq!(model.get(1).unwrap().id.0, "older");
+    }
+
+    #[test]
+    fn malformed_task_kind_does_not_crash_view_model() {
+        let t = api::TaskView {
+            id: api::TaskId("t".into()),
+            kind: api::TaskKind::Conversation {
+                conversation_id: String::new(),
+            },
+            status: api::TaskStatus::Running,
+            started_at: 0,
+            ended_at: None,
+            last_error: None,
+            parent: None,
+            children: vec![],
+            title: "t".into(),
+            progress_hint: None,
+        };
+        let vm = view_model_for(&t, 1_000);
+        assert_eq!(vm.conversation_id.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn format_log_line_includes_level_and_category() {
+        let mut e = log_entry(1, "calling search");
+        e.level = api::LogLevel::Warn;
+        e.category = api::LogCategory::ToolCall;
+        let line = format_log_line(&e);
+        assert!(line.contains("WARN"));
+        assert!(line.contains("tool"));
+        assert!(line.contains("calling search"));
+    }
+
+    fn cancel_id_for_selection(model: &TasksModel, selected: Option<usize>) -> Option<String> {
+        selected.and_then(|i| model.get(i)).map(|t| t.id.0.clone())
+    }
+
+    fn open_conversation_id_for_selection(
+        model: &TasksModel,
+        selected: Option<usize>,
+    ) -> Option<String> {
+        selected
+            .and_then(|i| model.get(i))
+            .and_then(|t| conversation_id_for(&t.kind))
+    }
+
+    #[test]
+    fn cancel_button_emits_cancel_command_for_selection() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("first", "c1"));
+        model.upsert(running_task("second", "c2"));
+        assert_eq!(
+            cancel_id_for_selection(&model, Some(0)).as_deref(),
+            Some("second")
+        );
+        assert_eq!(
+            cancel_id_for_selection(&model, Some(1)).as_deref(),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn cancel_with_no_selection_is_noop() {
+        let model = TasksModel::new();
+        assert_eq!(cancel_id_for_selection(&model, None), None);
+    }
+
+    #[test]
+    fn cancel_with_stale_index_is_noop() {
+        let model = TasksModel::new();
+        assert_eq!(cancel_id_for_selection(&model, Some(42)), None);
+    }
+
+    #[test]
+    fn open_conversation_routes_to_correct_id() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("agent", "the-conversation"));
+        assert_eq!(
+            open_conversation_id_for_selection(&model, Some(0)).as_deref(),
+            Some("the-conversation")
+        );
+    }
+
+    #[test]
+    fn open_conversation_with_no_selection_is_noop() {
+        let model = TasksModel::new();
+        assert_eq!(open_conversation_id_for_selection(&model, None), None);
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{
     AssistantClient, ChatMessage, ConnectionConfig, ConversationDetail, ConversationSummary,
     TransportClient,
@@ -9,7 +10,7 @@ use desktop_assistant_client_common::{
 use gtk4::prelude::*;
 use gtk4::{
     Align, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton, Entry, Label,
-    MenuButton, Orientation, Paned, Popover, Separator, Window, gdk, glib,
+    MenuButton, Orientation, Paned, Popover, Separator, Stack, StackSwitcher, Window, gdk, glib,
 };
 use tokio::sync::mpsc;
 
@@ -18,6 +19,7 @@ use crate::widgets::chat_view::ChatView;
 use crate::widgets::input_bar::InputBar;
 use crate::widgets::model_picker::ModelPicker;
 use crate::widgets::sidebar::Sidebar;
+use crate::widgets::tasks_panel::TasksPanel;
 
 /// Shared mutable state for the window.
 struct WindowState {
@@ -56,12 +58,33 @@ impl AdelieWindow {
             gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
 
-        // Layout: resizable paned split between sidebar and chat
+        // Layout: resizable paned split between sidebar and chat. The left
+        // pane is a `Stack` that swaps between the conversation list and the
+        // process-manager view (issue #19) — minimal disruption to the
+        // existing sidebar widget, the Tasks page just becomes a sibling.
         let paned = Paned::new(Orientation::Horizontal);
 
         let sidebar = Sidebar::new();
-        sidebar.container.set_size_request(280, -1); // minimum width
-        paned.set_start_child(Some(&sidebar.container));
+        let tasks_panel = TasksPanel::new();
+
+        let left_box = GtkBox::new(Orientation::Vertical, 0);
+        left_box.set_size_request(280, -1);
+
+        let stack = Stack::new();
+        stack.set_vexpand(true);
+        stack.add_titled(&sidebar.container, Some("conversations"), "Conversations");
+        stack.add_titled(&tasks_panel.container, Some("tasks"), "Tasks");
+
+        let stack_switcher = StackSwitcher::new();
+        stack_switcher.set_stack(Some(&stack));
+        stack_switcher.set_halign(Align::Center);
+        stack_switcher.set_margin_top(8);
+        stack_switcher.set_margin_bottom(4);
+        stack_switcher.add_css_class("sidebar-stack-switcher");
+        left_box.append(&stack_switcher);
+        left_box.append(&stack);
+
+        paned.set_start_child(Some(&left_box));
         paned.set_resize_start_child(false);
         paned.set_shrink_start_child(false);
         paned.set_position(280);
@@ -170,6 +193,8 @@ impl AdelieWindow {
         let input_bar = Rc::new(input_bar);
         let status_label = Rc::new(status_label);
         let model_picker = Rc::new(model_picker);
+        let tasks_panel = Rc::new(tasks_panel);
+        let stack = Rc::new(stack);
 
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
@@ -186,6 +211,7 @@ impl AdelieWindow {
             let client = Rc::clone(&client);
             let input_bar = Rc::clone(&input_bar);
             let model_picker = Rc::clone(&model_picker);
+            let tasks_panel = Rc::clone(&tasks_panel);
 
             AsyncBridge::new(move |msg, ui_tx| {
                 handle_ui_message(
@@ -197,6 +223,7 @@ impl AdelieWindow {
                     &client,
                     &input_bar,
                     &model_picker,
+                    &tasks_panel,
                     ui_tx,
                 );
             })
@@ -518,7 +545,8 @@ impl AdelieWindow {
                         // D-Bus we fall through to the plain send_prompt.
                         let result = match (client.as_ws(), override_selection) {
                             (Some(ws), Some(over)) => {
-                                ws.send_prompt_with_override(&conv_id, &text, Some(over)).await
+                                ws.send_prompt_with_override(&conv_id, &text, Some(over))
+                                    .await
                             }
                             _ => client.send_prompt(&conv_id, &text).await,
                         };
@@ -580,8 +608,7 @@ impl AdelieWindow {
             knowledge_btn.connect_clicked(move |_| {
                 popover_ref.popdown();
                 let Some(transport) = client_ref.borrow().clone() else {
-                    status_label_ref
-                        .set_text("Not connected — knowledge base unavailable");
+                    status_label_ref.set_text("Not connected — knowledge base unavailable");
                     return;
                 };
                 let browser = crate::widgets::knowledge_browser::KnowledgeBrowser::new(
@@ -614,23 +641,76 @@ impl AdelieWindow {
             debug_check.connect_toggled(move |btn| {
                 state.borrow_mut().debug_enabled = btn.is_active();
                 let conv_id = state.borrow().current_conversation_id.clone();
-                if let Some(conv_id) = conv_id {
-                    if let Some(client) = client_ref.borrow().clone() {
-                        let tx = bridge_ref.ui_sender();
-                        bridge_ref.spawn(async move {
-                            match client.get_conversation(&conv_id).await {
-                                Ok(detail) => {
-                                    let _ = tx.send(UiMessage::ConversationLoaded(detail));
-                                }
-                                Err(e) => {
-                                    let _ = tx.send(UiMessage::Error(format!(
-                                        "Reload conversation: {e}"
-                                    )));
-                                }
+                if let Some(conv_id) = conv_id
+                    && let Some(client) = client_ref.borrow().clone()
+                {
+                    let tx = bridge_ref.ui_sender();
+                    bridge_ref.spawn(async move {
+                        match client.get_conversation(&conv_id).await {
+                            Ok(detail) => {
+                                let _ = tx.send(UiMessage::ConversationLoaded(detail));
                             }
-                        });
-                    }
+                            Err(e) => {
+                                let _ =
+                                    tx.send(UiMessage::Error(format!("Reload conversation: {e}")));
+                            }
+                        }
+                    });
                 }
+            });
+        }
+
+        // Tasks panel: toolbar wiring (#19).
+        //
+        // `Cancel` sends `CancelBackgroundTask` over WS; `Open Conversation`
+        // routes the user back to the Conversations stack page and loads the
+        // task's conversation so the streaming output keeps flowing into the
+        // chat view.
+        {
+            let client_ref = Rc::clone(&client);
+            let bridge_ref = Rc::clone(&bridge);
+            tasks_panel.connect_cancel(move |task_id| {
+                let Some(transport) = client_ref.borrow().clone() else {
+                    return;
+                };
+                let tx = bridge_ref.ui_sender();
+                bridge_ref.spawn(async move {
+                    let Some(ws) = transport.as_ws() else {
+                        let _ = tx.send(UiMessage::Error(
+                            "Background tasks require the WebSocket transport".to_string(),
+                        ));
+                        return;
+                    };
+                    if let Err(e) = ws
+                        .send_command(api::Command::CancelBackgroundTask { id: task_id })
+                        .await
+                    {
+                        let _ = tx.send(UiMessage::Error(format!("Cancel task: {e}")));
+                    }
+                });
+            });
+        }
+
+        {
+            let client_ref = Rc::clone(&client);
+            let bridge_ref = Rc::clone(&bridge);
+            let stack_ref = Rc::clone(&stack);
+            tasks_panel.connect_open_conversation(move |conv_id| {
+                stack_ref.set_visible_child_name("conversations");
+                let Some(transport) = client_ref.borrow().clone() else {
+                    return;
+                };
+                let tx = bridge_ref.ui_sender();
+                bridge_ref.spawn(async move {
+                    match transport.get_conversation(&conv_id).await {
+                        Ok(detail) => {
+                            let _ = tx.send(UiMessage::ConversationLoaded(detail));
+                        }
+                        Err(e) => {
+                            let _ = tx.send(UiMessage::Error(format!("Load conversation: {e}")));
+                        }
+                    }
+                });
             });
         }
 
@@ -642,6 +722,17 @@ impl AdelieWindow {
     }
 }
 
+/// Current wall-clock time in epoch milliseconds. Centralized so the
+/// task-panel callers all use the same units as `TaskView.started_at`.
+fn now_epoch_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_ui_message(
     msg: UiMessage,
     state: &Rc<RefCell<WindowState>>,
@@ -651,6 +742,7 @@ fn handle_ui_message(
     client: &Rc<RefCell<Option<Arc<TransportClient>>>>,
     input_bar: &Rc<InputBar>,
     model_picker: &Rc<ModelPicker>,
+    tasks_panel: &Rc<TasksPanel>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
     match msg {
@@ -809,6 +901,25 @@ fn handle_ui_message(
             status_label.set_text(&label);
             input_bar.send_button.set_sensitive(true);
         }
+        UiMessage::TasksLoaded(tasks) => {
+            tasks_panel.replace_all(tasks, now_epoch_ms());
+        }
+        UiMessage::TaskStarted(task) => {
+            tasks_panel.handle_task_started(task, now_epoch_ms());
+        }
+        UiMessage::TaskProgress { id, progress_hint } => {
+            tasks_panel.handle_task_progress(id, progress_hint, now_epoch_ms());
+        }
+        UiMessage::TaskLogAppended { id, entry } => {
+            tasks_panel.handle_task_log_appended(id, entry);
+        }
+        UiMessage::TaskCompleted {
+            id,
+            status,
+            last_error,
+        } => {
+            tasks_panel.handle_task_completed(id, status, last_error, now_epoch_ms());
+        }
         UiMessage::Disconnected { reason } => {
             *client.borrow_mut() = None;
             input_bar.send_button.set_sensitive(false);
@@ -854,12 +965,12 @@ fn ensure_active_conversation(
         let s = state.borrow();
 
         // Already-active and still present → just sync the sidebar selection.
-        if let Some(active_id) = s.current_conversation_id.as_deref() {
-            if let Some(idx) = s.conversations.iter().position(|c| c.id == active_id) {
-                drop(s);
-                sidebar.select_index(idx);
-                return;
-            }
+        if let Some(active_id) = s.current_conversation_id.as_deref()
+            && let Some(idx) = s.conversations.iter().position(|c| c.id == active_id)
+        {
+            drop(s);
+            sidebar.select_index(idx);
+            return;
         }
 
         match s.conversations.first() {
@@ -902,9 +1013,7 @@ fn ensure_active_conversation(
                         }
                     }
                     Err(e) => {
-                        let _ = tx.send(UiMessage::Error(format!(
-                            "Auto-create conversation: {e}"
-                        )));
+                        let _ = tx.send(UiMessage::Error(format!("Auto-create conversation: {e}")));
                     }
                 }
             });
@@ -924,10 +1033,7 @@ pub fn install_app_icon() {
     let cache_root = dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join("adele-gtk-icons");
-    let icon_dir = cache_root
-        .join("hicolor")
-        .join("512x512")
-        .join("apps");
+    let icon_dir = cache_root.join("hicolor").join("512x512").join("apps");
     let icon_path = icon_dir.join(format!("{ICON_NAME}.png"));
 
     if let Err(e) = std::fs::create_dir_all(&icon_dir) {


### PR DESCRIPTION
## Summary

Adds the GTK process-manager panel for issue #19. The conversations sidebar is wrapped in a `GtkStack` with a switcher at the top of the left pane so a new **Tasks** page sits alongside **Conversations** — minimal disruption to the existing sidebar widget.

- `src/widgets/tasks_panel.rs` ships the panel: a `ListBox` of tasks with a coloured status dot + title + progress hint + age, a `TextView` log pane below, and a toolbar (`Cancel`, `Open Conversation`). The unit-testable `TasksModel` / `view_model_for` model layer lives in the same file with tests beside it.
- `src/async_bridge.rs` gains `UiMessage::TasksLoaded` plus the four streaming variants. The connection manager sends `SubscribeBackgroundTasks` + `ListBackgroundTasks` on connect, then polls `ListBackgroundTasks` every 5 s as the stop-gap live-data path.
- `src/window.rs` wires the toolbar: `Cancel` issues `CancelBackgroundTask` over WS, `Open Conversation` switches the stack back to **Conversations** and routes the existing `ConversationLoaded` path.
- `src/style.css` adds the per-status colour tokens and the stack-switcher styling.

## Coupling note (read before reviewing)

The four `UiMessage::Task{Started,Progress,LogAppended,Completed}` variants are populated by streaming events. `client-common::SignalEvent` does not yet expose them — the matching extension is on the `feat/client-common-task-signals` branch in `adelie-ai/desktop-assistant` (the empty-then-WIP sibling worktree the user already has open). Until that ships, the variants are stubbed with `#[allow(dead_code)]` and the panel stays live via the 5 s `ListBackgroundTasks` poll. When the SignalEvent extension lands, a small follow-up wires the streaming path into the same handlers; the poll then becomes a defensive refresh.

This PR is independently shippable today — initial population works, cancel works, open-conversation works, status updates arrive on the 5 s poll.

## Tests

40 new unit tests in `tasks_panel.rs`:

- View-model formatting (status class, age, conversation id, clock-skew clamp, minutes/hours).
- Task model: `upsert` ordering (newest at top), `apply_progress` for unknown id (no-op), `apply_completion`, `replace_all` GCs orphan log buffers, `append_log` preserves seq ordering even when events arrive out of order, deduplicates duplicate seq, enforces the bounded buffer cap.
- Controller selection logic: cancel and open-conversation routes to the right id, both handle no-selection / stale-index noop paths.
- Business outcome: `business_outcome_user_can_see_their_running_standalone_agent_appear_in_real_time` asserts a `TaskStarted` event surfaces a row.

Failing tests landed as their own commit (`62c6115`) before the implementation commit (`23cc221`) per the TDD discipline.

## Build / lint / audit

- `cargo test`: **50 / 50 pass** (40 new + 10 pre-existing).
- `cargo fmt --check`: clean (this PR also picks up the formatter drift in `main.rs` / `oauth.rs` / `knowledge_browser.rs` / `model_picker.rs` so the gate stays green).
- `cargo clippy --all-targets`: no new findings in any file this PR introduces or modifies. The 19 pre-existing warnings in other files (`webview.rs`, `oauth.rs`, `login_screen.rs`, `select_models_dialog.rs`, `setup_dialog.rs`, `sidebar.rs`, `input_bar.rs`, `markdown.rs`) are out of scope — a follow-up clean-up issue can sweep them.
- `cargo audit`: surfaces one pre-existing medium advisory (RUSTSEC-2023-0071, the `rsa` Marvin timing sidechannel via `jsonwebtoken` → `desktop-assistant-auth-jwt`). Not introduced by this PR — the dep flows in because the local-path `desktop-assistant` crates have moved forward and the lockfile re-resolved. Upstream `rsa` has no fix available; the GTK client only verifies JWTs (no RSA key signing on this side).

## Out of scope (per issue)

- Standalone-agent launcher UI.
- A dedicated top-level "background tasks" window — sidebar integration is enough for v1.

## Test plan

- [ ] Build with `cargo build` against a current `desktop-assistant` checkout.
- [ ] Connect to a daemon and confirm the **Tasks** tab appears at the top of the sidebar.
- [ ] Start a standalone background agent on the daemon; row appears within ~5 s (current polling cadence).
- [ ] Select a row → log view populates; status dot colour matches the task's status.
- [ ] Click `Cancel` on a running task → daemon transitions it to `Cancelled` and the row updates on the next poll.
- [ ] Click `Open Conversation` → stack flips back to **Conversations** and the right conversation loads in the chat view.

Closes #19.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>