### PR TITLE
feat: multi-connection Connections + Purposes config UI (#1)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -58,6 +58,15 @@ pub enum UiMessage {
         conversation_id: String,
         title: String,
     },
+    /// A one-time advisory for a conversation emitted as a live signal
+    /// (today only `DanglingModelSelection`: the stored model selection no
+    /// longer resolves and was cleared server-side). Drives a passive toast
+    /// in the window. Replaces the earlier lossy `StatusUpdate`-string
+    /// mapping so the handler can act on the typed warning.
+    ConversationWarning {
+        conversation_id: String,
+        warning: api::ConversationWarning,
+    },
     /// The wire ack carries a `task_id` (post-#114 `SendMessageAck`) or an
     /// empty string (legacy `Ack`). It is NOT the chunk-stream
     /// `request_id` — that is server-generated and arrives embedded in
@@ -338,7 +347,10 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
         SignalEvent::ConversationWarning {
             conversation_id,
             warning,
-        } => UiMessage::StatusUpdate(format!("Conversation {conversation_id}: {warning:?}")),
+        } => UiMessage::ConversationWarning {
+            conversation_id,
+            warning,
+        },
         SignalEvent::TaskStarted { task } => UiMessage::TaskStarted(task),
         SignalEvent::TaskProgress { id, progress_hint } => {
             UiMessage::TaskProgress { id, progress_hint }
@@ -449,6 +461,38 @@ mod tests {
                 assert_eq!(chunk, "hello");
             }
             other => panic!("expected StreamChunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signal_conversation_warning_routes_to_typed_ui_warning() {
+        let prev = api::ConversationModelSelectionView {
+            connection_id: "old".to_string(),
+            model_id: "gone".to_string(),
+            effort: None,
+        };
+        let fallback = api::ConversationModelSelectionView {
+            connection_id: "work".to_string(),
+            model_id: "claude".to_string(),
+            effort: None,
+        };
+        let warning = api::ConversationWarning::DanglingModelSelection {
+            previous_selection: prev,
+            fallback_to: fallback,
+        };
+        let msg = signal_to_ui_message(SignalEvent::ConversationWarning {
+            conversation_id: "conv-1".to_string(),
+            warning: warning.clone(),
+        });
+        match msg {
+            UiMessage::ConversationWarning {
+                conversation_id,
+                warning: got,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(got, warning);
+            }
+            other => panic!("expected ConversationWarning, got {other:?}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 mod async_bridge;
 mod avatars;
 mod credential_store;
+mod management_client;
 mod markdown;
 mod oauth;
 mod profile;

--- a/src/management_client.rs
+++ b/src/management_client.rs
@@ -13,7 +13,9 @@ use desktop_assistant_client_common::{AssistantCommands, TransportClient};
 
 /// Resolve the WebSocket client, erroring on transports that can't carry
 /// these management commands (D-Bus).
-fn ws(transport: &TransportClient) -> Result<&desktop_assistant_client_common::ws_client::WsClient> {
+fn ws(
+    transport: &TransportClient,
+) -> Result<&desktop_assistant_client_common::ws_client::WsClient> {
     transport
         .as_ws()
         .ok_or_else(|| anyhow!("named-connection management requires a WebSocket transport"))
@@ -36,7 +38,9 @@ pub async fn list_connections(transport: &TransportClient) -> Result<Vec<api::Co
         .await?;
     match result {
         api::CommandResult::Connections(list) => Ok(list),
-        other => Err(anyhow!("unexpected response for ListConnections: {other:?}")),
+        other => Err(anyhow!(
+            "unexpected response for ListConnections: {other:?}"
+        )),
     }
 }
 
@@ -62,11 +66,7 @@ pub async fn update_connection(
     expect_ack("UpdateConnection", result)
 }
 
-pub async fn delete_connection(
-    transport: &TransportClient,
-    id: String,
-    force: bool,
-) -> Result<()> {
+pub async fn delete_connection(transport: &TransportClient, id: String, force: bool) -> Result<()> {
     let result = ws(transport)?
         .send_command(api::Command::DeleteConnection { id, force })
         .await?;

--- a/src/management_client.rs
+++ b/src/management_client.rs
@@ -1,0 +1,143 @@
+//! Thin wrappers over the live `TransportClient` for named-connection and
+//! purpose management commands (Settings dialog).
+//!
+//! These use the WebSocket connection's `send_command` escape hatch (the
+//! `AssistantCommands` trait), which the D-Bus surface doesn't expose — the
+//! Settings dialog is WS-only, matching the per-conversation model picker.
+//! Each wrapper returns a typed result so callers don't pattern-match the
+//! protocol envelope.
+
+use anyhow::{Result, anyhow};
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::{AssistantCommands, TransportClient};
+
+/// Resolve the WebSocket client, erroring on transports that can't carry
+/// these management commands (D-Bus).
+fn ws(transport: &TransportClient) -> Result<&desktop_assistant_client_common::ws_client::WsClient> {
+    transport
+        .as_ws()
+        .ok_or_else(|| anyhow!("named-connection management requires a WebSocket transport"))
+}
+
+/// Coerce a `CommandResult` that should be a bare `Ack` into `()`, turning
+/// any other variant into a descriptive error. Shared by the mutating
+/// wrappers so the "unexpected response" arm is uniform and unit-testable
+/// without a live transport. `command` names the command for the message.
+fn expect_ack(command: &str, result: api::CommandResult) -> Result<()> {
+    match result {
+        api::CommandResult::Ack => Ok(()),
+        other => Err(anyhow!("unexpected response for {command}: {other:?}")),
+    }
+}
+
+pub async fn list_connections(transport: &TransportClient) -> Result<Vec<api::ConnectionView>> {
+    let result = ws(transport)?
+        .send_command(api::Command::ListConnections)
+        .await?;
+    match result {
+        api::CommandResult::Connections(list) => Ok(list),
+        other => Err(anyhow!("unexpected response for ListConnections: {other:?}")),
+    }
+}
+
+pub async fn create_connection(
+    transport: &TransportClient,
+    id: String,
+    config: api::ConnectionConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::CreateConnection { id, config })
+        .await?;
+    expect_ack("CreateConnection", result)
+}
+
+pub async fn update_connection(
+    transport: &TransportClient,
+    id: String,
+    config: api::ConnectionConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::UpdateConnection { id, config })
+        .await?;
+    expect_ack("UpdateConnection", result)
+}
+
+pub async fn delete_connection(
+    transport: &TransportClient,
+    id: String,
+    force: bool,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::DeleteConnection { id, force })
+        .await?;
+    expect_ack("DeleteConnection", result)
+}
+
+pub async fn list_available_models(
+    transport: &TransportClient,
+    connection_id: Option<String>,
+    refresh: bool,
+) -> Result<Vec<api::ModelListing>> {
+    let result = ws(transport)?
+        .send_command(api::Command::ListAvailableModels {
+            connection_id,
+            refresh,
+        })
+        .await?;
+    match result {
+        api::CommandResult::Models(m) => Ok(m),
+        other => Err(anyhow!(
+            "unexpected response for ListAvailableModels: {other:?}"
+        )),
+    }
+}
+
+pub async fn get_purposes(transport: &TransportClient) -> Result<api::PurposesView> {
+    let result = ws(transport)?
+        .send_command(api::Command::GetPurposes)
+        .await?;
+    match result {
+        api::CommandResult::Purposes(p) => Ok(p),
+        other => Err(anyhow!("unexpected response for GetPurposes: {other:?}")),
+    }
+}
+
+pub async fn set_purpose(
+    transport: &TransportClient,
+    purpose: api::PurposeKindApi,
+    config: api::PurposeConfigView,
+) -> Result<()> {
+    let result = ws(transport)?
+        .send_command(api::Command::SetPurpose { purpose, config })
+        .await?;
+    expect_ack("SetPurpose", result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GTK-free smoke test for a wrapper error arm: when the daemon answers a
+    /// mutating command with something other than `Ack`, the wrapper must
+    /// surface a descriptive error naming the command rather than silently
+    /// succeeding. `Connections(..)` stands in for any non-`Ack` envelope.
+    #[test]
+    fn expect_ack_rejects_non_ack_response() {
+        let err = expect_ack("CreateConnection", api::CommandResult::Connections(vec![]))
+            .expect_err("non-Ack response must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CreateConnection"),
+            "error should name the command: {msg}"
+        );
+        assert!(
+            msg.contains("unexpected response"),
+            "error should flag the unexpected envelope: {msg}"
+        );
+    }
+
+    #[test]
+    fn expect_ack_passes_through_ack() {
+        assert!(expect_ack("SetPurpose", api::CommandResult::Ack).is_ok());
+    }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -60,6 +60,13 @@ window {
     font-size: 12px;
 }
 
+/* Advisory toast (e.g. a dangling model selection cleared by the daemon). */
+.toast-row {
+    background-color: #2a2e45;
+    border-radius: 6px;
+    color: #e0e0e0;
+}
+
 .debug-check {
     color: #e0e0e0;
     margin-end: 12px;

--- a/src/widgets/connection_config_dialog.rs
+++ b/src/widgets/connection_config_dialog.rs
@@ -37,6 +37,11 @@ impl ConnectorType {
         }
     }
 
+    /// Inverse of [`Self::from_slug`]. Only exercised by the round-trip
+    /// test today (the daemon supplies connector-type strings directly),
+    /// so it's gated to test builds to avoid a dead-code warning while
+    /// keeping the round-trip assertion meaningful.
+    #[cfg(test)]
     pub fn slug(self) -> &'static str {
         match self {
             Self::Anthropic => "anthropic",

--- a/src/widgets/connection_config_dialog.rs
+++ b/src/widgets/connection_config_dialog.rs
@@ -1,0 +1,416 @@
+//! Per-connector-type Configure dialog.
+//!
+//! Each connector variant has its own field set (Anthropic / OpenAI use an
+//! API-key-env-var + base_url; Bedrock uses AWS profile/region and has a
+//! "Refresh models" escape hatch; Ollama is just base_url). The dialog
+//! produces a `(id, ConnectionConfigView)` pair that the caller submits via
+//! `CreateConnection` or `UpdateConnection`.
+//!
+//! Credentials: the API model carries only the *name* of the env var that
+//! holds the API key. Storing the actual secret is out of scope for the
+//! dialog — the user is expected to set the env var externally (or have
+//! their OS keyring forward it). The field is labelled accordingly.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, Button, Entry, Label, Orientation, Separator, Window};
+
+/// Which connector type this dialog is configuring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectorType {
+    Anthropic,
+    OpenAi,
+    Bedrock,
+    Ollama,
+}
+
+impl ConnectorType {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Anthropic => "Anthropic",
+            Self::OpenAi => "OpenAI",
+            Self::Bedrock => "Bedrock",
+            Self::Ollama => "Ollama",
+        }
+    }
+
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+            Self::Bedrock => "bedrock",
+            Self::Ollama => "ollama",
+        }
+    }
+
+    pub fn from_slug(s: &str) -> Option<Self> {
+        match s {
+            "anthropic" => Some(Self::Anthropic),
+            "openai" => Some(Self::OpenAi),
+            "bedrock" => Some(Self::Bedrock),
+            "ollama" => Some(Self::Ollama),
+            _ => None,
+        }
+    }
+
+    pub fn empty_config(self) -> api::ConnectionConfigView {
+        match self {
+            Self::Anthropic => api::ConnectionConfigView::Anthropic {
+                base_url: None,
+                api_key_env: None,
+            },
+            Self::OpenAi => api::ConnectionConfigView::OpenAi {
+                base_url: None,
+                api_key_env: None,
+            },
+            Self::Bedrock => api::ConnectionConfigView::Bedrock {
+                aws_profile: None,
+                region: None,
+                base_url: None,
+            },
+            Self::Ollama => api::ConnectionConfigView::Ollama { base_url: None },
+        }
+    }
+}
+
+/// Sanitize a text entry into `Option<String>`, trimming and treating the
+/// empty string as `None`.
+fn text_opt(entry: &Entry) -> Option<String> {
+    let t = entry.text().trim().to_string();
+    if t.is_empty() { None } else { Some(t) }
+}
+
+/// Show the Configure dialog. `existing` distinguishes edit (Some) from
+/// create (None). `on_save` is called with the final `(id, config)` pair
+/// when the user clicks Save; the dialog closes on its own.
+///
+/// `on_refresh_models` is invoked for Bedrock's "Refresh models" button;
+/// only meaningful for Bedrock — it's a best-effort affordance and the
+/// dialog doesn't display the returned list.
+pub fn show_configure_dialog<FSave, FRefresh>(
+    parent: &impl IsA<Window>,
+    connector: ConnectorType,
+    existing: Option<(String, api::ConnectionConfigView)>,
+    on_save: FSave,
+    on_refresh_models: FRefresh,
+) where
+    FSave: Fn(String, api::ConnectionConfigView) + 'static,
+    FRefresh: Fn(String) + 'static,
+{
+    let title = match &existing {
+        Some((id, _)) => format!("Edit {} connection: {id}", connector.label()),
+        None => format!("Add {} connection", connector.label()),
+    };
+
+    let dialog = Window::builder()
+        .title(&title)
+        .default_width(440)
+        .default_height(320)
+        .modal(true)
+        .transient_for(parent)
+        .build();
+
+    let content = GtkBox::new(Orientation::Vertical, 10);
+    content.set_margin_start(20);
+    content.set_margin_end(20);
+    content.set_margin_top(20);
+    content.set_margin_bottom(20);
+
+    // Connection id.
+    let id_label = Label::new(Some("Connection id (slug)"));
+    id_label.set_halign(Align::Start);
+    content.append(&id_label);
+
+    let id_entry = Entry::new();
+    id_entry.set_placeholder_text(Some("e.g. work, aws-prod, local"));
+    if let Some((id, _)) = &existing {
+        id_entry.set_text(id);
+        id_entry.set_sensitive(false);
+    }
+    content.append(&id_entry);
+
+    content.append(&Separator::new(Orientation::Horizontal));
+
+    // Per-connector field map: we track entries by name in a Vec so the
+    // save-handler can pick them up regardless of which variant is shown.
+    #[derive(Clone)]
+    struct Field {
+        name: &'static str,
+        entry: Entry,
+    }
+    let fields: Rc<RefCell<Vec<Field>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let add_field = |label_text: &str,
+                     name: &'static str,
+                     placeholder: Option<&str>,
+                     initial: Option<&str>,
+                     secret: bool| {
+        let lab = Label::new(Some(label_text));
+        lab.set_halign(Align::Start);
+        content.append(&lab);
+        let entry = Entry::new();
+        if let Some(p) = placeholder {
+            entry.set_placeholder_text(Some(p));
+        }
+        if secret {
+            entry.set_visibility(false);
+        }
+        if let Some(v) = initial {
+            entry.set_text(v);
+        }
+        content.append(&entry);
+        fields.borrow_mut().push(Field {
+            name,
+            entry: entry.clone(),
+        });
+    };
+
+    let existing_config = existing.as_ref().map(|(_, c)| c.clone());
+    match connector {
+        ConnectorType::Anthropic => {
+            let (base_url, api_key_env) = match &existing_config {
+                Some(api::ConnectionConfigView::Anthropic {
+                    base_url,
+                    api_key_env,
+                }) => (base_url.clone(), api_key_env.clone()),
+                _ => (None, None),
+            };
+            add_field(
+                "Base URL (optional override)",
+                "base_url",
+                Some("https://api.anthropic.com"),
+                base_url.as_deref(),
+                false,
+            );
+            add_field(
+                "API key env var (e.g. ANTHROPIC_API_KEY)",
+                "api_key_env",
+                Some("ANTHROPIC_API_KEY"),
+                api_key_env.as_deref(),
+                false,
+            );
+            let hint = Label::new(Some(
+                "The daemon reads the API key from the named env var. Set it in your daemon environment (systemd unit, shell, etc.).",
+            ));
+            hint.set_halign(Align::Start);
+            hint.set_wrap(true);
+            hint.add_css_class("dim-label");
+            content.append(&hint);
+        }
+        ConnectorType::OpenAi => {
+            let (base_url, api_key_env) = match &existing_config {
+                Some(api::ConnectionConfigView::OpenAi {
+                    base_url,
+                    api_key_env,
+                }) => (base_url.clone(), api_key_env.clone()),
+                _ => (None, None),
+            };
+            add_field(
+                "Base URL (for OpenAI-compatible providers)",
+                "base_url",
+                Some("https://api.openai.com/v1"),
+                base_url.as_deref(),
+                false,
+            );
+            add_field(
+                "API key env var (e.g. OPENAI_API_KEY)",
+                "api_key_env",
+                Some("OPENAI_API_KEY"),
+                api_key_env.as_deref(),
+                false,
+            );
+            let hint = Label::new(Some(
+                "The daemon reads the API key from the named env var. Set it in your daemon environment.",
+            ));
+            hint.set_halign(Align::Start);
+            hint.set_wrap(true);
+            hint.add_css_class("dim-label");
+            content.append(&hint);
+        }
+        ConnectorType::Bedrock => {
+            let (aws_profile, region, base_url) = match &existing_config {
+                Some(api::ConnectionConfigView::Bedrock {
+                    aws_profile,
+                    region,
+                    base_url,
+                }) => (aws_profile.clone(), region.clone(), base_url.clone()),
+                _ => (None, None, None),
+            };
+            add_field(
+                "AWS profile (optional)",
+                "aws_profile",
+                Some("default"),
+                aws_profile.as_deref(),
+                false,
+            );
+            add_field(
+                "Region",
+                "region",
+                Some("us-west-2"),
+                region.as_deref(),
+                false,
+            );
+            add_field(
+                "Base URL override (optional)",
+                "base_url",
+                None,
+                base_url.as_deref(),
+                false,
+            );
+        }
+        ConnectorType::Ollama => {
+            let base_url = match &existing_config {
+                Some(api::ConnectionConfigView::Ollama { base_url }) => base_url.clone(),
+                _ => None,
+            };
+            add_field(
+                "Base URL",
+                "base_url",
+                Some("http://localhost:11434"),
+                base_url.as_deref(),
+                false,
+            );
+        }
+    }
+
+    // Bedrock-only: "Refresh models" button. Only useful when editing (we
+    // need a valid id) — the handler saves first, then refreshes.
+    if connector == ConnectorType::Bedrock {
+        content.append(&Separator::new(Orientation::Horizontal));
+        let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+        let refresh_btn = Button::with_label("Refresh models");
+        refresh_btn.set_tooltip_text(Some(
+            "Re-query Bedrock's ListFoundationModels and update the cached model list.",
+        ));
+        let note = Label::new(Some("(Saves first, then refreshes.)"));
+        note.add_css_class("dim-label");
+        btn_row.append(&refresh_btn);
+        btn_row.append(&note);
+        content.append(&btn_row);
+
+        let id_entry_ref = id_entry.clone();
+        let refresh_cb = Rc::new(on_refresh_models);
+        refresh_btn.connect_clicked(move |_| {
+            let id = id_entry_ref.text().trim().to_string();
+            if id.is_empty() {
+                return;
+            }
+            refresh_cb(id);
+        });
+    }
+
+    content.append(&Separator::new(Orientation::Horizontal));
+
+    let status = Label::new(None);
+    status.add_css_class("status-bar");
+    status.set_halign(Align::Start);
+    content.append(&status);
+
+    let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+    btn_box.set_halign(Align::End);
+    btn_box.set_margin_top(4);
+
+    let cancel_btn = Button::with_label("Cancel");
+    btn_box.append(&cancel_btn);
+
+    let save_btn = Button::with_label("Save");
+    save_btn.add_css_class("suggested-action");
+    btn_box.append(&save_btn);
+
+    content.append(&btn_box);
+    dialog.set_child(Some(&content));
+
+    let dialog_ref = dialog.clone();
+    cancel_btn.connect_clicked(move |_| dialog_ref.close());
+
+    let save_cb = Rc::new(on_save);
+    let dialog_ref = dialog.clone();
+    let fields_for_save = Rc::clone(&fields);
+    save_btn.connect_clicked(move |_| {
+        let id = id_entry.text().trim().to_string();
+        if id.is_empty() {
+            status.set_text("Connection id is required");
+            return;
+        }
+        if !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            status.set_text("Id may only contain letters, digits, '-', and '_'");
+            return;
+        }
+
+        let by_name = |n: &str| -> Option<String> {
+            fields_for_save
+                .borrow()
+                .iter()
+                .find(|f| f.name == n)
+                .and_then(|f| text_opt(&f.entry))
+        };
+
+        let config = match connector {
+            ConnectorType::Anthropic => api::ConnectionConfigView::Anthropic {
+                base_url: by_name("base_url"),
+                api_key_env: by_name("api_key_env"),
+            },
+            ConnectorType::OpenAi => api::ConnectionConfigView::OpenAi {
+                base_url: by_name("base_url"),
+                api_key_env: by_name("api_key_env"),
+            },
+            ConnectorType::Bedrock => api::ConnectionConfigView::Bedrock {
+                aws_profile: by_name("aws_profile"),
+                region: by_name("region"),
+                base_url: by_name("base_url"),
+            },
+            ConnectorType::Ollama => api::ConnectionConfigView::Ollama {
+                base_url: by_name("base_url"),
+            },
+        };
+
+        save_cb(id, config);
+        dialog_ref.close();
+    });
+
+    dialog.present();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connector_slug_roundtrip() {
+        for c in [
+            ConnectorType::Anthropic,
+            ConnectorType::OpenAi,
+            ConnectorType::Bedrock,
+            ConnectorType::Ollama,
+        ] {
+            assert_eq!(ConnectorType::from_slug(c.slug()), Some(c));
+        }
+        assert_eq!(ConnectorType::from_slug("unknown"), None);
+    }
+
+    #[test]
+    fn empty_config_has_correct_variant() {
+        assert!(matches!(
+            ConnectorType::Anthropic.empty_config(),
+            api::ConnectionConfigView::Anthropic { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::Bedrock.empty_config(),
+            api::ConnectionConfigView::Bedrock { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::Ollama.empty_config(),
+            api::ConnectionConfigView::Ollama { .. }
+        ));
+        assert!(matches!(
+            ConnectorType::OpenAi.empty_config(),
+            api::ConnectionConfigView::OpenAi { .. }
+        ));
+    }
+}

--- a/src/widgets/connection_config_dialog.rs
+++ b/src/widgets/connection_config_dialog.rs
@@ -105,6 +105,7 @@ pub fn show_configure_dialog<FSave, FRefresh>(
     FSave: Fn(String, api::ConnectionConfigView) + 'static,
     FRefresh: Fn(String) + 'static,
 {
+    let is_edit = existing.is_some();
     let title = match &existing {
         Some((id, _)) => format!("Edit {} connection: {id}", connector.label()),
         None => format!("Add {} connection", connector.label()),
@@ -136,6 +137,20 @@ pub fn show_configure_dialog<FSave, FRefresh>(
         id_entry.set_sensitive(false);
     }
     content.append(&id_entry);
+
+    // Stopgap warning (edit only): the daemon's `ConnectionView` doesn't echo
+    // non-secret config back, so we pre-fill an empty config and `Update` is a
+    // full replace. Until the daemon echoes config, saving an edit without
+    // re-entering every field silently wipes the omitted ones.
+    if is_edit {
+        let edit_warning = Label::new(Some(
+            "Editing replaces all fields — re-enter any you want to keep.",
+        ));
+        edit_warning.set_halign(Align::Start);
+        edit_warning.set_wrap(true);
+        edit_warning.add_css_class("dim-label");
+        content.append(&edit_warning);
+    }
 
     content.append(&Separator::new(Orientation::Horizontal));
 
@@ -281,16 +296,18 @@ pub fn show_configure_dialog<FSave, FRefresh>(
         }
     }
 
-    // Bedrock-only: "Refresh models" button. Only useful when editing (we
-    // need a valid id) — the handler saves first, then refreshes.
-    if connector == ConnectorType::Bedrock {
+    // Bedrock-only: "Refresh models" button. Only meaningful when editing an
+    // existing connection (the Add path has nothing saved to refresh and wires
+    // a no-op callback), so only show it there. Refresh calls the refresh
+    // callback directly — it does NOT save the dialog's current fields.
+    if connector == ConnectorType::Bedrock && is_edit {
         content.append(&Separator::new(Orientation::Horizontal));
         let btn_row = GtkBox::new(Orientation::Horizontal, 8);
         let refresh_btn = Button::with_label("Refresh models");
         refresh_btn.set_tooltip_text(Some(
             "Re-query Bedrock's ListFoundationModels and update the cached model list.",
         ));
-        let note = Label::new(Some("(Saves first, then refreshes.)"));
+        let note = Label::new(Some("(Refreshes the model list for the saved connection.)"));
         note.add_css_class("dim-label");
         btn_row.append(&refresh_btn);
         btn_row.append(&note);

--- a/src/widgets/connections_tab.rs
+++ b/src/widgets/connections_tab.rs
@@ -1,0 +1,220 @@
+//! Connections tab of the Settings dialog.
+//!
+//! Shows the live list of configured connections (`ListConnections`) with
+//! Add / Configure / Remove. The tab is a passive view — it asks the
+//! parent to perform the actual RPC work via callbacks. The parent (the
+//! Settings dialog) owns the `TransportClient` and the async bridge.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, MenuButton, Orientation, Popover,
+    ScrolledWindow, SelectionMode, Separator,
+};
+
+use super::connection_config_dialog::ConnectorType;
+
+type AddConnectionCb = Box<dyn Fn(ConnectorType)>;
+type ConnectionActionCb = Box<dyn Fn(String)>;
+
+pub struct ConnectionsTab {
+    pub container: GtkBox,
+    list_box: ListBox,
+    connections: Rc<RefCell<Vec<api::ConnectionView>>>,
+    on_add: Rc<RefCell<Option<AddConnectionCb>>>,
+    on_configure: Rc<RefCell<Option<ConnectionActionCb>>>,
+    on_remove: Rc<RefCell<Option<ConnectionActionCb>>>,
+}
+
+impl ConnectionsTab {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 8);
+        container.set_margin_start(12);
+        container.set_margin_end(12);
+        container.set_margin_top(12);
+        container.set_margin_bottom(12);
+
+        // Header row: title + Add menu.
+        let header = GtkBox::new(Orientation::Horizontal, 6);
+        let title = Label::new(Some("Connections"));
+        title.add_css_class("heading");
+        title.set_halign(Align::Start);
+        title.set_hexpand(true);
+        header.append(&title);
+
+        let add_button = MenuButton::new();
+        add_button.set_label("Add");
+        add_button.add_css_class("suggested-action");
+
+        let popover = Popover::new();
+        popover.add_css_class("context-popover");
+        let popover_box = GtkBox::new(Orientation::Vertical, 0);
+
+        let on_add: Rc<RefCell<Option<AddConnectionCb>>> = Rc::new(RefCell::new(None));
+        for connector in [
+            ConnectorType::Anthropic,
+            ConnectorType::OpenAi,
+            ConnectorType::Bedrock,
+            ConnectorType::Ollama,
+        ] {
+            let btn = Button::with_label(connector.label());
+            btn.add_css_class("context-button");
+            btn.set_halign(Align::Fill);
+            let on_add_inner = Rc::clone(&on_add);
+            let popover_ref = popover.clone();
+            btn.connect_clicked(move |_| {
+                popover_ref.popdown();
+                if let Some(ref cb) = *on_add_inner.borrow() {
+                    cb(connector);
+                }
+            });
+            popover_box.append(&btn);
+        }
+        popover.set_child(Some(&popover_box));
+        add_button.set_popover(Some(&popover));
+        header.append(&add_button);
+
+        container.append(&header);
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        let scrolled = ScrolledWindow::new();
+        scrolled.set_vexpand(true);
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(SelectionMode::None);
+        list_box.add_css_class("connections-list");
+        scrolled.set_child(Some(&list_box));
+        container.append(&scrolled);
+
+        Self {
+            container,
+            list_box,
+            connections: Rc::new(RefCell::new(Vec::new())),
+            on_add,
+            on_configure: Rc::new(RefCell::new(None)),
+            on_remove: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    pub fn connect_add<F>(&self, f: F)
+    where
+        F: Fn(ConnectorType) + 'static,
+    {
+        *self.on_add.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_configure<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_configure.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_remove<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_remove.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Fetch the live view for a given id, if currently loaded.
+    pub fn find(&self, id: &str) -> Option<api::ConnectionView> {
+        self.connections
+            .borrow()
+            .iter()
+            .find(|c| c.id == id)
+            .cloned()
+    }
+
+    /// Replace the list contents.
+    pub fn set_connections(&self, connections: &[api::ConnectionView]) {
+        while let Some(child) = self.list_box.first_child() {
+            self.list_box.remove(&child);
+        }
+        *self.connections.borrow_mut() = connections.to_vec();
+
+        if connections.is_empty() {
+            let row = ListBoxRow::new();
+            row.set_selectable(false);
+            let placeholder =
+                Label::new(Some("No connections configured. Click Add to create one."));
+            placeholder.add_css_class("dim-label");
+            placeholder.set_margin_start(12);
+            placeholder.set_margin_end(12);
+            placeholder.set_margin_top(12);
+            placeholder.set_margin_bottom(12);
+            row.set_child(Some(&placeholder));
+            self.list_box.append(&row);
+            return;
+        }
+
+        for conn in connections {
+            let row = self.build_row(conn);
+            self.list_box.append(&row);
+        }
+    }
+
+    fn build_row(&self, conn: &api::ConnectionView) -> ListBoxRow {
+        let row = ListBoxRow::new();
+        row.set_selectable(false);
+
+        let hbox = GtkBox::new(Orientation::Horizontal, 12);
+        hbox.set_margin_start(10);
+        hbox.set_margin_end(10);
+        hbox.set_margin_top(8);
+        hbox.set_margin_bottom(8);
+
+        let text_col = GtkBox::new(Orientation::Vertical, 2);
+        text_col.set_hexpand(true);
+
+        let title = Label::new(Some(&format!("{}  ({})", conn.id, conn.connector_type)));
+        title.set_halign(Align::Start);
+        title.add_css_class("heading");
+        text_col.append(&title);
+
+        let availability_text = match &conn.availability {
+            api::ConnectionAvailability::Ok => "Available".to_string(),
+            api::ConnectionAvailability::Unavailable { reason } => {
+                format!("Unavailable: {reason}")
+            }
+        };
+        let creds_text = if conn.has_credentials {
+            "credentials: present"
+        } else {
+            "credentials: missing"
+        };
+        let subtitle = Label::new(Some(&format!("{availability_text} · {creds_text}")));
+        subtitle.set_halign(Align::Start);
+        subtitle.add_css_class("dim-label");
+        text_col.append(&subtitle);
+
+        hbox.append(&text_col);
+
+        let configure_btn = Button::with_label("Configure");
+        let on_configure = Rc::clone(&self.on_configure);
+        let id_for_configure = conn.id.clone();
+        configure_btn.connect_clicked(move |_| {
+            if let Some(ref cb) = *on_configure.borrow() {
+                cb(id_for_configure.clone());
+            }
+        });
+        hbox.append(&configure_btn);
+
+        let remove_btn = Button::with_label("Remove");
+        remove_btn.add_css_class("destructive-action");
+        let on_remove = Rc::clone(&self.on_remove);
+        let id_for_remove = conn.id.clone();
+        remove_btn.connect_clicked(move |_| {
+            if let Some(ref cb) = *on_remove.borrow() {
+                cb(id_for_remove.clone());
+            }
+        });
+        hbox.append(&remove_btn);
+
+        row.set_child(Some(&hbox));
+        row
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,9 +1,13 @@
 pub mod chat_view;
+pub mod connection_config_dialog;
+pub mod connections_tab;
 pub mod input_bar;
 pub mod knowledge_browser;
 pub mod login_screen;
 pub mod model_picker;
+pub mod purposes_tab;
 pub mod select_models_dialog;
+pub mod settings_dialog;
 pub mod setup_dialog;
 pub mod sidebar;
 pub mod tasks_panel;

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -1,0 +1,426 @@
+//! Purposes tab of the Settings dialog.
+//!
+//! Flat list of `(Purpose) (Connection ▾) (Model ▾) (Effort ▾)` for every
+//! configured purpose. Interactive must bind to a real connection and
+//! model; non-interactive purposes may use the sentinel string `"primary"`
+//! to inherit from the interactive purpose.
+//!
+//! The tab owns the dropdown rows. The parent (Settings dialog) supplies
+//! the list of connections, the per-connection models, and is called back
+//! on `SetPurpose` writes. Re-hydration after a write is the parent's
+//! job — the tab simply re-binds whenever `set_*` is invoked.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, DropDown, Label, Orientation, Separator, StringList};
+
+type SetPurposeCb = Box<dyn Fn(api::PurposeKindApi, api::PurposeConfigView)>;
+type RequestModelsCb = Box<dyn Fn(String)>;
+
+const PRIMARY_SENTINEL: &str = "primary";
+
+fn purpose_label(p: api::PurposeKindApi) -> &'static str {
+    match p {
+        api::PurposeKindApi::Interactive => "Interactive",
+        api::PurposeKindApi::Dreaming => "Dreaming",
+        api::PurposeKindApi::Embedding => "Embedding",
+        api::PurposeKindApi::Titling => "Titling",
+    }
+}
+
+/// Ephemeral UI state for each row.
+struct Row {
+    connection_dd: DropDown,
+    connection_list: StringList,
+    /// Mirror of the dropdown's string list in the same index order:
+    /// either a connection id or the `"primary"` sentinel. Kept separately
+    /// so we can map dropdown index → value without re-reading the gtk
+    /// model.
+    connection_values: Rc<RefCell<Vec<String>>>,
+    model_dd: DropDown,
+    model_list: StringList,
+    model_values: Rc<RefCell<Vec<String>>>,
+    effort_dd: DropDown,
+}
+
+pub struct PurposesTab {
+    pub container: GtkBox,
+    rows: Rc<RefCell<BTreeMap<String, Row>>>,
+    connections: Rc<RefCell<Vec<api::ConnectionView>>>,
+    purposes: Rc<RefCell<api::PurposesView>>,
+    /// Model lists keyed by connection id.
+    models_by_connection: Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>>,
+    on_set_purpose: Rc<RefCell<Option<SetPurposeCb>>>,
+    on_request_models: Rc<RefCell<Option<RequestModelsCb>>>,
+    /// When true, we're reconciling the UI to state — suppress
+    /// `set_purpose` callbacks on change notifications.
+    suppress: Rc<RefCell<bool>>,
+}
+
+impl PurposesTab {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 8);
+        container.set_margin_start(12);
+        container.set_margin_end(12);
+        container.set_margin_top(12);
+        container.set_margin_bottom(12);
+
+        let header = Label::new(Some("Purposes"));
+        header.add_css_class("heading");
+        header.set_halign(Align::Start);
+        container.append(&header);
+
+        let blurb = Label::new(Some(
+            "Each purpose maps to a connection and model. Non-interactive purposes may inherit from Interactive by choosing \"primary\".",
+        ));
+        blurb.set_wrap(true);
+        blurb.set_halign(Align::Start);
+        blurb.add_css_class("dim-label");
+        container.append(&blurb);
+
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        let rows: Rc<RefCell<BTreeMap<String, Row>>> = Rc::new(RefCell::new(BTreeMap::new()));
+        let connections: Rc<RefCell<Vec<api::ConnectionView>>> = Rc::new(RefCell::new(Vec::new()));
+        let purposes: Rc<RefCell<api::PurposesView>> =
+            Rc::new(RefCell::new(api::PurposesView::default()));
+        let models_by_connection: Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>> =
+            Rc::new(RefCell::new(BTreeMap::new()));
+        let on_set_purpose: Rc<RefCell<Option<SetPurposeCb>>> = Rc::new(RefCell::new(None));
+        let on_request_models: Rc<RefCell<Option<RequestModelsCb>>> = Rc::new(RefCell::new(None));
+        let suppress = Rc::new(RefCell::new(false));
+
+        for purpose in api::PurposeKindApi::all() {
+            let row_widget = GtkBox::new(Orientation::Horizontal, 8);
+            row_widget.set_margin_top(6);
+            row_widget.set_margin_bottom(6);
+
+            let label = Label::new(Some(purpose_label(purpose)));
+            label.set_width_chars(12);
+            label.set_halign(Align::Start);
+            row_widget.append(&label);
+
+            let connection_list = StringList::new(&[]);
+            let connection_dd = DropDown::new(Some(connection_list.clone()), gtk4::Expression::NONE);
+            connection_dd.set_hexpand(true);
+            row_widget.append(&connection_dd);
+
+            let model_list = StringList::new(&[]);
+            let model_dd = DropDown::new(Some(model_list.clone()), gtk4::Expression::NONE);
+            model_dd.set_hexpand(true);
+            row_widget.append(&model_dd);
+
+            let effort_list = StringList::new(&["None", "Low", "Medium", "High"]);
+            let effort_dd = DropDown::new(Some(effort_list.clone()), gtk4::Expression::NONE);
+            row_widget.append(&effort_dd);
+
+            container.append(&row_widget);
+
+            let row = Row {
+                connection_dd: connection_dd.clone(),
+                connection_list,
+                connection_values: Rc::new(RefCell::new(Vec::new())),
+                model_dd: model_dd.clone(),
+                model_list,
+                model_values: Rc::new(RefCell::new(Vec::new())),
+                effort_dd: effort_dd.clone(),
+            };
+
+            // When connection changes: rebuild models dropdown and emit a
+            // write if we're not currently reconciling.
+            {
+                let rows = Rc::clone(&rows);
+                let connections = Rc::clone(&connections);
+                let models_by_connection = Rc::clone(&models_by_connection);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let on_request_models = Rc::clone(&on_request_models);
+                let suppress = Rc::clone(&suppress);
+                connection_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    // Rebuild model dropdown to reflect the new connection.
+                    let _ = repopulate_models_for_purpose(
+                        purpose,
+                        &rows,
+                        &connections,
+                        &models_by_connection,
+                        &on_request_models,
+                        &suppress,
+                    );
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            {
+                let rows = Rc::clone(&rows);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let suppress = Rc::clone(&suppress);
+                model_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            {
+                let rows = Rc::clone(&rows);
+                let on_set_purpose = Rc::clone(&on_set_purpose);
+                let suppress = Rc::clone(&suppress);
+                effort_dd.connect_selected_notify(move |_| {
+                    if *suppress.borrow() {
+                        return;
+                    }
+                    emit_current(purpose, &rows, &on_set_purpose);
+                });
+            }
+
+            rows.borrow_mut().insert(purpose.as_key().to_string(), row);
+        }
+
+        Self {
+            container,
+            rows,
+            connections,
+            purposes,
+            models_by_connection,
+            on_set_purpose,
+            on_request_models,
+            suppress,
+        }
+    }
+
+    pub fn connect_set_purpose<F>(&self, f: F)
+    where
+        F: Fn(api::PurposeKindApi, api::PurposeConfigView) + 'static,
+    {
+        *self.on_set_purpose.borrow_mut() = Some(Box::new(f));
+    }
+
+    pub fn connect_request_models<F>(&self, f: F)
+    where
+        F: Fn(String) + 'static,
+    {
+        *self.on_request_models.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Replace the connection list. Resets dropdowns.
+    pub fn set_connections(&self, connections: &[api::ConnectionView]) {
+        *self.connections.borrow_mut() = connections.to_vec();
+        self.reconcile();
+    }
+
+    pub fn set_purposes(&self, purposes: api::PurposesView) {
+        *self.purposes.borrow_mut() = purposes;
+        self.reconcile();
+    }
+
+    pub fn set_models(&self, connection_id: &str, listings: Vec<api::ModelListing>) {
+        self.models_by_connection
+            .borrow_mut()
+            .insert(connection_id.to_string(), listings);
+        self.reconcile();
+    }
+
+    fn reconcile(&self) {
+        *self.suppress.borrow_mut() = true;
+        for purpose in api::PurposeKindApi::all() {
+            let _ = repopulate_models_for_purpose(
+                purpose,
+                &self.rows,
+                &self.connections,
+                &self.models_by_connection,
+                &self.on_request_models,
+                &self.suppress,
+            );
+            apply_purpose_config(purpose, &self.rows, &self.connections, &self.purposes);
+        }
+        *self.suppress.borrow_mut() = false;
+    }
+}
+
+/// Rebuild the connection/model dropdowns and request models for the
+/// currently-selected connection if not already cached.
+fn repopulate_models_for_purpose(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    connections: &Rc<RefCell<Vec<api::ConnectionView>>>,
+    models_by_connection: &Rc<RefCell<BTreeMap<String, Vec<api::ModelListing>>>>,
+    on_request_models: &Rc<RefCell<Option<RequestModelsCb>>>,
+    suppress: &Rc<RefCell<bool>>,
+) -> Option<()> {
+    let was_suppressed = *suppress.borrow();
+    *suppress.borrow_mut() = true;
+
+    let rows_borrow = rows.borrow();
+    let row = rows_borrow.get(purpose.as_key())?;
+
+    // Rebuild connection list. Interactive may not inherit from itself,
+    // so only non-interactive purposes see the "primary" sentinel.
+    let prev_conn_idx = row.connection_dd.selected() as usize;
+    let prev_conn_value = row.connection_values.borrow().get(prev_conn_idx).cloned();
+
+    while row.connection_list.n_items() > 0 {
+        row.connection_list.remove(0);
+    }
+    let mut conn_values: Vec<String> = Vec::new();
+    if !matches!(purpose, api::PurposeKindApi::Interactive) {
+        row.connection_list.append("primary (inherit)");
+        conn_values.push(PRIMARY_SENTINEL.to_string());
+    }
+    for conn in connections.borrow().iter() {
+        row.connection_list
+            .append(&format!("{}  ({})", conn.id, conn.connector_type));
+        conn_values.push(conn.id.clone());
+    }
+    *row.connection_values.borrow_mut() = conn_values.clone();
+
+    // Restore previous selection if still present.
+    if let Some(prev) = prev_conn_value
+        && let Some(idx) = conn_values.iter().position(|v| v == &prev)
+    {
+        row.connection_dd.set_selected(idx as u32);
+    }
+
+    // Which connection's models should we display in the model dropdown?
+    let selected_idx = row.connection_dd.selected() as usize;
+    let selected_conn = conn_values.get(selected_idx).cloned();
+    let cache = models_by_connection.borrow();
+    let (models, need_request): (Vec<api::ModelListing>, Option<String>) =
+        match selected_conn.as_deref() {
+            Some(PRIMARY_SENTINEL) | None => (Vec::new(), None),
+            Some(id) => match cache.get(id) {
+                Some(list) => (list.clone(), None),
+                None => (Vec::new(), Some(id.to_string())),
+            },
+        };
+    drop(cache);
+
+    // Rebuild model dropdown.
+    let prev_model_idx = row.model_dd.selected() as usize;
+    let prev_model_value = row.model_values.borrow().get(prev_model_idx).cloned();
+
+    while row.model_list.n_items() > 0 {
+        row.model_list.remove(0);
+    }
+    let mut model_values: Vec<String> = Vec::new();
+    if !matches!(purpose, api::PurposeKindApi::Interactive) {
+        row.model_list.append("primary (inherit)");
+        model_values.push(PRIMARY_SENTINEL.to_string());
+    }
+    for m in &models {
+        row.model_list.append(&m.model.display_name);
+        model_values.push(m.model.id.clone());
+    }
+    *row.model_values.borrow_mut() = model_values.clone();
+
+    if let Some(prev) = prev_model_value
+        && let Some(idx) = model_values.iter().position(|v| v == &prev)
+    {
+        row.model_dd.set_selected(idx as u32);
+    }
+
+    *suppress.borrow_mut() = was_suppressed;
+
+    // Kick off a model fetch for the newly-selected connection if we don't
+    // have it yet.
+    if let Some(id) = need_request
+        && let Some(ref cb) = *on_request_models.borrow()
+    {
+        cb(id);
+    }
+    Some(())
+}
+
+/// Apply the server-side `PurposesView` to the dropdowns. Non-existent
+/// purpose entries leave the dropdowns on their defaults.
+fn apply_purpose_config(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    _connections: &Rc<RefCell<Vec<api::ConnectionView>>>,
+    purposes: &Rc<RefCell<api::PurposesView>>,
+) {
+    let rows_borrow = rows.borrow();
+    let Some(row) = rows_borrow.get(purpose.as_key()) else {
+        return;
+    };
+    let purposes = purposes.borrow();
+    let cfg = match purpose {
+        api::PurposeKindApi::Interactive => purposes.interactive.as_ref(),
+        api::PurposeKindApi::Dreaming => purposes.dreaming.as_ref(),
+        api::PurposeKindApi::Embedding => purposes.embedding.as_ref(),
+        api::PurposeKindApi::Titling => purposes.titling.as_ref(),
+    };
+    let Some(cfg) = cfg else {
+        return;
+    };
+
+    if let Some(idx) = row
+        .connection_values
+        .borrow()
+        .iter()
+        .position(|v| v == &cfg.connection)
+    {
+        row.connection_dd.set_selected(idx as u32);
+    }
+    if let Some(idx) = row
+        .model_values
+        .borrow()
+        .iter()
+        .position(|v| v == &cfg.model)
+    {
+        row.model_dd.set_selected(idx as u32);
+    }
+    let effort_idx = match cfg.effort {
+        None => 0,
+        Some(api::EffortLevel::Low) => 1,
+        Some(api::EffortLevel::Medium) => 2,
+        Some(api::EffortLevel::High) => 3,
+    };
+    row.effort_dd.set_selected(effort_idx as u32);
+}
+
+/// Assemble a `PurposeConfigView` from the current dropdown state and
+/// emit a write callback.
+fn emit_current(
+    purpose: api::PurposeKindApi,
+    rows: &Rc<RefCell<BTreeMap<String, Row>>>,
+    on_set_purpose: &Rc<RefCell<Option<SetPurposeCb>>>,
+) {
+    let rows_borrow = rows.borrow();
+    let Some(row) = rows_borrow.get(purpose.as_key()) else {
+        return;
+    };
+    let conn_idx = row.connection_dd.selected() as usize;
+    let Some(connection) = row.connection_values.borrow().get(conn_idx).cloned() else {
+        return;
+    };
+    let model_idx = row.model_dd.selected() as usize;
+    let Some(model) = row.model_values.borrow().get(model_idx).cloned() else {
+        return;
+    };
+    let effort = match row.effort_dd.selected() {
+        0 => None,
+        1 => Some(api::EffortLevel::Low),
+        2 => Some(api::EffortLevel::Medium),
+        3 => Some(api::EffortLevel::High),
+        _ => None,
+    };
+    let config = api::PurposeConfigView {
+        connection,
+        model,
+        effort,
+        // Context-window override (#51) isn't exposed in this UI yet; leave
+        // it unset so the daemon uses its curated table / universal
+        // fallback.
+        max_context_tokens: None,
+    };
+    if let Some(ref cb) = *on_set_purpose.borrow() {
+        cb(purpose, config);
+    }
+}

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -105,7 +105,8 @@ impl PurposesTab {
             row_widget.append(&label);
 
             let connection_list = StringList::new(&[]);
-            let connection_dd = DropDown::new(Some(connection_list.clone()), gtk4::Expression::NONE);
+            let connection_dd =
+                DropDown::new(Some(connection_list.clone()), gtk4::Expression::NONE);
             connection_dd.set_hexpand(true);
             row_widget.append(&connection_dd);
 

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -45,6 +45,12 @@ struct Row {
     model_list: StringList,
     model_values: Rc<RefCell<Vec<String>>>,
     effort_dd: DropDown,
+    /// Preserved per-purpose context-window override (#51). The UI doesn't
+    /// edit this field, but `SetPurpose` is a full replace, so we remember
+    /// whatever the daemon reported and send it back unchanged on emit —
+    /// otherwise touching a dropdown would silently wipe an override set
+    /// elsewhere (TUI/config).
+    max_context_tokens: Rc<RefCell<Option<u64>>>,
 }
 
 pub struct PurposesTab {
@@ -129,6 +135,7 @@ impl PurposesTab {
                 model_list,
                 model_values: Rc::new(RefCell::new(Vec::new())),
                 effort_dd: effort_dd.clone(),
+                max_context_tokens: Rc::new(RefCell::new(None)),
             };
 
             // When connection changes: rebuild models dropdown and emit a
@@ -361,6 +368,10 @@ fn apply_purpose_config(
         return;
     };
 
+    // Remember the daemon's context-window override so a later emit can send
+    // it back unchanged (the UI doesn't edit this field).
+    *row.max_context_tokens.borrow_mut() = cfg.max_context_tokens;
+
     if let Some(idx) = row
         .connection_values
         .borrow()
@@ -416,10 +427,10 @@ fn emit_current(
         connection,
         model,
         effort,
-        // Context-window override (#51) isn't exposed in this UI yet; leave
-        // it unset so the daemon uses its curated table / universal
-        // fallback.
-        max_context_tokens: None,
+        // Context-window override (#51) isn't editable in this UI, but
+        // `SetPurpose` is a full replace — preserve whatever the daemon
+        // last reported so we don't clobber an override set elsewhere.
+        max_context_tokens: *row.max_context_tokens.borrow(),
     };
     if let Some(ref cb) = *on_set_purpose.borrow() {
         cb(purpose, config);

--- a/src/widgets/settings_dialog.rs
+++ b/src/widgets/settings_dialog.rs
@@ -1,0 +1,531 @@
+//! Top-level Settings dialog (Notebook with Connections + Purposes tabs).
+//!
+//! Owns the live transport handle and wires tab callbacks to async
+//! management RPCs. The dialog is transient to the parent window and
+//! refreshes its data every time it is presented (it is cheap: a couple
+//! of RPCs).
+//!
+//! Async wiring mirrors `widgets/knowledge_browser.rs`: the dialog is
+//! handed an `Arc<TransportClient>` (resolved once by the caller) and an
+//! `Rc<AsyncBridge>`. Each RPC is dispatched on the tokio runtime via
+//! `bridge.spawn`, with results routed back to the GTK main thread through
+//! a short-lived `tokio::sync::mpsc` channel consumed by
+//! `glib::spawn_future_local`. Surface-level errors go to the window status
+//! bar via `bridge.ui_sender()` → `UiMessage::Error`. The dialog owns its
+//! own `list_available_models` fetch (None connection_id) so the Purposes
+//! tab sees *all* models — including embedding models, which the header
+//! `ModelPicker` filters out.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::TransportClient;
+use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, Button, Label, Notebook, Orientation, Window, glib};
+use tokio::sync::mpsc;
+
+use crate::async_bridge::{AsyncBridge, UiMessage};
+use crate::management_client;
+
+use super::connection_config_dialog::{ConnectorType, show_configure_dialog};
+use super::connections_tab::ConnectionsTab;
+use super::purposes_tab::PurposesTab;
+
+/// Minimal yes/no confirmation dialog. We avoid GTK4's `AlertDialog`
+/// (gated behind the `v4_10` feature) to keep the feature floor low.
+/// `on_confirm` is called when the user clicks the affirmative button.
+fn confirm<F>(
+    parent: &impl IsA<Window>,
+    title: &str,
+    detail: &str,
+    affirmative: &str,
+    destructive: bool,
+    on_confirm: F,
+) where
+    F: Fn() + 'static,
+{
+    let dialog = Window::builder()
+        .title(title)
+        .default_width(420)
+        .modal(true)
+        .resizable(false)
+        .transient_for(parent)
+        .build();
+
+    let content = GtkBox::new(Orientation::Vertical, 12);
+    content.set_margin_start(20);
+    content.set_margin_end(20);
+    content.set_margin_top(20);
+    content.set_margin_bottom(20);
+
+    let message = Label::new(Some(detail));
+    message.set_wrap(true);
+    message.set_halign(Align::Start);
+    content.append(&message);
+
+    let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+    btn_row.set_halign(Align::End);
+    let cancel = Button::with_label("Cancel");
+    let confirm_btn = Button::with_label(affirmative);
+    if destructive {
+        confirm_btn.add_css_class("destructive-action");
+    } else {
+        confirm_btn.add_css_class("suggested-action");
+    }
+    btn_row.append(&cancel);
+    btn_row.append(&confirm_btn);
+    content.append(&btn_row);
+
+    dialog.set_child(Some(&content));
+
+    let dialog_ref = dialog.clone();
+    cancel.connect_clicked(move |_| dialog_ref.close());
+
+    let dialog_ref = dialog.clone();
+    confirm_btn.connect_clicked(move |_| {
+        dialog_ref.close();
+        on_confirm();
+    });
+
+    dialog.present();
+}
+
+/// Present the Settings dialog modally against `parent`, using `transport`
+/// for all RPC traffic. `bridge` provides the tokio runtime + the shared
+/// ui-message channel so errors propagate back to the window status bar.
+pub fn show_settings_dialog(
+    parent: &impl IsA<Window>,
+    transport: Arc<TransportClient>,
+    bridge: Rc<AsyncBridge>,
+) {
+    let dialog = Window::builder()
+        .title("Settings")
+        .default_width(720)
+        .default_height(520)
+        .modal(true)
+        .transient_for(parent)
+        .build();
+
+    let vbox = GtkBox::new(Orientation::Vertical, 0);
+    vbox.set_vexpand(true);
+
+    let notebook = Notebook::new();
+    notebook.set_vexpand(true);
+
+    let connections_tab = Rc::new(ConnectionsTab::new());
+    let purposes_tab = Rc::new(PurposesTab::new());
+
+    notebook.append_page(
+        &connections_tab.container,
+        Some(&Label::new(Some("Connections"))),
+    );
+    notebook.append_page(&purposes_tab.container, Some(&Label::new(Some("Purposes"))));
+
+    vbox.append(&notebook);
+
+    // Status row + close.
+    let footer = GtkBox::new(Orientation::Horizontal, 8);
+    footer.set_margin_start(12);
+    footer.set_margin_end(12);
+    footer.set_margin_top(6);
+    footer.set_margin_bottom(8);
+
+    let status_label = Rc::new(Label::new(None));
+    status_label.set_halign(Align::Start);
+    status_label.set_hexpand(true);
+    status_label.add_css_class("dim-label");
+    footer.append(&*status_label);
+
+    let close_btn = Button::with_label("Close");
+    let dialog_ref = dialog.clone();
+    close_btn.connect_clicked(move |_| dialog_ref.close());
+    footer.append(&close_btn);
+
+    vbox.append(&footer);
+    dialog.set_child(Some(&vbox));
+
+    // ---------------------------------------------------------------
+    // Data-refresh helper: re-fetches connections + purposes + the
+    // aggregated model list, then repopulates the tabs. Called on present
+    // and after any mutation. Owns its own `list_available_models(None)`
+    // fetch so embedding models reach the Purposes tab.
+    // ---------------------------------------------------------------
+    let refresh: Rc<dyn Fn()> = {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let connections_tab = Rc::clone(&connections_tab);
+        let purposes_tab = Rc::clone(&purposes_tab);
+        let status_label = Rc::clone(&status_label);
+        Rc::new(move || {
+            let connections_tab = Rc::clone(&connections_tab);
+            let purposes_tab = Rc::clone(&purposes_tab);
+            let status_label = Rc::clone(&status_label);
+
+            let (tx_conn, mut rx_conn) =
+                mpsc::unbounded_channel::<Result<Vec<api::ConnectionView>, String>>();
+            let (tx_purposes, mut rx_purposes) =
+                mpsc::unbounded_channel::<Result<api::PurposesView, String>>();
+            let (tx_models, mut rx_models) =
+                mpsc::unbounded_channel::<Result<Vec<api::ModelListing>, String>>();
+
+            let transport_for_task = Arc::clone(&transport);
+            bridge.spawn(async move {
+                let conns = management_client::list_connections(&transport_for_task)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = tx_conn.send(conns);
+
+                let purposes = management_client::get_purposes(&transport_for_task)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = tx_purposes.send(purposes);
+
+                // Aggregated list (None connection_id) populates model
+                // caches for every healthy connection at once.
+                let models =
+                    management_client::list_available_models(&transport_for_task, None, false)
+                        .await
+                        .map_err(|e| e.to_string());
+                let _ = tx_models.send(models);
+            });
+
+            let connections_tab_a = Rc::clone(&connections_tab);
+            let purposes_tab_a = Rc::clone(&purposes_tab);
+            let status_a = Rc::clone(&status_label);
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx_conn.recv().await {
+                    match result {
+                        Ok(list) => {
+                            connections_tab_a.set_connections(&list);
+                            purposes_tab_a.set_connections(&list);
+                        }
+                        Err(e) => status_a.set_text(&format!("List connections: {e}")),
+                    }
+                }
+                if let Some(result) = rx_purposes.recv().await {
+                    match result {
+                        Ok(p) => purposes_tab_a.set_purposes(p),
+                        Err(e) => status_a.set_text(&format!("Get purposes: {e}")),
+                    }
+                }
+                if let Some(result) = rx_models.recv().await {
+                    match result {
+                        Ok(listings) => {
+                            // Group by connection id and hand each slice to
+                            // the purposes tab so per-connection dropdowns
+                            // populate without firing extra requests.
+                            let mut by_conn: std::collections::BTreeMap<
+                                String,
+                                Vec<api::ModelListing>,
+                            > = std::collections::BTreeMap::new();
+                            for listing in listings {
+                                by_conn
+                                    .entry(listing.connection_id.clone())
+                                    .or_default()
+                                    .push(listing);
+                            }
+                            for (id, list) in by_conn {
+                                purposes_tab_a.set_models(&id, list);
+                            }
+                        }
+                        Err(e) => status_a.set_text(&format!("List models: {e}")),
+                    }
+                }
+            });
+        })
+    };
+
+    // ---------------------------------------------------------------
+    // Connections tab wiring.
+    // ---------------------------------------------------------------
+    {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let refresh = Rc::clone(&refresh);
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_add(move |connector| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let transport = Arc::clone(&transport);
+            let bridge = Rc::clone(&bridge);
+            let refresh = Rc::clone(&refresh);
+            show_configure_dialog(
+                &parent,
+                connector,
+                None,
+                move |id, config| {
+                    let transport = Arc::clone(&transport);
+                    let refresh = Rc::clone(&refresh);
+                    let ui_tx = bridge.ui_sender();
+                    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+                    bridge.spawn(async move {
+                        let r = management_client::create_connection(&transport, id, config)
+                            .await
+                            .map_err(|e| e.to_string());
+                        let _ = tx.send(r);
+                    });
+                    glib::spawn_future_local(async move {
+                        if let Some(result) = rx.recv().await {
+                            match result {
+                                Ok(()) => refresh(),
+                                Err(e) => {
+                                    let _ = ui_tx
+                                        .send(UiMessage::Error(format!("Create connection: {e}")));
+                                }
+                            }
+                        }
+                    });
+                },
+                // Add-flow never has a connection to refresh yet.
+                |_id| {},
+            );
+        });
+    }
+
+    {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let connections_tab_cfg = Rc::clone(&connections_tab);
+        let refresh = Rc::clone(&refresh);
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_configure(move |id| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let Some(existing) = connections_tab_cfg.find(&id) else {
+                return;
+            };
+            let connector = match ConnectorType::from_slug(&existing.connector_type) {
+                Some(c) => c,
+                None => {
+                    let _ = bridge.ui_sender().send(UiMessage::Error(format!(
+                        "Unknown connector type: {}",
+                        existing.connector_type
+                    )));
+                    return;
+                }
+            };
+            // We don't have the raw config from the daemon in ConnectionView
+            // (credentials are never surfaced). Pass an empty config of the
+            // right variant; the user re-enters fields on edit.
+            let existing_pair = Some((existing.id.clone(), connector.empty_config()));
+
+            let transport_save = Arc::clone(&transport);
+            let bridge_save = Rc::clone(&bridge);
+            let refresh_inner = Rc::clone(&refresh);
+            let transport_refresh = Arc::clone(&transport);
+            let bridge_refresh = Rc::clone(&bridge);
+
+            show_configure_dialog(
+                &parent,
+                connector,
+                existing_pair,
+                move |id, config| {
+                    let transport = Arc::clone(&transport_save);
+                    let refresh = Rc::clone(&refresh_inner);
+                    let ui_tx = bridge_save.ui_sender();
+                    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+                    bridge_save.spawn(async move {
+                        let r = management_client::update_connection(&transport, id, config)
+                            .await
+                            .map_err(|e| e.to_string());
+                        let _ = tx.send(r);
+                    });
+                    glib::spawn_future_local(async move {
+                        if let Some(result) = rx.recv().await {
+                            match result {
+                                Ok(()) => refresh(),
+                                Err(e) => {
+                                    let _ = ui_tx
+                                        .send(UiMessage::Error(format!("Update connection: {e}")));
+                                }
+                            }
+                        }
+                    });
+                },
+                move |id_for_refresh| {
+                    // Refresh Bedrock models cache (refresh: true).
+                    let transport = Arc::clone(&transport_refresh);
+                    let ui_tx = bridge_refresh.ui_sender();
+                    bridge_refresh.spawn(async move {
+                        let r = management_client::list_available_models(
+                            &transport,
+                            Some(id_for_refresh),
+                            true,
+                        )
+                        .await;
+                        if let Err(e) = r {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Refresh models: {e}")));
+                        }
+                    });
+                },
+            );
+        });
+    }
+
+    {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let refresh = Rc::clone(&refresh);
+        let dialog_weak = dialog.downgrade();
+        connections_tab.connect_remove(move |id| {
+            let Some(parent) = dialog_weak.upgrade() else {
+                return;
+            };
+            let transport_for_confirm = Arc::clone(&transport);
+            let bridge_for_confirm = Rc::clone(&bridge);
+            let refresh_for_confirm = Rc::clone(&refresh);
+            let parent_for_retry = parent.clone();
+            let id_for_confirm = id.clone();
+            confirm(
+                &parent,
+                &format!("Remove connection \"{id}\"?"),
+                "This will fail if any purpose still references the connection. You will be offered a force-remove on the retry dialog, which re-assigns referencing purposes to the interactive purpose.",
+                "Remove",
+                true,
+                move || {
+                    do_remove_connection(
+                        &parent_for_retry,
+                        Arc::clone(&transport_for_confirm),
+                        Rc::clone(&bridge_for_confirm),
+                        Rc::clone(&refresh_for_confirm),
+                        id_for_confirm.clone(),
+                        false,
+                    );
+                },
+            );
+        });
+    }
+
+    // ---------------------------------------------------------------
+    // Purposes tab wiring.
+    // ---------------------------------------------------------------
+    {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let refresh = Rc::clone(&refresh);
+        purposes_tab.connect_set_purpose(move |purpose, config| {
+            let transport = Arc::clone(&transport);
+            let refresh = Rc::clone(&refresh);
+            let ui_tx = bridge.ui_sender();
+            let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+            bridge.spawn(async move {
+                let r = management_client::set_purpose(&transport, purpose, config).await;
+                let _ = tx.send(r.map_err(|e| e.to_string()));
+            });
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx.recv().await {
+                    match result {
+                        Ok(()) => refresh(),
+                        Err(e) => {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Set purpose: {e}")));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    {
+        let transport = Arc::clone(&transport);
+        let bridge = Rc::clone(&bridge);
+        let purposes_tab_for_cb = Rc::clone(&purposes_tab);
+        purposes_tab.connect_request_models(move |connection_id| {
+            let transport = Arc::clone(&transport);
+            let ui_tx = bridge.ui_sender();
+            let purposes_tab = Rc::clone(&purposes_tab_for_cb);
+            let (tx, mut rx) = mpsc::unbounded_channel::<Result<Vec<api::ModelListing>, String>>();
+            let connection_id_for_task = connection_id.clone();
+            bridge.spawn(async move {
+                let r = management_client::list_available_models(
+                    &transport,
+                    Some(connection_id_for_task),
+                    false,
+                )
+                .await
+                .map_err(|e| e.to_string());
+                let _ = tx.send(r);
+            });
+            glib::spawn_future_local(async move {
+                if let Some(result) = rx.recv().await {
+                    match result {
+                        Ok(listings) => {
+                            purposes_tab.set_models(&connection_id, listings);
+                        }
+                        Err(e) => {
+                            let _ = ui_tx.send(UiMessage::Error(format!("List models: {e}")));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    // First refresh.
+    refresh();
+
+    dialog.present();
+}
+
+/// Issue a `DeleteConnection` call. On refusal (purposes still reference
+/// it), prompt the user to retry with `force: true`. On force success,
+/// the daemon rewires referencing purposes to fall back to interactive.
+fn do_remove_connection(
+    parent: &impl IsA<Window>,
+    transport: Arc<TransportClient>,
+    bridge: Rc<AsyncBridge>,
+    refresh: Rc<dyn Fn()>,
+    id: String,
+    force: bool,
+) {
+    let ui_tx = bridge.ui_sender();
+    let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
+    let transport_for_task = Arc::clone(&transport);
+    let id_for_task = id.clone();
+    bridge.spawn(async move {
+        let r = management_client::delete_connection(&transport_for_task, id_for_task, force).await;
+        let _ = tx.send(r.map_err(|e| e.to_string()));
+    });
+
+    let parent = parent.clone();
+    let refresh_outer = Rc::clone(&refresh);
+    glib::spawn_future_local(async move {
+        if let Some(result) = rx.recv().await {
+            match result {
+                Ok(()) => refresh_outer(),
+                Err(e) if !force => {
+                    let id_for_retry = id.clone();
+                    let parent_inner = parent.clone();
+                    let transport_inner = Arc::clone(&transport);
+                    let bridge_inner = Rc::clone(&bridge);
+                    let refresh_inner = Rc::clone(&refresh_outer);
+                    let parent_for_confirm = parent.clone();
+                    confirm(
+                        &parent_for_confirm,
+                        &format!("Cannot remove \"{id}\""),
+                        &format!(
+                            "{e}\n\nForce-remove will re-assign any referencing purpose to the interactive purpose."
+                        ),
+                        "Force remove",
+                        true,
+                        move || {
+                            do_remove_connection(
+                                &parent_inner,
+                                Arc::clone(&transport_inner),
+                                Rc::clone(&bridge_inner),
+                                Rc::clone(&refresh_inner),
+                                id_for_retry.clone(),
+                                true,
+                            );
+                        },
+                    );
+                }
+                Err(e) => {
+                    let _ = ui_tx.send(UiMessage::Error(format!("Delete connection: {e}")));
+                }
+            }
+        }
+    });
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -15,6 +15,7 @@ use gtk4::{
 use tokio::sync::mpsc;
 
 use crate::async_bridge::{AsyncBridge, InternalMsg, UiMessage, connection_manager};
+use crate::management_client;
 use crate::widgets::chat_view::ChatView;
 use crate::widgets::input_bar::InputBar;
 use crate::widgets::model_picker::ModelPicker;
@@ -118,6 +119,11 @@ impl AdelieWindow {
         let menu_popover = Popover::new();
         menu_popover.add_css_class("context-popover");
         let menu_box = GtkBox::new(Orientation::Vertical, 0);
+
+        let settings_btn = Button::with_label("Settings");
+        settings_btn.add_css_class("context-button");
+        settings_btn.set_halign(Align::Fill);
+        menu_box.append(&settings_btn);
 
         let switch_conn_btn = Button::with_label("Switch Connection…");
         switch_conn_btn.add_css_class("context-button");
@@ -595,6 +601,51 @@ impl AdelieWindow {
                 popover_ref.popdown();
                 let login = crate::widgets::login_screen::LoginScreen::new(&app_ref);
                 login.present();
+            });
+        }
+
+        // Hamburger menu: Settings → Connections / Purposes tabs (#1). The
+        // dialog is WS-only (named-connection management isn't exposed over
+        // D-Bus); on a D-Bus transport we status-message and no-op — the
+        // header model picker is already hidden there.
+        {
+            let popover_ref = menu_popover.clone();
+            let window_ref = window.clone();
+            let client_ref = Rc::clone(&client);
+            let bridge_ref = Rc::clone(&bridge);
+            let status_label_ref = Rc::clone(&status_label);
+            settings_btn.connect_clicked(move |_| {
+                popover_ref.popdown();
+                let Some(transport) = client_ref.borrow().clone() else {
+                    status_label_ref.set_text("Not connected — settings unavailable");
+                    return;
+                };
+                if transport.as_ws().is_none() {
+                    status_label_ref
+                        .set_text("Settings require the WebSocket transport (unavailable on D-Bus)");
+                    return;
+                }
+                crate::widgets::settings_dialog::show_settings_dialog(
+                    &window_ref,
+                    Arc::clone(&transport),
+                    Rc::clone(&bridge_ref),
+                );
+                // The user may have added/removed connections; re-query the
+                // aggregated model list so the header picker reflects the new
+                // set. Fire-and-forget — errors are non-fatal. Runs once when
+                // Settings is opened (so it picks up the previous session's
+                // changes); the dialog itself keeps its own tabs in sync.
+                let tx = bridge_ref.ui_sender();
+                bridge_ref.spawn(async move {
+                    match management_client::list_available_models(&transport, None, false).await {
+                        Ok(listings) => {
+                            let _ = tx.send(UiMessage::ModelsLoaded(listings));
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to refresh models after settings: {e}");
+                        }
+                    }
+                });
             });
         }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,7 +10,8 @@ use desktop_assistant_client_common::{
 use gtk4::prelude::*;
 use gtk4::{
     Align, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton, Entry, Label,
-    MenuButton, Orientation, Paned, Popover, Separator, Stack, StackSwitcher, Window, gdk, glib,
+    MenuButton, Orientation, Paned, Popover, Revealer, RevealerTransitionType, Separator, Stack,
+    StackSwitcher, Window, gdk, glib,
 };
 use tokio::sync::mpsc;
 
@@ -152,6 +153,34 @@ impl AdelieWindow {
         let chat_view = ChatView::new();
         right_box.append(&chat_view.container);
 
+        // Passive toast for advisory warnings (e.g. a dangling model
+        // selection cleared by the daemon). The revealer is always in the
+        // layout; we reveal it with a message when something needs
+        // attention, and the user can dismiss it.
+        let toast_revealer = Revealer::new();
+        toast_revealer.set_transition_type(RevealerTransitionType::SlideUp);
+        toast_revealer.set_reveal_child(false);
+        let toast_row = GtkBox::new(Orientation::Horizontal, 8);
+        toast_row.add_css_class("toast-row");
+        toast_row.set_margin_start(12);
+        toast_row.set_margin_end(12);
+        toast_row.set_margin_top(6);
+        toast_row.set_margin_bottom(6);
+        let toast_label = Label::new(None);
+        toast_label.set_halign(Align::Start);
+        toast_label.set_hexpand(true);
+        toast_label.set_wrap(true);
+        toast_row.append(&toast_label);
+        let toast_dismiss = Button::from_icon_name("window-close-symbolic");
+        toast_dismiss.add_css_class("flat");
+        {
+            let revealer_ref = toast_revealer.clone();
+            toast_dismiss.connect_clicked(move |_| revealer_ref.set_reveal_child(false));
+        }
+        toast_row.append(&toast_dismiss);
+        toast_revealer.set_child(Some(&toast_row));
+        right_box.append(&toast_revealer);
+
         let input_sep = Separator::new(Orientation::Horizontal);
         right_box.append(&input_sep);
 
@@ -201,6 +230,8 @@ impl AdelieWindow {
         let model_picker = Rc::new(model_picker);
         let tasks_panel = Rc::new(tasks_panel);
         let stack = Rc::new(stack);
+        let toast_revealer = Rc::new(toast_revealer);
+        let toast_label = Rc::new(toast_label);
 
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
@@ -218,6 +249,8 @@ impl AdelieWindow {
             let input_bar = Rc::clone(&input_bar);
             let model_picker = Rc::clone(&model_picker);
             let tasks_panel = Rc::clone(&tasks_panel);
+            let toast_revealer = Rc::clone(&toast_revealer);
+            let toast_label = Rc::clone(&toast_label);
 
             AsyncBridge::new(move |msg, ui_tx| {
                 handle_ui_message(
@@ -230,6 +263,8 @@ impl AdelieWindow {
                     &input_bar,
                     &model_picker,
                     &tasks_panel,
+                    &toast_revealer,
+                    &toast_label,
                     ui_tx,
                 );
             })
@@ -621,8 +656,9 @@ impl AdelieWindow {
                     return;
                 };
                 if transport.as_ws().is_none() {
-                    status_label_ref
-                        .set_text("Settings require the WebSocket transport (unavailable on D-Bus)");
+                    status_label_ref.set_text(
+                        "Settings require the WebSocket transport (unavailable on D-Bus)",
+                    );
                     return;
                 }
                 crate::widgets::settings_dialog::show_settings_dialog(
@@ -794,6 +830,8 @@ fn handle_ui_message(
     input_bar: &Rc<InputBar>,
     model_picker: &Rc<ModelPicker>,
     tasks_panel: &Rc<TasksPanel>,
+    toast_revealer: &Rc<Revealer>,
+    toast_label: &Rc<Label>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
     match msg {
@@ -932,6 +970,37 @@ fn handle_ui_message(
             let convs = s.conversations.clone();
             drop(s);
             sidebar.set_conversations(&convs);
+        }
+        UiMessage::ConversationWarning {
+            conversation_id,
+            warning,
+        } => {
+            // Single variant today — DanglingModelSelection. The daemon has
+            // already cleared its side and fell back; if this is the
+            // currently-open conversation, clear the header picker so it
+            // doesn't show a stale "stuck" model, then surface a passive
+            // toast explaining the fallback.
+            match &warning {
+                api::ConversationWarning::DanglingModelSelection {
+                    previous_selection,
+                    fallback_to,
+                } => {
+                    let is_current = state.borrow().current_conversation_id.as_deref()
+                        == Some(conversation_id.as_str());
+                    if is_current {
+                        model_picker.set_selection(None);
+                    }
+                    let message = format!(
+                        "The model \"{}\" on connection \"{}\" is no longer available — falling back to \"{}\" on \"{}\".",
+                        previous_selection.model_id,
+                        previous_selection.connection_id,
+                        fallback_to.model_id,
+                        fallback_to.connection_id,
+                    );
+                    toast_label.set_text(&message);
+                    toast_revealer.set_reveal_child(true);
+                }
+            }
         }
         UiMessage::StatusUpdate(text) => {
             status_label.set_text(&text);

--- a/src/window.rs
+++ b/src/window.rs
@@ -989,6 +989,12 @@ fn handle_ui_message(
                         == Some(conversation_id.as_str());
                     if is_current {
                         model_picker.set_selection(None);
+                        // Also clear the cached detail's selection so a later
+                        // `ModelsLoaded` doesn't re-apply the stale dangling
+                        // selection, contradicting this toast.
+                        if let Some(ref mut conv) = state.borrow_mut().current_conversation {
+                            conv.model_selection = None;
+                        }
                     }
                     let message = format!(
                         "The model \"{}\" on connection \"{}\" is no longer available — falling back to \"{}\" on \"{}\".",


### PR DESCRIPTION
Closes #1

Ports the multi-connection config UI from `feat/multi-connection` onto current `main`, wiring it to main's existing per-conversation model picker rather than the branch's duplicate selector.

## What was ported / dropped / adapted

**Ported as-is**
- `widgets/connection_config_dialog.rs` — per-connector Configure dialog (Anthropic / OpenAI / Bedrock / Ollama) with Bedrock "Refresh models" button. Kept its unit tests (slug round-trip, empty-config variant).
- `widgets/connections_tab.rs` — live `ListConnections` view with Add / Configure / Remove, delegating RPC work to the parent via callbacks.

**Ported + adapted**
- `widgets/purposes_tab.rs` — per-purpose connection/model/effort dropdowns with the `"primary"` inherit sentinel.
- `widgets/settings_dialog.rs` — Notebook host + add/configure/remove + force-remove-confirm flow. Entry point refactored to `show_settings_dialog(&window, Arc<TransportClient>, Rc<AsyncBridge>)`, mirroring `KnowledgeBrowser::new` and using `bridge.spawn` / `bridge.ui_sender()`. The dialog owns its own `list_available_models(None)` fetch so the Purposes tab sees **all** models (including embedding models, which the header `ModelPicker` filters out).
- `management_client.rs` — kept only the subset the Settings dialog needs: `list_connections`, `create_connection`, `update_connection`, `delete_connection`, `list_available_models`, `get_purposes`, `set_purpose`.

**Dropped**
- The branch's `selection_store.rs` and `widgets/model_selector.rs` — main's `selected_models.rs` + `widgets/model_picker.rs` already cover the per-conversation picker and are reused unchanged.
- The branch's `send_prompt_with_override` and `get_conversation_view` management wrappers (drifted / not needed — see below).
- The branch's `[dev-dependencies] tempfile` addition (no longer needed).

## Daemon-API fixes applied (vs the branch)
1. `api::PurposeConfigView` gained a 5th field — the literal in `purposes_tab::emit_current` now sets `max_context_tokens: None` (per-purpose context-window override, #51, not surfaced in this UI yet).
2. The branch's `send_prompt_with_override` wrapper assumed `SendMessage` returns `Ack`; the daemon now returns `SendMessageAck { task_id }` and main's send path already uses client-common's `WsClient::send_prompt_with_override`. The wrapper was dropped rather than fixed.

(Also: the local `PURPOSES` const was replaced by `api::PurposeKindApi::all()`, which yields the same stable order.)

## Send / load paths left intact
Main's send path (`model_picker.current_override()` on send) and load path (`model_picker.set_selection(detail.model_selection)` on load) are unchanged. Per-conversation stickiness is **daemon-backed** via the stored `model_selection`; no client-side persistence was added.

## How the Settings dialog gets models / how the picker refreshes
- The dialog issues its own `list_available_models(None, false)` and groups the result by connection id for the Purposes tab (so embedding models are included). Per-connection lazy fetches happen on demand via `connect_request_models`.
- After the Settings dialog is presented, the window fires `list_available_models(None, false)` → `UiMessage::ModelsLoaded`, which calls `model_picker.set_models(...)` so the header picker reflects connection changes. On a D-Bus transport (no `as_ws()`) the entry point status-messages and no-ops — the picker is hidden there.

## Toast scope (Phase 7)
Added a typed `UiMessage::ConversationWarning` and mapped the **live** `SignalEvent::ConversationWarning` to it (replacing the lossy `StatusUpdate`-string mapping). A dismissable `Revealer` toast surfaces `DanglingModelSelection`; when it targets the open conversation we reset `model_picker.set_selection(None)`. This covers *delete a connection referenced by an open conversation → toast*.

**Follow-up (deliberate):** synchronous load-time warnings via a raw `GetConversation` view are not reintroduced — the branch's `get_conversation_view` load-path rewrite conflicts with main's load path.

## Verification
- `cargo fmt -p adele-gtk -- --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0
- `cargo build --all-targets` → ok
- `cargo test` → 83 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
