### PR TITLE
chore: fmt + clippy hygiene, pin toolchain (#27)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -63,6 +63,11 @@ pub enum UiMessage {
     /// `request_id` — that is server-generated and arrives embedded in
     /// the first `AssistantDelta`. See issue #31.
     PromptSent {
+        // Staged for streaming-chunk correlation (#31): consumer currently
+        // ignores it (`PromptSent { task_id: _ }`), but the ack value is kept
+        // on the message so the streaming work can correlate without a wire
+        // change. See the variant doc above and issues #114/#31.
+        #[allow(dead_code)]
         task_id: String,
     },
     /// Available (connection, model) pairs, fetched once on connect.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,12 @@
+//! adele-gtk — the GTK4 desktop client for the Adele assistant.
+//!
+//! Renders the chat UI and talks to the `desktop-assistant` daemon over the
+//! transport provided by `desktop-assistant-client-common` (D-Bus on Linux,
+//! or a direct WebSocket/UDS connection). The GTK widget tree lives in
+//! [`widgets`] and [`window`]; daemon I/O runs on a Tokio runtime and is
+//! marshalled back onto the GTK main loop via [`async_bridge`]. Credentials
+//! and OAuth/OIDC login are handled by [`credential_store`] and [`oauth`].
+
 mod async_bridge;
 mod avatars;
 mod credential_store;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -92,14 +92,14 @@ pub fn render_messages_html(
         ));
     }
 
