### PR TITLE
feat(gtk): migrate credential store to keyring-core 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "desktop-assistant-client-common",
  "dirs",
  "gtk4",
- "keyring",
+ "keyring-core",
  "oauth2",
  "open",
  "pulldown-cmark",
@@ -29,6 +29,7 @@ dependencies = [
  "url",
  "uuid",
  "webkit6",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -151,6 +152,20 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -592,35 +607,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "aes",
- "block-padding",
- "cbc",
- "dbus",
- "fastrand",
- "hkdf",
- "num",
- "once_cell",
- "sha2",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,7 +650,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
- "zbus 5.15.0",
+ "zbus",
 ]
 
 [[package]]
@@ -1776,15 +1762,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "dbus-secret-service",
  "log",
- "secret-service",
- "zeroize",
 ]
 
 [[package]]
@@ -1804,15 +1787,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libredox"
@@ -1936,19 +1910,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2751,21 +2712,21 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secret-service"
-version = "4.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
  "aes",
  "cbc",
  "futures-util",
  "generic-array",
+ "getrandom 0.2.17",
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.6",
  "serde",
  "sha2",
- "zbus 4.4.0",
+ "zbus",
 ]
 
 [[package]]
@@ -3026,12 +2987,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3941,15 +3896,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -4205,16 +4151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4239,45 +4175,19 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-process",
- "async-recursion",
- "async-trait",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix",
- "ordered-stream",
- "rand 0.8.6",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus"
 version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",
@@ -4294,22 +4204,20 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros 5.15.0",
- "zbus_names 4.3.2",
- "zvariant 5.11.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
-name = "zbus_macros"
-version = "4.4.0"
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 2.1.0",
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]
@@ -4322,20 +4230,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zbus_names 4.3.2",
- "zvariant 5.11.0",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant 4.2.0",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4346,7 +4243,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow",
- "zvariant 5.11.0",
+ "zvariant",
 ]
 
 [[package]]
@@ -4451,19 +4348,6 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
 version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
@@ -4472,21 +4356,8 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow",
- "zvariant_derive 5.11.0",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 2.1.0",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4499,18 +4370,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zvariant_utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ linux = ["dep:webkit6", "desktop-assistant-client-common/dbus"]
 anyhow = "1"
 base64 = "0.22"
 dirs = "6"
-keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+keyring-core = "1"
+zbus-secret-service-keyring-store = { version = "1", features = ["rt-tokio-crypto-rust"] }
 oauth2 = "5"
 open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/credential_store.rs
