### PR TITLE
chore: refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Adele GTK
 
-GTK4-based desktop client for the Adelie Desktop Assistant.
+GTK4 desktop client for the [Adelie AI Platform](https://github.com/adelie-ai/desktop-assistant).
+Connects to the `desktop-assistant-daemon` over WebSocket or D-Bus.
+
+## What it does today
+
+- **Streaming chat** rendered via a WebKitGTK web view (with a Label-based
+  fallback when WebKit is unavailable).
+- **Connection profiles** with login screen, multi-window support, and
+  conversation archival.
+- **Per-conversation model picker** in the chat header, plus a Select Models
+  dialog for filtering the dropdown.
+- **Knowledge base browser/editor** from the hamburger menu.
+- **Process manager view** as a sidebar `GtkStack` page with a status dot per
+  task and toolbar buttons for Cancel / Open Conversation. Currently polls
+  every 5s — streaming via `SignalEvent::Task*` is tracked in
+  [#22](https://github.com/adelie-ai/adele-gtk/issues/22).
+- **Auto-reconnect** to the last profile, with a hamburger entry to switch
+  profiles without restart.
 
 ## Requirements
 
@@ -30,22 +47,10 @@ cargo build --no-default-features
 
 ## Install
 
-Install binary, desktop entry, and icon:
-
 ```sh
-just install
-```
-
-Or install just the desktop entry and icon (if the binary is already installed):
-
-```sh
-just install-desktop
-```
-
-To remove the desktop entry and icon:
-
-```sh
-just uninstall-desktop
+just install            # binary + desktop entry + icon
+just install-desktop    # desktop entry + icon only
+just uninstall-desktop  # remove desktop entry and icon
 ```
 
 ## Run
@@ -70,3 +75,14 @@ adele-gtk
 ```sh
 cargo test
 ```
+
+## Architecture
+
+Shared protocol types and transport clients live in the
+[`desktop-assistant`](https://github.com/adelie-ai/desktop-assistant) workspace
+under `crates/api-model` and `crates/client-common`. This repo depends on them
+via git; `Cargo.lock` pins the revision.
+
+## License
+
+GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`).


### PR DESCRIPTION
Add a "What it does today" section so the README is not just install steps.

## Summary

- Names the shipped features: WebKitGTK chat view (with Label fallback), connection profiles + multi-window + login screen, conversation archival, per-conversation model picker, Select Models dialog, KB browser, auto-reconnect + profile switch.
- Adds the new process manager sidebar view. Calls out the current 5s polling and links the streaming follow-up at #22.
- Adds an Architecture note pointing at `crates/api-model` + `crates/client-common` for the shared protocol surface.

## Test plan

- [ ] Read end-to-end and confirm it accurately represents the current GTK client
- [ ] Verify #22 is the right issue to link for streaming