### PR TITLE
feat(cli): wire --ws-url/--ws-subject/--transport into startup connection (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ adele-gtk
 
 ### CLI options
 
-| Flag | Env var | Default | Description |
-|------|---------|---------|-------------|
-| `--transport` | `ADELIE_GTK_TRANSPORT` | `ws` | Transport: `ws` or `dbus` |
-| `--ws-url` | `ADELIE_GTK_WS_URL` | `ws://127.0.0.1:11339/ws` | WebSocket URL |
-| `--ws-jwt` | `ADELIE_GTK_WS_JWT` | | Direct JWT token |
-| `--ws-login-username` | `ADELIE_GTK_WS_LOGIN_USERNAME` | | Login username |
-| `--ws-login-password` | `ADELIE_GTK_WS_LOGIN_PASSWORD` | | Login password |
-| `--ws-subject` | `ADELIE_GTK_WS_SUBJECT` | `desktop-tui` | JWT subject |
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--transport` | `ADELIE_GTK_TRANSPORT` | `ws` or `dbus`. `dbus` forces a connection to the local daemon, overriding the saved startup profile. |
+| `--ws-url` | `ADELIE_GTK_WS_URL` | WebSocket URL. Overrides the startup target and bypasses the saved-profile picker. |
+| `--ws-subject` | `ADELIE_GTK_WS_SUBJECT` | JWT subject used with `--ws-url` (defaults to `desktop-tui`). |
+
+When `--ws-url` is given (or `--transport dbus`), it overrides the saved
+auto-reconnect profile so headless/scripted/remote launches work without a
+pre-saved profile; the resulting connection is ephemeral and is not persisted as
+the last connection.
 
 ## Test
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ mod window;
 
 use anyhow::Result;
 use clap::Parser;
-use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 use gtk4::Application;
 use gtk4::glib;
 use gtk4::prelude::*;
@@ -29,12 +28,12 @@ use tracing_subscriber::EnvFilter;
 
 use crate::async_bridge::spawn_on_runtime;
 use crate::credential_store::CredentialStore;
-use crate::profile::{LastConnectionStore, ProfileStore};
+use crate::profile::{
+    ConnectionProfile, LastConnectionStore, ProfileStore, ProtocolConfig, default_ws_subject,
+};
 use crate::widgets::login_screen::{LoginScreen, connect_to_profile};
 
 const APP_ID: &str = "org.adelie.DesktopAssistant";
-const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
-const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 #[value(rename_all = "lower")]
@@ -46,78 +45,77 @@ enum CliTransportMode {
 #[derive(Debug, Parser)]
 #[command(name = "adele-gtk")]
 struct CliArgs {
-    #[arg(
-        long,
-        env = "ADELIE_GTK_TRANSPORT",
-        value_enum,
-        default_value_t = CliTransportMode::Ws
-    )]
-    transport: CliTransportMode,
-    #[arg(
-        long = "ws-url",
-        env = "ADELIE_GTK_WS_URL",
-        default_value = DEFAULT_WS_URL
-    )]
-    ws_url: String,
-    #[arg(
-        long = "ws-subject",
-        env = "ADELIE_GTK_WS_SUBJECT",
-        default_value = DEFAULT_WS_SUBJECT
-    )]
-    ws_subject: String,
-}
-
-impl From<CliArgs> for ConnectionConfig {
-    fn from(cli: CliArgs) -> Self {
-        let ws_url = {
-            let trimmed = cli.ws_url.trim();
-            if trimmed.is_empty() {
-                DEFAULT_WS_URL.to_string()
-            } else {
-                trimmed.to_string()
-            }
-        };
-
-        let ws_subject = {
-            let trimmed = cli.ws_subject.trim();
-            if trimmed.is_empty() {
-                DEFAULT_WS_SUBJECT.to_string()
-            } else {
-                trimmed.to_string()
-            }
-        };
-
-        let transport_mode = match cli.transport {
-            CliTransportMode::Ws => TransportMode::Ws,
-            CliTransportMode::Dbus => TransportMode::Dbus,
-        };
-
-        Self {
-            transport_mode,
-            ws_url,
-            ws_jwt: None,
-            ws_login_username: None,
-            ws_login_password: None,
-            ws_subject,
-            ..Default::default()
-        }
-    }
+    /// Override the startup transport. With `dbus`, connect to the local
+    /// daemon over D-Bus instead of replaying the saved auto-reconnect profile.
+    #[arg(long, env = "ADELIE_GTK_TRANSPORT", value_enum)]
+    transport: Option<CliTransportMode>,
+    /// Override the startup target with this WebSocket URL, bypassing the
+    /// saved-profile picker.
+    #[arg(long = "ws-url", env = "ADELIE_GTK_WS_URL")]
+    ws_url: Option<String>,
+    /// JWT subject to use with `--ws-url` (defaults to the standard subject).
+    #[arg(long = "ws-subject", env = "ADELIE_GTK_WS_SUBJECT")]
+    ws_subject: Option<String>,
 }
 
 /// CLI connection overrides; `None` for a field means the flag was not given.
+#[derive(Clone)]
 struct CliConnectionOverride {
     transport: Option<CliTransportMode>,
     ws_url: Option<String>,
     ws_subject: Option<String>,
 }
 
-/// Resolve the startup connection target. STUB — implemented after the
-/// failing-tests commit (#26).
+impl From<CliArgs> for CliConnectionOverride {
+    fn from(cli: CliArgs) -> Self {
+        Self {
+            transport: cli.transport,
+            ws_url: cli.ws_url,
+            ws_subject: cli.ws_subject,
+        }
+    }
+}
+
+impl CliConnectionOverride {
+    /// Whether any flag was supplied that overrides the saved startup target.
+    /// When false, the saved auto-reconnect profile is used unchanged.
+    fn is_active(&self) -> bool {
+        self.ws_url.is_some() || matches!(self.transport, Some(CliTransportMode::Dbus))
+    }
+}
+
+/// Resolve the startup connection target.
+///
+/// A CLI override takes precedence over the saved auto-reconnect profile so a
+/// headless/scripted/remote launch works without a pre-saved profile:
+/// - `--ws-url` produces an ephemeral WebSocket profile (with `--ws-subject`
+///   or the default subject), bypassing the picker.
+/// - otherwise `--transport dbus` forces the local daemon.
+/// - otherwise the saved `last_active` profile is returned unchanged.
 fn resolve_startup_target(
-    _cli: &CliConnectionOverride,
-    _last_active: Option<profile::ConnectionProfile>,
-) -> Option<profile::ConnectionProfile> {
-    None
+    cli: &CliConnectionOverride,
+    last_active: Option<ConnectionProfile>,
+) -> Option<ConnectionProfile> {
+    if let Some(url) = &cli.ws_url {
+        return Some(ConnectionProfile {
+            id: "cli-override".to_string(),
+            name: "CLI override".to_string(),
+            protocol: ProtocolConfig::Websocket {
+                url: url.clone(),
+                subject: cli.ws_subject.clone().unwrap_or_else(default_ws_subject),
+            },
+        });
+    }
+
+    if matches!(cli.transport, Some(CliTransportMode::Dbus)) {
+        return Some(ConnectionProfile {
+            id: "cli-local".to_string(),
+            name: "CLI override (local)".to_string(),
+            protocol: ProtocolConfig::Local { path: None },
+        });
+    }
+
+    last_active
 }
 
 fn main() -> Result<()> {
@@ -131,22 +129,25 @@ fn main() -> Result<()> {
 
     CredentialStore::init_store();
 
-    let cli = CliArgs::parse();
-    let _config = ConnectionConfig::from(cli);
+    let cli_override = CliConnectionOverride::from(CliArgs::parse());
 
     let app = Application::builder().application_id(APP_ID).build();
 
     app.connect_activate(move |app| {
-        // If a profile was used last time and is still configured, attempt to
-        // silently re-establish that connection. On any failure, fall back to
-        // the connection picker.
+        // Resolve the startup target: a CLI override (--ws-url / --transport
+        // dbus) wins over the saved auto-reconnect profile. On any failure,
+        // fall back to the connection picker.
+        let cli_override = cli_override.clone();
         let app_clone = app.clone();
         // Hold the application active across the async reconnect so it does
         // not shut down before the future creates its first window.
         let hold = app.hold();
         glib::spawn_future_local(async move {
             let _hold = hold;
-            if let Some(profile) = last_active_profile() {
+            // Ephemeral CLI-override profiles must not be persisted as the
+            // last connection; only refresh the marker for real saved profiles.
+            let override_active = cli_override.is_active();
+            if let Some(profile) = resolve_startup_target(&cli_override, last_active_profile()) {
                 let profile_id = profile.id.clone();
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 spawn_on_runtime(async move {
@@ -154,7 +155,9 @@ fn main() -> Result<()> {
                 });
                 match rx.await {
                     Ok(Ok(config)) => {
-                        if let Err(e) = LastConnectionStore::new().set(&profile_id) {
+                        if !override_active
+                            && let Err(e) = LastConnectionStore::new().set(&profile_id)
+                        {
                             tracing::warn!("Failed to refresh last-connection marker: {e}");
                         }
                         let main_win = window::AdelieWindow::new(&app_clone, config);
@@ -192,7 +195,6 @@ fn last_active_profile() -> Option<profile::ConnectionProfile> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profile::{ConnectionProfile, ProtocolConfig, default_ws_subject};
 
     fn ws_profile(id: &str, url: &str) -> ConnectionProfile {
         ConnectionProfile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,22 @@ impl From<CliArgs> for ConnectionConfig {
     }
 }
 
+/// CLI connection overrides; `None` for a field means the flag was not given.
+struct CliConnectionOverride {
+    transport: Option<CliTransportMode>,
+    ws_url: Option<String>,
+    ws_subject: Option<String>,
+}
+
+/// Resolve the startup connection target. STUB — implemented after the
+/// failing-tests commit (#26).
+fn resolve_startup_target(
+    _cli: &CliConnectionOverride,
+    _last_active: Option<profile::ConnectionProfile>,
+) -> Option<profile::ConnectionProfile> {
+    None
+}
+
 fn main() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
@@ -171,4 +187,90 @@ fn last_active_profile() -> Option<profile::ConnectionProfile> {
     let id = LastConnectionStore::new().get()?;
     let profiles = ProfileStore::new().load().ok()?;
     profiles.into_iter().find(|p| p.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::{ConnectionProfile, ProtocolConfig, default_ws_subject};
+
+    fn ws_profile(id: &str, url: &str) -> ConnectionProfile {
+        ConnectionProfile {
+            id: id.to_string(),
+            name: format!("name-{id}"),
+            protocol: ProtocolConfig::Websocket {
+                url: url.to_string(),
+                subject: default_ws_subject(),
+            },
+        }
+    }
+
+    #[test]
+    fn cli_ws_url_override_changes_default_profile_target() {
+        let cli = CliConnectionOverride {
+            transport: None,
+            ws_url: Some("wss://remote/ws".to_string()),
+            ws_subject: None,
+        };
+        let last_active = Some(ws_profile("saved", "ws://127.0.0.1:11339/ws"));
+        let target = resolve_startup_target(&cli, last_active).expect("expected override target");
+        match target.protocol {
+            ProtocolConfig::Websocket { url, subject } => {
+                assert_eq!(url, "wss://remote/ws");
+                assert_eq!(subject, default_ws_subject());
+            }
+            other => panic!("expected websocket override, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_ws_url_override_applies_custom_subject() {
+        let cli = CliConnectionOverride {
+            transport: None,
+            ws_url: Some("wss://remote/ws".to_string()),
+            ws_subject: Some("custom".to_string()),
+        };
+        let target = resolve_startup_target(&cli, None).expect("expected override target");
+        match target.protocol {
+            ProtocolConfig::Websocket { url, subject } => {
+                assert_eq!(url, "wss://remote/ws");
+                assert_eq!(subject, "custom");
+            }
+            other => panic!("expected websocket override, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_override_returns_last_active() {
+        let cli = CliConnectionOverride {
+            transport: None,
+            ws_url: None,
+            ws_subject: None,
+        };
+        let p = ws_profile("saved", "ws://127.0.0.1:11339/ws");
+        let target = resolve_startup_target(&cli, Some(p.clone()));
+        assert_eq!(target, Some(p));
+    }
+
+    #[test]
+    fn no_override_and_no_last_active_returns_none() {
+        let cli = CliConnectionOverride {
+            transport: None,
+            ws_url: None,
+            ws_subject: None,
+        };
+        assert_eq!(resolve_startup_target(&cli, None), None);
+    }
+
+    #[test]
+    fn dbus_transport_override_forces_local() {
+        let cli = CliConnectionOverride {
+            transport: Some(CliTransportMode::Dbus),
+            ws_url: None,
+            ws_subject: None,
+        };
+        let last_active = Some(ws_profile("saved", "ws://127.0.0.1:11339/ws"));
+        let target = resolve_startup_target(&cli, last_active).expect("expected local override");
+        assert_eq!(target.protocol, ProtocolConfig::Local { path: None });
+    }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -37,7 +37,7 @@ pub struct ConnectionProfile {
     pub protocol: ProtocolConfig,
 }
 
-fn default_ws_subject() -> String {
+pub fn default_ws_subject() -> String {
     "desktop-tui".to_string()
 }
 


### PR DESCRIPTION
Closes #26.

## Problem
`main()` parsed the CLI into a `ConnectionConfig` and then dropped it (`let _config = ...`), so `--transport` / `--ws-url` / `--ws-subject` had no effect. The README additionally documented three flags (`--ws-jwt`, `--ws-login-username`, `--ws-login-password`) that were never defined in `CliArgs`.

The maintainer decided to **wire the flags** (not delete them).

## Design
Introduces a pure, unit-testable resolver in `src/main.rs`:

```rust
fn resolve_startup_target(
    cli: &CliConnectionOverride,
    last_active: Option<ConnectionProfile>,
) -> Option<ConnectionProfile>
```

Semantics:
- `--ws-url` → ephemeral `Websocket` profile (`id: "cli-override"`) using `--ws-subject` or `default_ws_subject()`; overrides the saved profile and bypasses the picker.
- else `--transport dbus` → ephemeral `Local { path: None }` profile (`id: "cli-local"`), forcing the local daemon.
- else → the saved `last_active` profile, unchanged (current behavior).

`main()` builds a `CliConnectionOverride`, resolves the target, runs the existing `connect_to_profile` path, and **guards `LastConnectionStore::set`** so ephemeral CLI-override targets are never persisted as the last connection. `CliArgs` fields are now `Option<…>` (no `default_value`, `env=` kept) so flag absence is detectable.

Removed the dead `From<CliArgs> for ConnectionConfig` impl and the now-unused `DEFAULT_WS_URL` / `DEFAULT_WS_SUBJECT` consts; exposed `profile::default_ws_subject`.

## Tests (TDD — failing tests landed first)
Five named unit tests (no GTK needed):
- `cli_ws_url_override_changes_default_profile_target`
- `cli_ws_url_override_applies_custom_subject`
- `no_override_returns_last_active`
- `no_override_and_no_last_active_returns_none`
- `dbus_transport_override_forces_local`

## README
Fixed the flags table to match reality: removed the three non-existent flags, documented the real override behavior, and added a prose note that the override connection is ephemeral and not persisted.

## Verification
- `cargo fmt -p adele-gtk -- --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0
- `cargo build --all-targets` → ok
- `cargo test` → 78 passed, 0 failed (includes the 5 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)