### PR TITLE
Evict terminal rows from tasks panel on TaskCompleted

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -426,21 +426,19 @@ mod tests {
     }
 
     #[test]
-    fn signal_task_completed_routes_with_status_and_last_error() {
+    fn signal_task_completed_routes_id_only() {
+        // Terminal-row eviction means the panel only needs the id —
+        // status / last_error are not displayed once the row is gone.
+        // (Test still destructures the legacy fields here because the
+        // impl commit is the one that drops them from the message shape.)
         let msg = signal_to_ui_message(SignalEvent::TaskCompleted {
             id: "task-1".to_string(),
             status: api::TaskStatus::Failed,
             last_error: Some("boom".to_string()),
         });
         match msg {
-            UiMessage::TaskCompleted {
-                id,
-                status,
-                last_error,
-            } => {
+            UiMessage::TaskCompleted { id, .. } => {
                 assert_eq!(id, "task-1");
-                assert!(matches!(status, api::TaskStatus::Failed));
-                assert_eq!(last_error.as_deref(), Some("boom"));
             }
             other => panic!("expected TaskCompleted, got {other:?}"),
         }

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -99,8 +99,6 @@ pub enum UiMessage {
     },
     TaskCompleted {
         id: String,
-        status: api::TaskStatus,
-        last_error: Option<String>,
     },
 }
 
@@ -341,15 +339,7 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
             UiMessage::TaskProgress { id, progress_hint }
         }
         SignalEvent::TaskLogAppended { id, entry } => UiMessage::TaskLogAppended { id, entry },
-        SignalEvent::TaskCompleted {
-            id,
-            status,
-            last_error,
-        } => UiMessage::TaskCompleted {
-            id,
-            status,
-            last_error,
-        },
+        SignalEvent::TaskCompleted { id, .. } => UiMessage::TaskCompleted { id },
         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
     }
 }
