### PR TITLE
chore: local verification just targets + pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Local-CI gate: run the verification suite before allowing a push.
+# Activated via `just install-hooks` (sets core.hooksPath = .githooks).
+# Bypass in an emergency with: git push --no-verify
+set -euo pipefail
+
+echo "==> pre-push: running 'just check' (bypass with --no-verify)"
+exec just check

--- a/justfile
+++ b/justfile
@@ -26,3 +26,46 @@ uninstall-desktop:
     rm -f ~/.local/share/applications/adele-gtk.desktop
     rm -f ~/.local/share/icons/hicolor/512x512/apps/adele-gtk.png
     update-desktop-database ~/.local/share/applications 2>/dev/null || true
+
+# --- Local verification ("local CI") -----------------------------------------
+# We run these locally instead of GitHub Actions. `install-hooks` wires `check`
+# into a git pre-push hook so it runs automatically before every push. fmt/clippy
+# are scoped to `-p adele-gtk` because the workspace path-deps desktop-assistant.
+
+# Full local gate: formatting, lints, build, tests (on the pinned toolchain)
+check: fmt-check lint build test
+
+# Verify formatting without modifying files (scoped — don't touch the path-dep)
+fmt-check:
+    cargo fmt -p adele-gtk --check
+
+# Apply formatting (scoped)
+fmt:
+    cargo fmt -p adele-gtk
+
+# Clippy on this crate; warnings are errors
+lint:
+    cargo clippy -p adele-gtk --all-targets -- -D warnings
+
+# Build
+build:
+    cargo build
+
+# Run the test suite (excludes #[ignore] integration tests)
+test:
+    cargo test
+
+# Real-Secret-Service integration tests (needs a live session bus; mutates + cleans keyring)
+test-integration:
+    cargo test -- --ignored
+
+# Rebase onto latest origin/main then run the gate (catches clean-rebase-but-broken-build)
+premerge:
+    git fetch origin
+    git rebase origin/main
+    just check
+
+# Install git hooks (pre-push runs `just check`). Local config; run once per clone.
+install-hooks:
+    git config core.hooksPath .githooks
+    @echo "pre-push hook active — bypass once with: git push --no-verify"

--- a/src/credential_store.rs
+++ b/src/credential_store.rs
@@ -140,3 +140,113 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod integration {
+    //! Real-Secret-Service integration test. Ignored by default — needs a live
+    //! session bus and `secret-tool`; mutates the keyring (namespaced, cleaned
+    //! up). Run via `just test-integration`.
+    //!
+    //! Covers what the mock store cannot: that credentials written under the old
+    //! `keyring` v3 attribute scheme stay readable by keyring-core. v3's
+    //! secret-service store keyed items by `service`+`username`+`target`+
+    //! `application`; keyring-core searches the `service`+`username` subset, and
+    //! Secret Service subset-matches — so v3 items must still be found.
+    use super::*;
+    use std::process::Command;
+    use std::sync::Once;
+
+    static REAL_STORE: Once = Once::new();
+
+    fn real_store_ready() -> bool {
+        if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+            eprintln!("SKIP: no DBUS_SESSION_BUS_ADDRESS");
+            return false;
+        }
+        if !command_present("secret-tool") {
+            eprintln!("SKIP: secret-tool not installed");
+            return false;
+        }
+        REAL_STORE.call_once(|| match zbus_secret_service_keyring_store::Store::new() {
+            Ok(store) => keyring_core::set_default_store(store),
+            Err(error) => eprintln!("WARN: could not connect to Secret Service: {error}"),
+        });
+        match keyring_core::Entry::new("adele-gtk-it-probe", "probe").and_then(|e| e.get_password())
+        {
+            Ok(_) | Err(keyring_core::Error::NoEntry) => true,
+            Err(error) => {
+                eprintln!("SKIP: Secret Service unavailable: {error}");
+                false
+            }
+        }
+    }
+
+    fn command_present(bin: &str) -> bool {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {bin}"))
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn secret_tool_store(attrs: &[(&str, &str)], value: &str) {
+        use std::io::Write as _;
+        use std::process::Stdio;
+        let mut cmd = Command::new("secret-tool");
+        cmd.arg("store")
+            .arg("--label")
+            .arg("adele-gtk integration test");
+        for (key, val) in attrs {
+            cmd.arg(key).arg(val);
+        }
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("spawn secret-tool");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(value.as_bytes())
+            .unwrap();
+        assert!(child.wait().unwrap().success(), "secret-tool store failed");
+    }
+
+    fn secret_tool_clear(attrs: &[(&str, &str)]) {
+        let mut cmd = Command::new("secret-tool");
+        cmd.arg("clear");
+        for (key, val) in attrs {
+            cmd.arg(key).arg(val);
+        }
+        let _ = cmd.output();
+    }
+
+    #[test]
+    #[ignore = "needs a real Secret Service; run via `just test-integration`"]
+    fn reads_credential_written_by_keyring_v3() {
+        if !real_store_ready() {
+            return;
+        }
+        let profile = "it-v3-profile";
+        // keyring v3 stored a password under username "password:<profile>" with
+        // the full v3 attribute set.
+        let username = format!("password:{profile}");
+        let attrs = [
+            ("service", SERVICE_NAME),
+            ("username", username.as_str()),
+            ("target", "default"),
+            ("application", "rust-keyring"),
+        ];
+        secret_tool_clear(&attrs);
+        secret_tool_store(&attrs, "v3-secret-value");
+
+        // The migrated code must read it via the service+username subset match.
+        let got = CredentialStore::get_password(profile);
+        assert_eq!(got.unwrap(), Some("v3-secret-value".to_string()));
+
+        // Cleanup.
+        let _ = CredentialStore::delete_credentials(profile);
+        secret_tool_clear(&attrs);
+    }
+}


### PR DESCRIPTION
Mirrors adelie-ai/desktop-assistant#167 for adele-gtk. Adds `just check` (fmt-check + clippy --all-targets -D warnings + build + test, scoped `-p adele-gtk` for fmt/clippy due to the desktop-assistant path-dep), `test-integration`, `premerge`, and a `.githooks/pre-push` hook (via `just install-hooks`). Promotes the keyring-v3 read-compat probe into a permanent #[ignore] real-Secret-Service test. Verified: `just check` passes; `reads_credential_written_by_keyring_v3` passes against the live keyring.