+++ b/src/credential_store.rs
@@ -5,54 +5,138 @@ const SERVICE_NAME: &str = "adele-gtk";
 pub struct CredentialStore;
 
 impl CredentialStore {
-    fn entry(key: &str) -> Result<keyring::Entry> {
-        keyring::Entry::new(SERVICE_NAME, key).map_err(|e| anyhow::anyhow!("keyring error: {e}"))
+    /// Register the system Secret Service as keyring-core's default credential
+    /// store. Best-effort: if unavailable (headless / no session bus) we log and
+    /// continue — credential calls then surface errors and callers fall back.
+    pub fn init_store() {
+        run_keyring_blocking(|| match zbus_secret_service_keyring_store::Store::new() {
+            Ok(store) => keyring_core::set_default_store(store),
+            Err(error) => tracing::warn!("Secret Service unavailable; keyring disabled: {error}"),
+        });
+    }
+
+    fn entry(key: &str) -> Result<keyring_core::Entry> {
+        keyring_core::Entry::new(SERVICE_NAME, key)
+            .map_err(|e| anyhow::anyhow!("keyring error: {e}"))
     }
 
     pub fn store_password(profile_id: &str, password: &str) -> Result<()> {
         let key = format!("password:{profile_id}");
-        let entry = Self::entry(&key)?;
-        entry
-            .set_password(password)
-            .map_err(|e| anyhow::anyhow!("failed to store password: {e}"))
+        run_keyring_blocking(|| {
+            let entry = Self::entry(&key)?;
+            entry
+                .set_password(password)
+                .map_err(|e| anyhow::anyhow!("failed to store password: {e}"))
+        })
     }
 
     pub fn get_password(profile_id: &str) -> Result<Option<String>> {
         let key = format!("password:{profile_id}");
-        let entry = Self::entry(&key)?;
-        match entry.get_password() {
-            Ok(pw) => Ok(Some(pw)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(anyhow::anyhow!("failed to get password: {e}")),
-        }
+        run_keyring_blocking(|| {
+            let entry = Self::entry(&key)?;
+            match entry.get_password() {
+                Ok(pw) => Ok(Some(pw)),
+                Err(keyring_core::Error::NoEntry) => Ok(None),
+                Err(e) => Err(anyhow::anyhow!("failed to get password: {e}")),
+            }
+        })
     }
 
     pub fn store_refresh_token(profile_id: &str, token: &str) -> Result<()> {
         let key = format!("refresh-token:{profile_id}");
-        let entry = Self::entry(&key)?;
-        entry
-            .set_password(token)
-            .map_err(|e| anyhow::anyhow!("failed to store refresh token: {e}"))
+        run_keyring_blocking(|| {
+            let entry = Self::entry(&key)?;
+            entry
+                .set_password(token)
+                .map_err(|e| anyhow::anyhow!("failed to store refresh token: {e}"))
+        })
     }
 
     pub fn get_refresh_token(profile_id: &str) -> Result<Option<String>> {
         let key = format!("refresh-token:{profile_id}");
-        let entry = Self::entry(&key)?;
-        match entry.get_password() {
-            Ok(token) => Ok(Some(token)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(anyhow::anyhow!("failed to get refresh token: {e}")),
-        }
+        run_keyring_blocking(|| {
+            let entry = Self::entry(&key)?;
+            match entry.get_password() {
+                Ok(token) => Ok(Some(token)),
+                Err(keyring_core::Error::NoEntry) => Ok(None),
+                Err(e) => Err(anyhow::anyhow!("failed to get refresh token: {e}")),
+            }
+        })
     }
 
     pub fn delete_credentials(profile_id: &str) -> Result<()> {
-        for prefix in &["password", "refresh-token"] {
-            let key = format!("{prefix}:{profile_id}");
-            if let Ok(entry) = Self::entry(&key) {
-                // Ignore NoEntry errors on delete
-                let _ = entry.delete_credential();
+        run_keyring_blocking(|| {
+            for prefix in &["password", "refresh-token"] {
+                let key = format!("{prefix}:{profile_id}");
+                if let Ok(entry) = Self::entry(&key) {
+                    // Ignore NoEntry errors on delete
+                    let _ = entry.delete_credential();
+                }
             }
-        }
+        });
         Ok(())
+    }
+}
+
+/// Run a blocking Secret Service operation without starving the async runtime.
+///
+/// keyring-core's Secret Service store drives D-Bus over zbus's *blocking*
+/// API, which must not run directly on an async worker thread. On a
+/// multi-thread runtime we hand the work to `block_in_place`; off a runtime
+/// (the GTK main thread) we run inline.
+fn run_keyring_blocking<T>(operation: impl FnOnce() -> T) -> T {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(operation)
+        }
+        _ => operation(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // keyring-core's default store is process-global, so register the in-memory
+    // mock store once for the whole test binary. Each test uses a unique profile
+    // id so the shared store can't cross-contaminate across parallel tests.
+    fn with_mock_store() {
+        use std::sync::Once;
+        static MOCK_STORE: Once = Once::new();
+        MOCK_STORE.call_once(|| {
+            keyring_core::set_default_store(keyring_core::mock::Store::new().unwrap());
+        });
+    }
+
+    #[test]
+    fn password_round_trips() {
+        with_mock_store();
+        let profile_id = "test-password-roundtrip";
+        CredentialStore::store_password(profile_id, "hunter2").unwrap();
+        assert_eq!(
+            CredentialStore::get_password(profile_id).unwrap(),
+            Some("hunter2".to_string())
+        );
+    }
+
+    #[test]
+    fn get_password_returns_none_when_absent() {
+        with_mock_store();
+        assert_eq!(
+            CredentialStore::get_password("test-password-absent").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_token_round_trips() {
+        with_mock_store();
+        let profile_id = "test-refresh-roundtrip";
+        CredentialStore::store_refresh_token(profile_id, "refresh-abc").unwrap();
+        assert_eq!(
+            CredentialStore::get_refresh_token(profile_id).unwrap(),
+            Some("refresh-abc".to_string())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use gtk4::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 use crate::async_bridge::spawn_on_runtime;
+use crate::credential_store::CredentialStore;
 use crate::profile::{LastConnectionStore, ProfileStore};
 use crate::widgets::login_screen::{LoginScreen, connect_to_profile};
 
@@ -111,6 +112,8 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
+
+    CredentialStore::init_store();
 
     let cli = CliArgs::parse();
     let _config = ConnectionConfig::from(cli);


### PR DESCRIPTION
## Migrate `adele-gtk` credential store to `keyring-core` 1.0

`keyring 3.x → 4.x` is not a version bump — v4 is a sample CLI app, not a library. This moves the GTK client to **`keyring-core` 1.0** (runtime-registered store) + **`zbus-secret-service-keyring-store`** (`rt-tokio-crypto-rust`; pure-Rust crypto, no libdbus C dep). Mirrors the daemon migration (adelie-ai/desktop-assistant#164 / #149).

### Changes
- `Cargo.toml` — `keyring = "3"` → `keyring-core = "1"` + `zbus-secret-service-keyring-store` (`rt-tokio-crypto-rust`).
- `src/credential_store.rs` — port `Entry`/`Error` to `keyring_core`; add `CredentialStore::init_store()` (best-effort store registration, warns + continues when headless); wrap every credential op in a runtime-aware `run_keyring_blocking`.
- `src/main.rs` — call `CredentialStore::init_store()` once at startup (after tracing init, before building the GTK `Application`).

### Testing
- `cargo test` — all pass, including three new store-path tests against `keyring_core::mock::Store` (password round-trip; absent → `Ok(None)`; refresh-token round-trip).
- `cargo clippy --all-targets` — zero warnings on the changed files. (Pre-existing lints elsewhere are the unrelated adele-gtk#27 drift, left as-is.)
- CVE scan (OSV.dev) of the new dependency set — 0 findings (same versions vetted in desktop-assistant#164).
- **Runtime path verified against a real Secret Service:** unlike the daemon/TUI, the GTK client has no ambient tokio runtime on its glib main thread, where credential ops run. I confirmed empirically that `Store::new()` and a full `store_password → get_password → delete_credentials` round-trip succeed from a non-tokio context (zbus's blocking facade self-manages its executor) — so `rt-tokio-crypto-rust` is correct here and no `rt-async-io` variant is needed.

### Manual verification before merge
⚠️ Reading credentials **previously written by keyring v3**: keyring-core keys on `service` + `username` and the Secret Service matches on attribute subsets, so legacy items should be found — confirm on a real upgrade. Worst case is a one-time re-login.

Closes #37