@@ -428,16 +418,14 @@ mod tests {
     #[test]
     fn signal_task_completed_routes_id_only() {
         // Terminal-row eviction means the panel only needs the id —
-        // status / last_error are not displayed once the row is gone.
-        // (Test still destructures the legacy fields here because the
-        // impl commit is the one that drops them from the message shape.)
+        // status / last_error are dropped at the routing boundary.
         let msg = signal_to_ui_message(SignalEvent::TaskCompleted {
             id: "task-1".to_string(),
             status: api::TaskStatus::Failed,
             last_error: Some("boom".to_string()),
         });
         match msg {
-            UiMessage::TaskCompleted { id, .. } => {
+            UiMessage::TaskCompleted { id } => {
                 assert_eq!(id, "task-1");
             }
             other => panic!("expected TaskCompleted, got {other:?}"),

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -194,20 +194,15 @@ impl TasksModel {
         self.logs.get(id).map(Vec::as_slice).unwrap_or(&[])
     }
 
-    /// Apply a `TaskCompleted` event to the matching task.
-    pub fn apply_completion(
-        &mut self,
-        id: &str,
-        status: api::TaskStatus,
-        last_error: Option<String>,
-        ended_at: i64,
-    ) {
+    /// Remove the matching task from the model on a `TaskCompleted`
+    /// event. The associated log buffer is dropped too; the daemon
+    /// already filters terminal rows out of subsequent snapshots, so
+    /// retaining them would only let the panel accumulate stale rows.
+    pub fn apply_completion(&mut self, id: &str) {
         if let Some(idx) = self.position_of(id) {
-            let t = &mut self.tasks[idx];
-            t.status = status;
-            t.last_error = last_error;
-            t.ended_at = Some(ended_at);
+            self.tasks.remove(idx);
         }
+        self.logs.remove(id);
     }
 }
 
@@ -447,16 +442,8 @@ impl TasksPanel {
     }
 
     /// Apply a `UiMessage::TaskCompleted` event.
-    pub fn handle_task_completed(
-        &self,
-        id: String,
-        status: api::TaskStatus,
-        last_error: Option<String>,
-        now_ms: i64,
-    ) {
-        self.model
-            .borrow_mut()
-            .apply_completion(&id, status, last_error, now_ms);
+    pub fn handle_task_completed(&self, id: String, now_ms: i64) {
+        self.model.borrow_mut().apply_completion(&id);
         self.refresh_rows(now_ms);
     }
 
@@ -719,7 +706,7 @@ mod tests {
     fn apply_completion_removes_task_from_list() {
         let mut model = TasksModel::new();
         model.upsert(running_task("t-end", "c"));
-        model.apply_completion("t-end", api::TaskStatus::Failed, Some("boom".into()), 1);
+        model.apply_completion("t-end");
         assert_eq!(model.len(), 0);
         assert!(model.position_of("t-end").is_none());
     }
@@ -730,7 +717,7 @@ mod tests {
         model.upsert(running_task("t-end", "c"));
         model.append_log("t-end", log_entry(1, "hello"));
         model.append_log("t-end", log_entry(2, "world"));
-        model.apply_completion("t-end", api::TaskStatus::Completed, None, 1);
+        model.apply_completion("t-end");
         assert!(model.logs_for("t-end").is_empty());
     }
 
@@ -738,7 +725,7 @@ mod tests {
     fn apply_completion_for_unknown_id_is_noop() {
         let mut model = TasksModel::new();
         model.upsert(running_task("t-1", "c"));
-        model.apply_completion("missing", api::TaskStatus::Completed, None, 1);
+        model.apply_completion("missing");
         assert_eq!(model.len(), 1);
     }
 
@@ -747,7 +734,7 @@ mod tests {
         let mut model = TasksModel::new();
         model.upsert(running_task("keep", "c1"));
         model.upsert(running_task("drop", "c2"));
-        model.apply_completion("drop", api::TaskStatus::Completed, None, 1);
+        model.apply_completion("drop");
         assert_eq!(model.len(), 1);
         assert_eq!(model.get(0).unwrap().id.0, "keep");
     }

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -716,19 +716,40 @@ mod tests {
     }
 
     #[test]
-    fn apply_completion_transitions_status() {
+    fn apply_completion_removes_task_from_list() {
         let mut model = TasksModel::new();
         model.upsert(running_task("t-end", "c"));
-        model.apply_completion(
-            "t-end",
-            api::TaskStatus::Failed,
-            Some("boom".into()),
-            1_700_000_999_000,
-        );
-        let t = model.get(0).unwrap();
-        assert_eq!(t.status, api::TaskStatus::Failed);
-        assert_eq!(t.last_error.as_deref(), Some("boom"));
-        assert_eq!(t.ended_at, Some(1_700_000_999_000));
+        model.apply_completion("t-end", api::TaskStatus::Failed, Some("boom".into()), 1);
+        assert_eq!(model.len(), 0);
+        assert!(model.position_of("t-end").is_none());
+    }
+
+    #[test]
+    fn apply_completion_drops_log_buffer() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-end", "c"));
+        model.append_log("t-end", log_entry(1, "hello"));
+        model.append_log("t-end", log_entry(2, "world"));
+        model.apply_completion("t-end", api::TaskStatus::Completed, None, 1);
+        assert!(model.logs_for("t-end").is_empty());
+    }
+
+    #[test]
+    fn apply_completion_for_unknown_id_is_noop() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("t-1", "c"));
+        model.apply_completion("missing", api::TaskStatus::Completed, None, 1);
+        assert_eq!(model.len(), 1);
+    }
+
+    #[test]
+    fn apply_completion_leaves_other_tasks_alone() {
+        let mut model = TasksModel::new();
+        model.upsert(running_task("keep", "c1"));
+        model.upsert(running_task("drop", "c2"));
+        model.apply_completion("drop", api::TaskStatus::Completed, None, 1);
+        assert_eq!(model.len(), 1);
+        assert_eq!(model.get(0).unwrap().id.0, "keep");
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -914,12 +914,8 @@ fn handle_ui_message(
         UiMessage::TaskLogAppended { id, entry } => {
             tasks_panel.handle_task_log_appended(id, entry);
         }
-        UiMessage::TaskCompleted {
-            id,
-            status,
-            last_error,
-        } => {
-            tasks_panel.handle_task_completed(id, status, last_error, now_epoch_ms());
+        UiMessage::TaskCompleted { id } => {
+            tasks_panel.handle_task_completed(id, now_epoch_ms());
         }
         UiMessage::Disconnected { reason } => {
             *client.borrow_mut() = None;


### PR DESCRIPTION
## Summary

- `TasksModel::apply_completion` now removes the task (and its log buffer) instead of mutating its status in place.
- Drops unused `status` / `last_error` fields from `UiMessage::TaskCompleted` and the `TasksPanel::handle_task_completed` signature — neither is rendered once the row is gone.
- `signal_to_ui_message` routes only the id at the boundary.

The daemon already filters terminal tasks out of `ListBackgroundTasks(include_finished: false)` for the initial snapshot, so without UI-side removal the panel accumulated colored rows for every finished task until reconnect.

Two commits: failing tests first (TDD), implementation second. GTK twin of adelie-ai/adele-tui#56.

## Test plan

- [x] `cargo test` — 67 passing, 0 failing
- [ ] Manual: send several chat messages with the panel open; confirm completed/failed/cancelled rows disappear immediately on completion
- [ ] Manual: with a subagent in flight, observe it complete — the row should vanish and selection should clear naturally

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)