### PR TITLE
feat(connection): default to local socket; protocol selector in setup dialog

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::SignalEvent;
 use desktop_assistant_client_common::{
-    AssistantClient, ConnectionConfig, TransportClient, connect_transport,
+    AssistantClient, AssistantCommands, ConnectionConfig, TransportClient, connect_transport,
     transport::transport_label,
 };
 use gtk4::glib;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -2,13 +2,39 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Transport-specific connection settings for a profile.
+///
+/// Tagged on a `kind` field so the on-disk JSON is self-describing:
+/// `{"kind":"local"}` or `{"kind":"websocket","url":...,"subject":...}`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ProtocolConfig {
+    /// Local Unix domain socket. A `None` path uses the daemon's default
+    /// socket (`$XDG_RUNTIME_DIR/adelie/sock`).
+    Local {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<PathBuf>,
+    },
+    /// WebSocket endpoint (local or remote).
+    Websocket {
+        url: String,
+        #[serde(default = "default_ws_subject")]
+        subject: String,
+    },
+}
+
+impl Default for ProtocolConfig {
+    fn default() -> Self {
+        // New connections default to the local socket.
+        ProtocolConfig::Local { path: None }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConnectionProfile {
     pub id: String,
     pub name: String,
-    pub ws_url: String,
-    #[serde(default = "default_ws_subject")]
-    pub ws_subject: String,
+    pub protocol: ProtocolConfig,
 }
 
 fn default_ws_subject() -> String {
@@ -47,9 +73,22 @@ impl ProfileStore {
         }
         let data = std::fs::read_to_string(&self.path)
             .with_context(|| format!("reading {}", self.path.display()))?;
-        let file: ProfilesFile =
-            serde_json::from_str(&data).with_context(|| "parsing profiles.json")?;
-        Ok(file.profiles)
+        // No schema migration (#33): a profiles.json written by an older build
+        // (the flat `ws_url`/`ws_subject` shape) lacks the `protocol` field and
+        // won't parse into the tagged shape. Treat an unparseable file as "no
+        // profiles" so the user just re-creates their connections instead of
+        // the app erroring on startup. Mirrors `LastConnectionStore::get`'s
+        // existing corrupt-file tolerance.
+        match serde_json::from_str::<ProfilesFile>(&data) {
+            Ok(file) => Ok(file.profiles),
+            Err(e) => {
+                tracing::warn!(
+                    "ignoring unparseable {} ({e}); starting with no profiles",
+                    self.path.display()
+                );
+                Ok(Vec::new())
+            }
+        }
     }
 
     pub fn save(&self, profiles: &[ConnectionProfile]) -> Result<()> {
@@ -162,8 +201,10 @@ mod tests {
         ConnectionProfile {
             id: id.to_string(),
             name: format!("name-{id}"),
-            ws_url: format!("ws://example.com/{id}"),
-            ws_subject: "desktop-tui".to_string(),
+            protocol: ProtocolConfig::Websocket {
+                url: format!("ws://example.com/{id}"),
+                subject: "desktop-tui".to_string(),
+            },
         }
     }
 
@@ -190,6 +231,61 @@ mod tests {
         let remaining = store.load().unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].id, "b");
+    }
+
+    #[test]
+    fn protocol_config_serializes_both_variants() {
+        let local = ProtocolConfig::Local {
+            path: Some(PathBuf::from("/run/user/1000/adelie/sock")),
+        };
+        let local_json = serde_json::to_string(&local).unwrap();
+        assert!(local_json.contains("\"kind\":\"local\""));
+        assert_eq!(
+            serde_json::from_str::<ProtocolConfig>(&local_json).unwrap(),
+            local
+        );
+
+        // Default Local omits the path entirely.
+        let default_local = ProtocolConfig::Local { path: None };
+        let json = serde_json::to_string(&default_local).unwrap();
+        assert_eq!(json, r#"{"kind":"local"}"#);
+        assert_eq!(
+            serde_json::from_str::<ProtocolConfig>(&json).unwrap(),
+            default_local
+        );
+
+        let ws = ProtocolConfig::Websocket {
+            url: "wss://host/ws".into(),
+            subject: "desktop-tui".into(),
+        };
+        let ws_json = serde_json::to_string(&ws).unwrap();
+        assert!(ws_json.contains("\"kind\":\"websocket\""));
+        assert_eq!(
+            serde_json::from_str::<ProtocolConfig>(&ws_json).unwrap(),
+            ws
+        );
+    }
+
+    #[test]
+    fn new_profile_protocol_defaults_to_local() {
+        assert_eq!(
+            ProtocolConfig::default(),
+            ProtocolConfig::Local { path: None }
+        );
+    }
+
+    #[test]
+    fn load_tolerates_legacy_unparseable_profiles() {
+        // The pre-#33 flat shape (ws_url/ws_subject, no `protocol`). With no
+        // migration, this must degrade to "no profiles", not an error.
+        let dir = TempDir::new("legacy-profiles");
+        let store = ProfileStore::with_dir(dir.path.clone());
+        std::fs::write(
+            dir.path.join("profiles.json"),
+            r#"{"profiles":[{"id":"1","name":"old","ws_url":"ws://x","ws_subject":"s"}]}"#,
+        )
+        .unwrap();
+        assert!(store.load().unwrap().is_empty());
     }
 
     #[test]

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -10,7 +10,7 @@ use gtk4::{
 use crate::async_bridge;
 use crate::credential_store::CredentialStore;
 use crate::oauth;
-use crate::profile::{ConnectionProfile, LastConnectionStore, ProfileStore};
+use crate::profile::{ConnectionProfile, LastConnectionStore, ProfileStore, ProtocolConfig};
 use crate::widgets::setup_dialog;
 use crate::window;
 
@@ -156,7 +156,14 @@ impl LoginScreen {
                     name_label.set_hexpand(true);
                     hbox.append(&name_label);
 
-                    let url_label = Label::new(Some(&profile.ws_url));
+                    let detail = match &profile.protocol {
+                        ProtocolConfig::Local { path: Some(p) } => {
+                            format!("local · {}", p.display())
+                        }
+                        ProtocolConfig::Local { path: None } => "Local socket".to_string(),
+                        ProtocolConfig::Websocket { url, .. } => url.clone(),
+                    };
+                    let url_label = Label::new(Some(&detail));
                     url_label.add_css_class("dim-label");
                     url_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
                     url_label.set_max_width_chars(30);
@@ -372,10 +379,25 @@ pub async fn connect_to_profile(
 ) -> anyhow::Result<desktop_assistant_client_common::ConnectionConfig> {
     use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 
+    // Local socket: skip auth discovery entirely. The bearer token is minted
+    // locally (via D-Bus) inside `connect_transport`, so we just hand back a
+    // UDS config and let it dial `$XDG_RUNTIME_DIR/adelie/sock` (or the
+    // explicit path).
+    let (ws_url, ws_subject) = match &profile.protocol {
+        ProtocolConfig::Local { path } => {
+            return Ok(ConnectionConfig {
+                transport_mode: TransportMode::Uds,
+                socket_path: path.clone(),
+                ..Default::default()
+            });
+        }
+        ProtocolConfig::Websocket { url, subject } => (url.clone(), subject.clone()),
+    };
+
     // Try to discover auth config from server
     let ca_cert = desktop_assistant_client_common::config::default_ca_cert_path();
     let ca_cert_ref = ca_cert.as_path();
-    let discovery = match oauth::discover_auth_config(&profile.ws_url, Some(ca_cert_ref)).await {
+    let discovery = match oauth::discover_auth_config(&ws_url, Some(ca_cert_ref)).await {
         Ok(d) => d,
         Err(e) => {
             tracing::warn!("auth discovery failed, assuming password-only: {e}");
@@ -403,11 +425,11 @@ pub async fn connect_to_profile(
                         }
                         return Ok(ConnectionConfig {
                             transport_mode: TransportMode::Ws,
-                            ws_url: profile.ws_url.clone(),
+                            ws_url: ws_url.clone(),
                             ws_jwt: Some(tokens.access_token),
                             ws_login_username: None,
                             ws_login_password: None,
-                            ws_subject: profile.ws_subject.clone(),
+                            ws_subject: ws_subject.clone(),
                             ..Default::default()
                         });
                     }
@@ -428,11 +450,11 @@ pub async fn connect_to_profile(
 
             return Ok(ConnectionConfig {
                 transport_mode: TransportMode::Ws,
-                ws_url: profile.ws_url.clone(),
+                ws_url: ws_url.clone(),
                 ws_jwt: Some(tokens.access_token),
                 ws_login_username: None,
                 ws_login_password: None,
-                ws_subject: profile.ws_subject.clone(),
+                ws_subject: ws_subject.clone(),
                 ..Default::default()
             });
         }
@@ -447,11 +469,11 @@ pub async fn connect_to_profile(
 
         return Ok(ConnectionConfig {
             transport_mode: TransportMode::Ws,
-            ws_url: profile.ws_url.clone(),
+            ws_url: ws_url.clone(),
             ws_jwt: None,
             ws_login_username: username,
             ws_login_password: password,
-            ws_subject: profile.ws_subject.clone(),
+            ws_subject: ws_subject.clone(),
             ..Default::default()
         });
     }

--- a/src/widgets/setup_dialog.rs
+++ b/src/widgets/setup_dialog.rs
@@ -1,13 +1,18 @@
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Button, Entry, Label, Orientation, Window};
+use gtk4::{Align, Box as GtkBox, Button, DropDown, Entry, Label, Orientation, StringList, Window};
 
 use crate::credential_store::CredentialStore;
-use crate::profile::ConnectionProfile;
+use crate::profile::{ConnectionProfile, ProtocolConfig};
+
+// DropDown indices for the protocol selector.
+const PROTO_LOCAL: u32 = 0;
+const PROTO_WEBSOCKET: u32 = 1;
 
 /// Show a modal dialog for adding or editing a connection profile.
 ///
-/// `existing` is `Some` when editing, `None` when creating.
-/// `on_save` is called with the completed profile when the user clicks Save.
+/// `existing` is `Some` when editing, `None` when creating. New profiles
+/// default to the local Unix socket. `on_save` is called with the completed
+/// profile when the user clicks Save.
 pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
     parent: &impl IsA<Window>,
     existing: Option<&ConnectionProfile>,
@@ -23,7 +28,7 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
     let dialog = Window::builder()
         .title(dialog_title)
         .default_width(400)
-        .default_height(320)
+        .default_height(360)
         .modal(true)
         .transient_for(parent)
         .build();
@@ -46,45 +51,93 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
     }
     content.append(&name_entry);
 
-    // Server URL
+    // Protocol selector
+    let proto_label = Label::new(Some("Protocol"));
+    proto_label.set_halign(Align::Start);
+    content.append(&proto_label);
+
+    let proto_model = StringList::new(&["Local socket", "WebSocket"]);
+    let proto_dropdown = DropDown::builder().model(&proto_model).build();
+    content.append(&proto_dropdown);
+
+    // --- Local group: an optional socket path ---
+    let local_group = GtkBox::new(Orientation::Vertical, 12);
+
+    let sock_label = Label::new(Some("Socket path (optional — blank uses the default)"));
+    sock_label.set_halign(Align::Start);
+    local_group.append(&sock_label);
+
+    let sock_entry = Entry::new();
+    sock_entry.set_placeholder_text(Some("$XDG_RUNTIME_DIR/adelie/sock"));
+    local_group.append(&sock_entry);
+
+    content.append(&local_group);
+
+    // --- WebSocket group: URL + password-auth credentials ---
+    let ws_group = GtkBox::new(Orientation::Vertical, 12);
+
     let url_label = Label::new(Some("Server URL"));
     url_label.set_halign(Align::Start);
-    content.append(&url_label);
+    ws_group.append(&url_label);
 
     let url_entry = Entry::new();
     url_entry.set_placeholder_text(Some("wss://127.0.0.1:11339/ws"));
-    if let Some(profile) = existing {
-        url_entry.set_text(&profile.ws_url);
-    } else {
-        url_entry.set_text("wss://127.0.0.1:11339/ws");
-    }
-    content.append(&url_entry);
+    url_entry.set_text("wss://127.0.0.1:11339/ws");
+    ws_group.append(&url_entry);
 
-    // Username (for password auth)
     let user_label = Label::new(Some("Username (for password auth, optional)"));
     user_label.set_halign(Align::Start);
-    content.append(&user_label);
+    ws_group.append(&user_label);
 
     let user_entry = Entry::new();
     user_entry.set_placeholder_text(Some("Leave blank to skip"));
-    if let Some(profile) = existing {
-        if let Ok(Some(username)) =
-            CredentialStore::get_password(&format!("{}-username", profile.id))
-        {
-            user_entry.set_text(&username);
-        }
-    }
-    content.append(&user_entry);
+    ws_group.append(&user_entry);
 
-    // Password
     let pass_label = Label::new(Some("Password (optional)"));
     pass_label.set_halign(Align::Start);
-    content.append(&pass_label);
+    ws_group.append(&pass_label);
 
     let pass_entry = Entry::new();
     pass_entry.set_visibility(false);
     pass_entry.set_placeholder_text(Some("Leave blank to skip"));
-    content.append(&pass_entry);
+    ws_group.append(&pass_entry);
+
+    content.append(&ws_group);
+
+    // Populate fields from an existing profile, or default a new one to Local.
+    match existing.map(|p| &p.protocol) {
+        Some(ProtocolConfig::Local { path }) => {
+            proto_dropdown.set_selected(PROTO_LOCAL);
+            if let Some(p) = path {
+                sock_entry.set_text(&p.display().to_string());
+            }
+        }
+        Some(ProtocolConfig::Websocket { url, .. }) => {
+            proto_dropdown.set_selected(PROTO_WEBSOCKET);
+            url_entry.set_text(url);
+        }
+        None => proto_dropdown.set_selected(PROTO_LOCAL),
+    }
+    if let Some(profile) = existing
+        && let Ok(Some(username)) =
+            CredentialStore::get_password(&format!("{}-username", profile.id))
+    {
+        user_entry.set_text(&username);
+    }
+
+    // Show only the group matching the selected protocol, now and on change.
+    let apply_visibility = |sel: u32, local: &GtkBox, ws: &GtkBox| {
+        local.set_visible(sel == PROTO_LOCAL);
+        ws.set_visible(sel == PROTO_WEBSOCKET);
+    };
+    apply_visibility(proto_dropdown.selected(), &local_group, &ws_group);
+    {
+        let local_group = local_group.clone();
+        let ws_group = ws_group.clone();
+        proto_dropdown.connect_selected_notify(move |dd| {
+            apply_visibility(dd.selected(), &local_group, &ws_group);
+        });
+    }
 
     // Buttons
     let button_box = GtkBox::new(Orientation::Horizontal, 8);
@@ -99,13 +152,14 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
     button_box.append(&save_btn);
 
     content.append(&button_box);
-    dialog.set_child(Some(&content));
 
     // Status label for validation errors
     let status = Label::new(None);
     status.add_css_class("status-bar");
     status.set_halign(Align::Start);
     content.append(&status);
+
+    dialog.set_child(Some(&content));
 
     // Cancel
     {
@@ -121,16 +175,8 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
         let existing_id = existing.map(|p| p.id.clone());
         save_btn.connect_clicked(move |_| {
             let name = name_entry.text().trim().to_string();
-            let url = url_entry.text().trim().to_string();
-            let username = user_entry.text().trim().to_string();
-            let password = pass_entry.text().to_string();
-
             if name.is_empty() {
                 status.set_text("Connection name is required");
-                return;
-            }
-            if url.is_empty() {
-                status.set_text("Server URL is required");
                 return;
             }
 
@@ -138,22 +184,36 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
                 .clone()
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-            // Store credentials in keyring
-            if !username.is_empty() {
-                let _ = CredentialStore::store_password(&format!("{id}-username"), &username);
-            }
-            if !password.is_empty() {
-                let _ = CredentialStore::store_password(&id, &password);
-            }
-
-            let profile = ConnectionProfile {
-                id,
-                name,
-                ws_url: url,
-                ws_subject: "desktop-tui".to_string(),
+            let protocol = if proto_dropdown.selected() == PROTO_WEBSOCKET {
+                let url = url_entry.text().trim().to_string();
+                if url.is_empty() {
+                    status.set_text("Server URL is required for WebSocket");
+                    return;
+                }
+                // Store credentials in the keyring (never in the profile).
+                let username = user_entry.text().trim().to_string();
+                let password = pass_entry.text().to_string();
+                if !username.is_empty() {
+                    let _ = CredentialStore::store_password(&format!("{id}-username"), &username);
+                }
+                if !password.is_empty() {
+                    let _ = CredentialStore::store_password(&id, &password);
+                }
+                ProtocolConfig::Websocket {
+                    url,
+                    subject: "desktop-tui".to_string(),
+                }
+            } else {
+                let raw = sock_entry.text().trim().to_string();
+                let path = if raw.is_empty() {
+                    None
+                } else {
+                    Some(std::path::PathBuf::from(raw))
+                };
+                ProtocolConfig::Local { path }
             };
 
-            on_save(profile);
+            on_save(ConnectionProfile { id, name, protocol });
             dialog_ref.close();
         });
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{
-    AssistantClient, ChatMessage, ConnectionConfig, ConversationDetail, ConversationSummary,
-    TransportClient,
+    AssistantClient, AssistantCommands, ChatMessage, ConnectionConfig, ConversationDetail,
+    ConversationSummary, TransportClient,
 };
 use gtk4::prelude::*;
 use gtk4::{


### PR DESCRIPTION
Closes #33

Makes the daemon's local Unix socket the default connector for the gtk app and adds a protocol selector to the connection dialog (issue #33 plus the "UDS as default connector" follow-up).

## How

- `ConnectionProfile.protocol` becomes a tagged `ProtocolConfig` (`Local { path: Option<PathBuf> }` | `Websocket { url, subject }`); new profiles default to `Local { path: None }`.
- Setup dialog: a **Protocol** dropdown (Local / WebSocket) swaps the visible fields — an optional socket-path entry for Local, URL + password-auth credentials for WebSocket.
- `connect_to_profile` short-circuits Local → a UDS `ConnectionConfig` (the bearer token is minted locally via D-Bus inside `connect_transport`); the WebSocket path keeps its OIDC / password discovery unchanged. The profile-list label is protocol-aware.
- **No migration** (per #33): `ProfileStore::load` tolerates a legacy/unparseable `profiles.json` by starting fresh instead of erroring the app — the user re-creates connections (mirrors the existing `last_connection.json` tolerance).

## Tests

`ProtocolConfig` serde (both variants, default-Local, omitted path), legacy-file tolerance, and the profile-store round-trip. `cargo test` green (70 tests); `cargo build` with the default `linux` feature is clean.

## Dependency

Requires `TransportMode::Uds` from adelie-ai/desktop-assistant#159 (now on `main`). The gtk path-dep must resolve to a desktop-assistant checkout that includes #159.

## Pre-existing drift (out of scope)

This PR's new code is `cargo fmt` + clippy clean. The crate's pre-existing fmt/clippy drift under the current toolchain is tracked in #27 — intentionally not bundled here to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