-    if let Some(buffer) = streaming_buffer {
-        if !buffer.is_empty() {
-            let content_html = markdown_to_html(buffer);
-            let avatar_html = avatar_img(&avatars.adele, "Adele");
-            html.push_str(&format!(
+    if let Some(buffer) = streaming_buffer
+        && !buffer.is_empty()
+    {
+        let content_html = markdown_to_html(buffer);
+        let avatar_html = avatar_img(&avatars.adele, "Adele");
+        html.push_str(&format!(
                 r#"<div class="message assistant-message streaming">{avatar_html}<div class="bubble"><div class="label">Adele</div><div class="content">{content_html}<span class="cursor">▌</span></div></div></div>"#
             ));
-        }
     }
 
     html

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -488,8 +488,14 @@ mod tests {
         // ammonia, which keeps <img> with a safe src — what must vanish is
         // the executable event handler.
         let html = markdown_to_html("before <img src=x onerror=\"alert(1)\"> after");
-        assert!(html.contains("before"), "leading text must survive: {html:?}");
-        assert!(html.contains("after"), "trailing text must survive: {html:?}");
+        assert!(
+            html.contains("before"),
+            "leading text must survive: {html:?}"
+        );
+        assert!(
+            html.contains("after"),
+            "trailing text must survive: {html:?}"
+        );
         assert!(
             !html.to_ascii_lowercase().contains("onerror"),
             "onerror handler must never appear in output: {html:?}"
@@ -511,8 +517,14 @@ mod tests {
             !html.to_ascii_lowercase().contains("javascript:"),
             "javascript: URIs must be stripped: {html:?}"
         );
-        assert!(html.contains("click"), "surrounding text must survive: {html:?}");
-        assert!(html.contains("now"), "surrounding text must survive: {html:?}");
+        assert!(
+            html.contains("click"),
+            "surrounding text must survive: {html:?}"
+        );
+        assert!(
+            html.contains("now"),
+            "surrounding text must survive: {html:?}"
+        );
         assert!(html.contains("me"), "link text must survive: {html:?}");
     }
 
@@ -523,19 +535,37 @@ mod tests {
                   > quoted\n\n\
                   [link](https://example.com)";
         let html = markdown_to_html(md);
-        assert!(html.contains("<h1>Heading</h1>"), "headings render: {html:?}");
-        assert!(html.contains("<strong>bold</strong>"), "bold renders: {html:?}");
+        assert!(
+            html.contains("<h1>Heading</h1>"),
+            "headings render: {html:?}"
+        );
+        assert!(
+            html.contains("<strong>bold</strong>"),
+            "bold renders: {html:?}"
+        );
         assert!(html.contains("<em>italic</em>"), "italic renders: {html:?}");
-        assert!(html.contains("<code>code</code>"), "inline code renders: {html:?}");
-        assert!(html.contains("<ul>") && html.contains("<li>item 1</li>"), "lists render: {html:?}");
-        assert!(html.contains("<blockquote>"), "blockquotes render: {html:?}");
+        assert!(
+            html.contains("<code>code</code>"),
+            "inline code renders: {html:?}"
+        );
+        assert!(
+            html.contains("<ul>") && html.contains("<li>item 1</li>"),
+            "lists render: {html:?}"
+        );
+        assert!(
+            html.contains("<blockquote>"),
+            "blockquotes render: {html:?}"
+        );
         // ammonia adds rel="noopener noreferrer" to <a> tags, so assert
         // the load-bearing attributes/text rather than the full tag string.
         assert!(
             html.contains(r#"href="https://example.com""#),
             "markdown link href renders: {html:?}"
         );
-        assert!(html.contains(">link</a>"), "markdown link text renders: {html:?}");
+        assert!(
+            html.contains(">link</a>"),
+            "markdown link text renders: {html:?}"
+        );
     }
 
     #[test]
@@ -546,8 +576,12 @@ mod tests {
             .find("Content-Security-Policy")
             .expect("template has CSP meta tag");
         let after = &template[csp_start..];
-        let content_start = after.find("content=\"").expect("CSP has content attr") + "content=\"".len();
-        let content_end = content_start + after[content_start..].find('"').expect("CSP content closes");
+        let content_start =
+            after.find("content=\"").expect("CSP has content attr") + "content=\"".len();
+        let content_end = content_start
+            + after[content_start..]
+                .find('"')
+                .expect("CSP content closes");
         let csp = &after[content_start..content_end];
 
         // Find the script-src directive specifically.
@@ -578,7 +612,9 @@ mod tests {
         // If they drift, the WebView silently refuses to run the script and the
         // chat UI stops updating — this test pins them together.
         let template = html_template();
-        let script_open = template.find("<script>").expect("template has inline script");
+        let script_open = template
+            .find("<script>")
+            .expect("template has inline script");
         let body_start = script_open + "<script>".len();
         let body_end = body_start
             + template[body_start..]

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -36,12 +36,11 @@ pub async fn discover_auth_config(
     let url = format!("{base_url}/auth/config");
 
     let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
-    if let Some(ca_path) = tls_ca_cert {
-        if let Ok(pem_bytes) = std::fs::read(ca_path) {
-            if let Ok(cert) = reqwest::tls::Certificate::from_pem(&pem_bytes) {
-                builder = builder.add_root_certificate(cert);
-            }
-        }
+    if let Some(ca_path) = tls_ca_cert
+        && let Ok(pem_bytes) = std::fs::read(ca_path)
+        && let Ok(cert) = reqwest::tls::Certificate::from_pem(&pem_bytes)
+    {
+        builder = builder.add_root_certificate(cert);
     }
     let client = builder.build().unwrap_or_else(|_| reqwest::Client::new());
 

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -13,31 +13,28 @@ pub fn create_chat_webview() -> WebView {
 
     // Intercept navigation to open external links in the default browser
     webview.connect_decide_policy(|_webview, decision, decision_type| {
-        if decision_type == PolicyDecisionType::NavigationAction {
-            if let Some(nav_decision) = decision.downcast_ref::<NavigationPolicyDecision>() {
-                if let Some(mut action) = nav_decision.navigation_action() {
-                    if let Some(request) = action.request() {
-                        if let Some(uri) = request.uri() {
-                            let uri_str = uri.as_str();
-                            // Allow internal navigation (initial page load)
-                            if uri_str == "about:blank"
-                                || uri_str.starts_with("data:")
-                                || uri_str.starts_with("file:")
-                            {
-                                return false; // allow
-                            }
-
-                            // Open external links in default browser
-                            let _ = gtk4::gio::AppInfo::launch_default_for_uri(
-                                uri_str,
-                                gtk4::gio::AppLaunchContext::NONE,
-                            );
-                            decision.ignore();
-                            return true; // handled
-                        }
-                    }
-                }
+        if decision_type == PolicyDecisionType::NavigationAction
+            && let Some(nav_decision) = decision.downcast_ref::<NavigationPolicyDecision>()
+            && let Some(action) = nav_decision.navigation_action()
+            && let Some(request) = action.request()
+            && let Some(uri) = request.uri()
+        {
+            let uri_str = uri.as_str();
+            // Allow internal navigation (initial page load)
+            if uri_str == "about:blank"
+                || uri_str.starts_with("data:")
+                || uri_str.starts_with("file:")
+            {
+                return false; // allow
             }
+
+            // Open external links in default browser
+            let _ = gtk4::gio::AppInfo::launch_default_for_uri(
+                uri_str,
+                gtk4::gio::AppLaunchContext::NONE,
+            );
+            decision.ignore();
+            return true; // handled
         }
         false
     });
@@ -83,6 +80,11 @@ pub fn clear_status(webview: &WebView) {
 }
 
 /// Scroll the webview to the bottom.
+// Companion to the JS `scrollToBottom()` helper (called automatically inside
+// `update_messages`/`append_chunk`). This explicit Rust wrapper is currently
+// unwired but kept as part of the webview helper surface; the per-conversation
+// model-selector work (#1) re-renders the chat and may need an explicit scroll.
+#[allow(dead_code)]
 pub fn scroll_to_bottom(webview: &WebView) {
     webview.evaluate_javascript(
         "scrollToBottom();",

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -55,6 +55,10 @@ impl InputBar {
     }
 
     /// Get the current text content without clearing.
+    // Read-only counterpart to `take_text` (which is used). Part of the public
+    // InputBar API; not yet called from `window.rs` but kept for the input-bar
+    // consumers added by the connections/model-selector work (#1).
+    #[allow(dead_code)]
     pub fn text(&self) -> String {
         let buffer = self.text_view.buffer();
         buffer

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -60,10 +60,9 @@ impl LoginScreen {
             .create_new(true)
             .open(&icon_path)
             .and_then(|mut f| std::io::Write::write_all(&mut f, ICON_BYTES))
+            && e.kind() != std::io::ErrorKind::AlreadyExists
         {
-            if e.kind() != std::io::ErrorKind::AlreadyExists {
-                tracing::warn!("Failed to write brand icon: {e}");
-            }
+            tracing::warn!("Failed to write brand icon: {e}");
         }
         let icon = Image::from_file(icon_path.to_str().unwrap_or_default());
         icon.set_pixel_size(56);
@@ -122,6 +121,9 @@ impl LoginScreen {
 
         // Use a shared flag so `populate` can schedule itself after a popover closes.
         // The Rc<dyn Fn()> is built in two steps because the closure references itself.
+        // Narrow allow: this self-referential closure cell is a one-off local; a
+        // `type` alias would not reduce cognitive load and is out of scope here.
+        #[allow(clippy::type_complexity)]
         let populate: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
 
         {
@@ -263,10 +265,10 @@ impl LoginScreen {
                 }
 
                 // Select first row if any
-                if !profs.is_empty() {
-                    if let Some(first_row) = list_box.row_at_index(0) {
-                        list_box.select_row(Some(&first_row));
-                    }
+                if !profs.is_empty()
+                    && let Some(first_row) = list_box.row_at_index(0)
+                {
+                    list_box.select_row(Some(&first_row));
                 }
             });
 
@@ -412,52 +414,50 @@ pub async fn connect_to_profile(
     let has_password = discovery.methods.contains(&"password".to_string());
 
     // Try OIDC first if available
-    if has_oidc {
-        if let Some(ref oidc) = discovery.oidc {
-            // Try silent refresh first
-            if let Ok(Some(refresh_token)) = CredentialStore::get_refresh_token(&profile.id) {
-                tracing::info!("attempting silent token refresh");
-                match oauth::refresh_access_token(oidc, &refresh_token).await {
-                    Ok(tokens) => {
-                        // Store new refresh token if provided
-                        if let Some(ref new_refresh) = tokens.refresh_token {
-                            let _ = CredentialStore::store_refresh_token(&profile.id, new_refresh);
-                        }
-                        return Ok(ConnectionConfig {
-                            transport_mode: TransportMode::Ws,
-                            ws_url: ws_url.clone(),
-                            ws_jwt: Some(tokens.access_token),
-                            ws_login_username: None,
-                            ws_login_password: None,
-                            ws_subject: ws_subject.clone(),
-                            ..Default::default()
-                        });
+    if has_oidc && let Some(ref oidc) = discovery.oidc {
+        // Try silent refresh first
+        if let Ok(Some(refresh_token)) = CredentialStore::get_refresh_token(&profile.id) {
+            tracing::info!("attempting silent token refresh");
+            match oauth::refresh_access_token(oidc, &refresh_token).await {
+                Ok(tokens) => {
+                    // Store new refresh token if provided
+                    if let Some(ref new_refresh) = tokens.refresh_token {
+                        let _ = CredentialStore::store_refresh_token(&profile.id, new_refresh);
                     }
-                    Err(e) => {
-                        tracing::info!("silent refresh failed, will try browser flow: {e}");
-                    }
+                    return Ok(ConnectionConfig {
+                        transport_mode: TransportMode::Ws,
+                        ws_url: ws_url.clone(),
+                        ws_jwt: Some(tokens.access_token),
+                        ws_login_username: None,
+                        ws_login_password: None,
+                        ws_subject: ws_subject.clone(),
+                        ..Default::default()
+                    });
+                }
+                Err(e) => {
+                    tracing::info!("silent refresh failed, will try browser flow: {e}");
                 }
             }
-
-            // Full browser OAuth flow
-            tracing::info!("starting browser OAuth flow");
-            let tokens = oauth::run_oauth_flow(oidc).await?;
-
-            // Store refresh token for next time
-            if let Some(ref refresh_token) = tokens.refresh_token {
-                let _ = CredentialStore::store_refresh_token(&profile.id, refresh_token);
-            }
-
-            return Ok(ConnectionConfig {
-                transport_mode: TransportMode::Ws,
-                ws_url: ws_url.clone(),
-                ws_jwt: Some(tokens.access_token),
-                ws_login_username: None,
-                ws_login_password: None,
-                ws_subject: ws_subject.clone(),
-                ..Default::default()
-            });
         }
+
+        // Full browser OAuth flow
+        tracing::info!("starting browser OAuth flow");
+        let tokens = oauth::run_oauth_flow(oidc).await?;
+
+        // Store refresh token for next time
+        if let Some(ref refresh_token) = tokens.refresh_token {
+            let _ = CredentialStore::store_refresh_token(&profile.id, refresh_token);
+        }
+
+        return Ok(ConnectionConfig {
+            transport_mode: TransportMode::Ws,
+            ws_url: ws_url.clone(),
+            ws_jwt: Some(tokens.access_token),
+            ws_login_username: None,
+            ws_login_password: None,
+            ws_subject: ws_subject.clone(),
+            ..Default::default()
+        });
     }
 
     // Fall back to password auth

--- a/src/widgets/select_models_dialog.rs
+++ b/src/widgets/select_models_dialog.rs
@@ -144,7 +144,8 @@ pub fn show_select_models_dialog<F>(
         let chosen: Vec<SelectedModel> = checks_ref
             .borrow()
             .iter()
-            .filter_map(|(model, check)| check.is_active().then(|| model.clone()))
+            .filter(|&(_model, check)| check.is_active())
+            .map(|(model, _check)| model.clone())
             .collect();
         dialog_ref.close();
         on_save(chosen);

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -16,7 +16,13 @@ pub struct Sidebar {
     pub container: GtkBox,
     pub list_box: ListBox,
     pub new_button: Button,
+    // Both widgets are fully wired during `new()` (appended to the container,
+    // toggle handler connected); these fields retain handles for external
+    // access that is not yet exercised. Kept as part of the public Sidebar
+    // surface for the connections/control-panel work (#1).
+    #[allow(dead_code)]
     pub show_archived_check: CheckButton,
+    #[allow(dead_code)]
     pub scrolled_window: ScrolledWindow,
     on_rename: Rc<RefCell<Option<IndexCallback>>>,
     on_delete: Rc<RefCell<Option<IndexCallback>>>,
@@ -44,10 +50,9 @@ impl Sidebar {
             .create_new(true)
             .open(&icon_path)
             .and_then(|mut f| std::io::Write::write_all(&mut f, ICON_BYTES))
+            && e.kind() != std::io::ErrorKind::AlreadyExists
         {
-            if e.kind() != std::io::ErrorKind::AlreadyExists {
-                tracing::warn!("Failed to write brand icon: {e}");
-            }
+            tracing::warn!("Failed to write brand icon: {e}");
         }
         let icon = Image::from_file(icon_path.to_str().unwrap_or_default());
         icon.set_pixel_size(44);
@@ -235,6 +240,10 @@ impl Sidebar {
     }
 
     /// Get the index of the currently selected row.
+    // Getter counterpart to `select_index` (which is used by `window.rs`).
+    // Part of the public Sidebar API; not yet read but kept for the
+    // connections/control-panel work (#1).
+    #[allow(dead_code)]
     pub fn selected_index(&self) -> Option<usize> {
         let row = self.list_box.selected_row()?;
         Some(row.index() as usize)


### PR DESCRIPTION
Closes #27

Dedicated fmt + clippy hygiene pass. No behavior changes beyond what clippy's lints imply.

## Summary
- **Pin toolchain** — add `rust-toolchain.toml` (channel `1.96.0`, components `rustfmt`, `clippy`) for reproducible fmt/clippy. (Originally pinned `1.95.0`; bumped to `1.96.0` and re-verified — rustfmt internal version unchanged so zero fmt delta, and clippy `0.1.96` surfaced no new lints.)
- **fmt** — `cargo fmt` was dirty in `src/markdown.rs` only (6 hunks, long `assert!` lines in the test module rewrapped). The 4 files named in the issue (`async_bridge.rs`, `main.rs`, `oauth.rs`, `knowledge_browser.rs`) are no longer drifted — the tree moved since the issue was filed.
- **clippy** — was 19 warnings; now `cargo clippy --all-targets -- -D warnings` is clean.
- **crate-root doc** — added `//!` to `src/main.rs` (crate root).

Note: ran `cargo fmt -p adele-gtk` rather than `cargo fmt --all`. This crate is not a workspace and path-depends on `../desktop-assistant/crates/{client-common,api-model}`; `--all` walks those path-deps and reformats source in a *different* repo (own hygiene tracked in desktop-assistant#146). `-p adele-gtk` formats all of this crate without that cross-repo bleed.

## Clippy fixes by category
- `collapsible_if` x11 -> let-chains, via `cargo clippy --fix` (`markdown.rs`, `oauth.rs`, `webview.rs`, `login_screen.rs` x3, `sidebar.rs`).
- `unused_mut` x1 -> dropped `mut` on `action` in the webview nav-decision closure (`webview.rs`).
- `filter_map_bool_then` x1 -> `filter().map()` (`select_models_dialog.rs`).
- `type_complexity` x1 -> narrow `#[allow]` (see below).
- dead-code x6 -> narrow `#[allow(dead_code)]` (see below).

Build verified after `--fix` (glib/gtk macros survive the let-chain rewrites).

## `#[allow]` decisions (file:line + why)
- `src/widgets/login_screen.rs:126` — `#[allow(clippy::type_complexity)]` on `let populate: Rc<RefCell<Option<Rc<dyn Fn()>>>>`. Self-referential GTK closure cell built in two steps; it's a one-off local, a `type` alias wouldn't reduce cognitive load, and introducing one is out of scope for a hygiene PR.

## Dead-code decisions (every one: allow vs remove + reasoning)
All six are `#[allow(dead_code)]` (not removed). Rationale: every item is public widget/message API, none is clearly orphaned, and the multi-connection model-selection feature (#1) and refactor (#29) are imminent. The local `feat/connections-ui` branch (the #1 work) still carries all of these definitions. Per "when in doubt, prefer allow over deletion":
- `src/async_bridge.rs` `UiMessage::PromptSent.task_id` — staged for streaming-chunk correlation (#31). Already deliberately ignored at the consumer (`PromptSent { task_id: _ }`) and carries an explanatory doc referencing #114/#31. Keeping the value on the message lets the streaming work correlate without a wire change.
- `src/webview.rs` `scroll_to_bottom` — Rust wrapper for the JS `scrollToBottom()` (which is already invoked automatically inside `update_messages`/`append_chunk`). Currently unwired; kept as part of the webview helper surface alongside `set_status`/`clear_status`. **Most borderline** (truly orphaned today, no branch calls it) — flagged for sanity-check; allowed rather than removed per the in-doubt rule.
- `src/widgets/input_bar.rs` `InputBar::text` — read-only counterpart to the used `take_text`; public InputBar API.
- `src/widgets/sidebar.rs:24,26` `show_archived_check` / `scrolled_window` — public fields; both widgets are fully wired in `new()` (appended + handler connected), the fields just retain handles for not-yet-exercised external access.
- `src/widgets/sidebar.rs` `Sidebar::selected_index` — getter counterpart to the used `select_index`; public Sidebar API.

## Crate-root docs added
- `src/main.rs` — `//!` describing the GTK4 client, its transport via `client-common`, the widget tree, and the Tokio<->GTK bridge.

## Out of scope / noticed
- The issue says crate-root `//!` is missing on 18/19 source files; this PR adds it only to the crate root (`main.rs`) per the agreed scope. Per-module `//!` docs on the other ~17 files remain a follow-up.
- The 19->6 clippy delta after `--fix` matched the issue's enumerated lints exactly; the issue text also mentioned `redundant_closure` / `useless_vec`, but neither was present in the current tree (already resolved upstream).
- desktop-assistant working tree had unrelated pre-existing uncommitted edits during this work; untouched by this PR (scoped fmt).

## Verification
- `cargo fmt -p adele-gtk -- --check` -> exit 0
- `cargo clippy --all-targets -- -D warnings` -> exit 0
- `cargo build --all-targets` -> ok
- `cargo test` -> 70 passed; 0 failed; 0 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

