### PR TITLE
refactor: glib::clone!, extract icon-cache, fold InternalMsg, dedupe oauth config (#29)

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,0 +1,44 @@
+//! Embedded-asset cache helpers.
+//!
+//! Several widgets embed a PNG via `include_bytes!` and need it on disk as
+//! a real file (GTK's `Image::from_file` / icon-theme search path can't read
+//! an in-memory `&[u8]`). They all wrote the bytes to a path under the user
+//! cache directory with the same idempotent create-new dance; this module
+//! centralizes that so the write semantics live in one place.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Write `bytes` to `<cache-dir>/<name>`, returning the resolved path.
+///
+/// `name` may contain sub-directories (e.g. `hicolor/512x512/apps/x.png`);
+/// any missing parent directories are created. The cache directory falls
+/// back to the system temp directory when no user cache dir is available,
+/// matching the previous call-site behavior.
+///
+/// The write uses `create_new` so it is idempotent and TOCTOU-free: the file
+/// is either atomically created and filled, or already exists (treated as
+/// success). Any other I/O error is returned to the caller.
+pub fn extract_to_cache(bytes: &[u8], name: &str) -> std::io::Result<PathBuf> {
+    let path = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(name);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // `create_new` avoids TOCTOU: the write either atomically creates the
+    // file or harmlessly fails because it already exists.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut file) => file.write_all(bytes)?,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(e),
+    }
+
+    Ok(path)
+}

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -24,8 +24,14 @@ fn runtime() -> &'static Runtime {
 }
 
 /// Messages sent from async tasks back to the GTK main thread.
-#[derive(Debug)]
 pub enum UiMessage {
+    /// A freshly connected transport handed off to the GTK main thread.
+    /// `Arc<TransportClient>` is `Send`, so this rides the same channel as
+    /// every other UI message (replacing the former dedicated `InternalMsg`
+    /// channel). Sent by `connection_manager` immediately after `Connected`
+    /// and before `ConversationsLoaded`, so the window's client cell is
+    /// populated before any handler that needs it runs.
+    ClientReady(Arc<TransportClient>),
     ConversationsLoaded(Vec<desktop_assistant_client_common::ConversationSummary>),
     ConversationLoaded(desktop_assistant_client_common::ConversationDetail),
     ConversationCreated {
@@ -116,9 +122,108 @@ pub enum UiMessage {
     },
 }
 
-/// Internal message for delivering a new client to the GTK main thread.
-pub enum InternalMsg {
-    ClientReady(Arc<TransportClient>),
+// Manual `Debug` (can't derive: `TransportClient` is not `Debug`). Only
+// `ClientReady` needs special handling — it prints a marker instead of the
+// opaque transport; every other variant forwards its fields as before so
+// the test panic messages stay informative.
+impl std::fmt::Debug for UiMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UiMessage::ClientReady(_) => {
+                f.debug_tuple("ClientReady").field(&"<transport>").finish()
+            }
+            UiMessage::ConversationsLoaded(v) => {
+                f.debug_tuple("ConversationsLoaded").field(v).finish()
+            }
+            UiMessage::ConversationLoaded(v) => {
+                f.debug_tuple("ConversationLoaded").field(v).finish()
+            }
+            UiMessage::ConversationCreated { id } => f
+                .debug_struct("ConversationCreated")
+                .field("id", id)
+                .finish(),
+            UiMessage::ConversationDeleted { id } => f
+                .debug_struct("ConversationDeleted")
+                .field("id", id)
+                .finish(),
+            UiMessage::ConversationRenamed { id, title } => f
+                .debug_struct("ConversationRenamed")
+                .field("id", id)
+                .field("title", title)
+                .finish(),
+            UiMessage::StreamChunk { request_id, chunk } => f
+                .debug_struct("StreamChunk")
+                .field("request_id", request_id)
+                .field("chunk", chunk)
+                .finish(),
+            UiMessage::StreamComplete {
+                request_id,
+                full_response,
+            } => f
+                .debug_struct("StreamComplete")
+                .field("request_id", request_id)
+                .field("full_response", full_response)
+                .finish(),
+            UiMessage::StreamError { request_id, error } => f
+                .debug_struct("StreamError")
+                .field("request_id", request_id)
+                .field("error", error)
+                .finish(),
+            UiMessage::AssistantStatus {
+                request_id,
+                message,
+            } => f
+                .debug_struct("AssistantStatus")
+                .field("request_id", request_id)
+                .field("message", message)
+                .finish(),
+            UiMessage::TitleChanged {
+                conversation_id,
+                title,
+            } => f
+                .debug_struct("TitleChanged")
+                .field("conversation_id", conversation_id)
+                .field("title", title)
+                .finish(),
+            UiMessage::ConversationWarning {
+                conversation_id,
+                warning,
+            } => f
+                .debug_struct("ConversationWarning")
+                .field("conversation_id", conversation_id)
+                .field("warning", warning)
+                .finish(),
+            UiMessage::PromptSent { task_id } => f
+                .debug_struct("PromptSent")
+                .field("task_id", task_id)
+                .finish(),
+            UiMessage::ModelsLoaded(v) => f.debug_tuple("ModelsLoaded").field(v).finish(),
+            UiMessage::Connected { label } => {
+                f.debug_struct("Connected").field("label", label).finish()
+            }
+            UiMessage::Disconnected { reason } => f
+                .debug_struct("Disconnected")
+                .field("reason", reason)
+                .finish(),
+            UiMessage::StatusUpdate(s) => f.debug_tuple("StatusUpdate").field(s).finish(),
+            UiMessage::Error(s) => f.debug_tuple("Error").field(s).finish(),
+            UiMessage::TasksLoaded(v) => f.debug_tuple("TasksLoaded").field(v).finish(),
+            UiMessage::TaskStarted(v) => f.debug_tuple("TaskStarted").field(v).finish(),
+            UiMessage::TaskProgress { id, progress_hint } => f
+                .debug_struct("TaskProgress")
+                .field("id", id)
+                .field("progress_hint", progress_hint)
+                .finish(),
+            UiMessage::TaskLogAppended { id, entry } => f
+                .debug_struct("TaskLogAppended")
+                .field("id", id)
+                .field("entry", entry)
+                .finish(),
+            UiMessage::TaskCompleted { id } => {
+                f.debug_struct("TaskCompleted").field("id", id).finish()
+            }
+        }
+    }
 }
 
 /// Bridge between the GTK main loop and tokio async tasks.
@@ -177,11 +282,7 @@ where
 /// disconnect → reconnect with exponential backoff.
 ///
 /// Exits when `ui_tx` is closed (GTK window gone).
-pub async fn connection_manager(
-    config: ConnectionConfig,
-    ui_tx: mpsc::UnboundedSender<UiMessage>,
-    internal_tx: mpsc::UnboundedSender<InternalMsg>,
-) {
+pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::UnboundedSender<UiMessage>) {
     const INITIAL_BACKOFF_SECS: u64 = 2;
     const MAX_BACKOFF_SECS: u64 = 30;
 
@@ -198,8 +299,11 @@ pub async fn connection_manager(
                     return;
                 }
 
-                if internal_tx
-                    .send(InternalMsg::ClientReady(Arc::clone(&transport)))
+                // Hand the transport to the GTK main thread before the
+                // conversation list (which needs it). Same channel, so
+                // delivery stays ordered.
+                if ui_tx
+                    .send(UiMessage::ClientReady(Arc::clone(&transport)))
                     .is_err()
                 {
                     return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 //! marshalled back onto the GTK main loop via [`async_bridge`]. Credentials
 //! and OAuth/OIDC login are handled by [`credential_store`] and [`oauth`].
 
+mod assets;
 mod async_bridge;
 mod avatars;
 mod credential_store;

--- a/src/widgets/connection_config_dialog.rs
+++ b/src/widgets/connection_config_dialog.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 
 use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Button, Entry, Label, Orientation, Separator, Window};
+use gtk4::{Align, Box as GtkBox, Button, Entry, Label, Orientation, Separator, Window, glib};
 
 /// Which connector type this dialog is configuring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -313,15 +313,18 @@ pub fn show_configure_dialog<FSave, FRefresh>(
         btn_row.append(&note);
         content.append(&btn_row);
 
-        let id_entry_ref = id_entry.clone();
         let refresh_cb = Rc::new(on_refresh_models);
-        refresh_btn.connect_clicked(move |_| {
-            let id = id_entry_ref.text().trim().to_string();
-            if id.is_empty() {
-                return;
+        refresh_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = id_entry_ref)]
+            id_entry,
+            move |_| {
+                let id = id_entry_ref.text().trim().to_string();
+                if id.is_empty() {
+                    return;
+                }
+                refresh_cb(id);
             }
-            refresh_cb(id);
-        });
+        ));
     }
 
     content.append(&Separator::new(Orientation::Horizontal));
@@ -345,56 +348,65 @@ pub fn show_configure_dialog<FSave, FRefresh>(
     content.append(&btn_box);
     dialog.set_child(Some(&content));
 
-    let dialog_ref = dialog.clone();
-    cancel_btn.connect_clicked(move |_| dialog_ref.close());
+    cancel_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| dialog.close()
+    ));
 
     let save_cb = Rc::new(on_save);
-    let dialog_ref = dialog.clone();
-    let fields_for_save = Rc::clone(&fields);
-    save_btn.connect_clicked(move |_| {
-        let id = id_entry.text().trim().to_string();
-        if id.is_empty() {
-            status.set_text("Connection id is required");
-            return;
+    save_btn.connect_clicked(glib::clone!(
+        #[weak(rename_to = dialog_ref)]
+        dialog,
+        #[strong(rename_to = fields_for_save)]
+        fields,
+        #[weak]
+        id_entry,
+        move |_| {
+            let id = id_entry.text().trim().to_string();
+            if id.is_empty() {
+                status.set_text("Connection id is required");
+                return;
+            }
+            if !id
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                status.set_text("Id may only contain letters, digits, '-', and '_'");
+                return;
+            }
+
+            let by_name = |n: &str| -> Option<String> {
+                fields_for_save
+                    .borrow()
+                    .iter()
+                    .find(|f| f.name == n)
+                    .and_then(|f| text_opt(&f.entry))
+            };
+
+            let config = match connector {
+                ConnectorType::Anthropic => api::ConnectionConfigView::Anthropic {
+                    base_url: by_name("base_url"),
+                    api_key_env: by_name("api_key_env"),
+                },
+                ConnectorType::OpenAi => api::ConnectionConfigView::OpenAi {
+                    base_url: by_name("base_url"),
+                    api_key_env: by_name("api_key_env"),
+                },
+                ConnectorType::Bedrock => api::ConnectionConfigView::Bedrock {
+                    aws_profile: by_name("aws_profile"),
+                    region: by_name("region"),
+                    base_url: by_name("base_url"),
+                },
+                ConnectorType::Ollama => api::ConnectionConfigView::Ollama {
+                    base_url: by_name("base_url"),
+                },
+            };
+
+            save_cb(id, config);
+            dialog_ref.close();
         }
-        if !id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        {
-            status.set_text("Id may only contain letters, digits, '-', and '_'");
-            return;
-        }
-
-        let by_name = |n: &str| -> Option<String> {
-            fields_for_save
-                .borrow()
-                .iter()
-                .find(|f| f.name == n)
-                .and_then(|f| text_opt(&f.entry))
-        };
-
-        let config = match connector {
-            ConnectorType::Anthropic => api::ConnectionConfigView::Anthropic {
-                base_url: by_name("base_url"),
-                api_key_env: by_name("api_key_env"),
-            },
-            ConnectorType::OpenAi => api::ConnectionConfigView::OpenAi {
-                base_url: by_name("base_url"),
-                api_key_env: by_name("api_key_env"),
-            },
-            ConnectorType::Bedrock => api::ConnectionConfigView::Bedrock {
-                aws_profile: by_name("aws_profile"),
-                region: by_name("region"),
-                base_url: by_name("base_url"),
-            },
-            ConnectorType::Ollama => api::ConnectionConfigView::Ollama {
-                base_url: by_name("base_url"),
-            },
-        };
-
-        save_cb(id, config);
-        dialog_ref.close();
-    });
+    ));
 
     dialog.present();
 }

--- a/src/widgets/connections_tab.rs
+++ b/src/widgets/connections_tab.rs
@@ -12,7 +12,7 @@ use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, MenuButton, Orientation, Popover,
-    ScrolledWindow, SelectionMode, Separator,
+    ScrolledWindow, SelectionMode, Separator, glib,
 };
 
 use super::connection_config_dialog::ConnectorType;
@@ -63,14 +63,18 @@ impl ConnectionsTab {
             let btn = Button::with_label(connector.label());
             btn.add_css_class("context-button");
             btn.set_halign(Align::Fill);
-            let on_add_inner = Rc::clone(&on_add);
-            let popover_ref = popover.clone();
-            btn.connect_clicked(move |_| {
-                popover_ref.popdown();
-                if let Some(ref cb) = *on_add_inner.borrow() {
-                    cb(connector);
+            btn.connect_clicked(glib::clone!(
+                #[strong(rename_to = on_add_inner)]
+                on_add,
+                #[weak(rename_to = popover_ref)]
+                popover,
+                move |_| {
+                    popover_ref.popdown();
+                    if let Some(ref cb) = *on_add_inner.borrow() {
+                        cb(connector);
+                    }
                 }
-            });
+            ));
             popover_box.append(&btn);
         }
         popover.set_child(Some(&popover_box));
@@ -194,24 +198,30 @@ impl ConnectionsTab {
         hbox.append(&text_col);
 
         let configure_btn = Button::with_label("Configure");
-        let on_configure = Rc::clone(&self.on_configure);
         let id_for_configure = conn.id.clone();
-        configure_btn.connect_clicked(move |_| {
-            if let Some(ref cb) = *on_configure.borrow() {
-                cb(id_for_configure.clone());
+        configure_btn.connect_clicked(glib::clone!(
+            #[strong(rename_to = on_configure)]
+            self.on_configure,
+            move |_| {
+                if let Some(ref cb) = *on_configure.borrow() {
+                    cb(id_for_configure.clone());
+                }
             }
-        });
+        ));
         hbox.append(&configure_btn);
 
         let remove_btn = Button::with_label("Remove");
         remove_btn.add_css_class("destructive-action");
-        let on_remove = Rc::clone(&self.on_remove);
         let id_for_remove = conn.id.clone();
-        remove_btn.connect_clicked(move |_| {
-            if let Some(ref cb) = *on_remove.borrow() {
-                cb(id_for_remove.clone());
+        remove_btn.connect_clicked(glib::clone!(
+            #[strong(rename_to = on_remove)]
+            self.on_remove,
+            move |_| {
+                if let Some(ref cb) = *on_remove.borrow() {
+                    cb(id_for_remove.clone());
+                }
             }
-        });
+        ));
         hbox.append(&remove_btn);
 
         row.set_child(Some(&hbox));

--- a/src/widgets/knowledge_browser.rs
+++ b/src/widgets/knowledge_browser.rs
@@ -229,12 +229,16 @@ impl KnowledgeBrowser {
         // search debouncer, post-save/delete) holds a clone of the same
         // closure rather than each maintaining their own copy of the
         // captured `transport` / `bridge` / `msg_tx`.
-        let refresh: Rc<dyn Fn()> = {
-            let transport = Arc::clone(&transport);
-            let bridge = Rc::clone(&bridge);
-            let msg_tx = msg_tx.clone();
-            let state = Rc::clone(&state);
-            Rc::new(move || {
+        let refresh: Rc<dyn Fn()> = Rc::new(glib::clone!(
+            #[strong]
+            transport,
+            #[strong]
+            bridge,
+            #[strong]
+            msg_tx,
+            #[strong]
+            state,
+            move || {
                 let query = state.borrow().last_query.clone();
                 let transport = Arc::clone(&transport);
                 let msg_tx = msg_tx.clone();
@@ -251,26 +255,36 @@ impl KnowledgeBrowser {
                         Err(e) => msg_tx.send(BrowserMsg::Error(e.to_string())),
                     };
                 })
-            })
-        };
+            }
+        ));
 
         // GTK-side message pump. Dropped automatically when the window
         // closes (because the cloned widget refs are dropped, breaking
         // the channel).
-        {
-            let list_box = list_box.clone();
-            let list_status = list_status.clone();
-            let editor_status = editor_status.clone();
-            let id_label = id_label.clone();
-            let updated_label = updated_label.clone();
-            let content_view = content_view.clone();
-            let tags_entry = tags_entry.clone();
-            let metadata_view = metadata_view.clone();
-            let delete_button = delete_button.clone();
-            let state = Rc::clone(&state);
-            let refresh = Rc::clone(&refresh);
-
-            glib::spawn_future_local(async move {
+        glib::spawn_future_local(glib::clone!(
+            #[strong]
+            list_box,
+            #[strong]
+            list_status,
+            #[strong]
+            editor_status,
+            #[strong]
+            id_label,
+            #[strong]
+            updated_label,
+            #[strong]
+            content_view,
+            #[strong]
+            tags_entry,
+            #[strong]
+            metadata_view,
+            #[strong]
+            delete_button,
+            #[strong]
+            state,
+            #[strong]
+            refresh,
+            async move {
                 while let Some(msg) = msg_rx.recv().await {
                     match msg {
                         BrowserMsg::EntriesLoaded(entries) => {
@@ -321,58 +335,72 @@ impl KnowledgeBrowser {
                         }
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // Initial load.
         refresh();
 
         // Refresh button.
-        {
-            let refresh = Rc::clone(&refresh);
-            refresh_button.connect_clicked(move |_| refresh());
-        }
+        refresh_button.connect_clicked(glib::clone!(
+            #[strong]
+            refresh,
+            move |_| refresh()
+        ));
 
         // Search entry: debounce keystrokes, then re-run the query.
         {
-            let state = Rc::clone(&state);
-            let list_status = list_status.clone();
-            let refresh = Rc::clone(&refresh);
             let search_handle: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
-            search.connect_search_changed(move |entry| {
-                let q = entry.text().to_string();
-                state.borrow_mut().last_query = q;
-                list_status.set_text("Searching…");
-                // Cancel any pending debounce.
-                if let Some(prev) = search_handle.borrow_mut().take() {
-                    prev.remove();
+            search.connect_search_changed(glib::clone!(
+                #[strong]
+                state,
+                #[strong]
+                list_status,
+                #[strong]
+                refresh,
+                move |entry| {
+                    let q = entry.text().to_string();
+                    state.borrow_mut().last_query = q;
+                    list_status.set_text("Searching…");
+                    // Cancel any pending debounce.
+                    if let Some(prev) = search_handle.borrow_mut().take() {
+                        prev.remove();
+                    }
+                    let handle_slot = Rc::clone(&search_handle);
+                    let refresh_for_timeout = Rc::clone(&refresh);
+                    let timeout = glib::timeout_add_local_once(
+                        std::time::Duration::from_millis(SEARCH_DEBOUNCE_MS as u64),
+                        move || {
+                            // Drop our slot so we don't try to remove an
+                            // already-fired source on the next keystroke.
+                            let _ = handle_slot.borrow_mut().take();
+                            refresh_for_timeout();
+                        },
+                    );
+                    *search_handle.borrow_mut() = Some(timeout);
                 }
-                let handle_slot = Rc::clone(&search_handle);
-                let refresh_for_timeout = Rc::clone(&refresh);
-                let timeout = glib::timeout_add_local_once(
-                    std::time::Duration::from_millis(SEARCH_DEBOUNCE_MS as u64),
-                    move || {
-                        // Drop our slot so we don't try to remove an
-                        // already-fired source on the next keystroke.
-                        let _ = handle_slot.borrow_mut().take();
-                        refresh_for_timeout();
-                    },
-                );
-                *search_handle.borrow_mut() = Some(timeout);
-            });
+            ));
         }
 
         // List selection: load the selected entry into the editor.
-        {
-            let state = Rc::clone(&state);
-            let id_label = id_label.clone();
-            let updated_label = updated_label.clone();
-            let content_view = content_view.clone();
-            let tags_entry = tags_entry.clone();
-            let metadata_view = metadata_view.clone();
-            let delete_button = delete_button.clone();
-            let editor_status = editor_status.clone();
-            list_box.connect_row_selected(move |_, row| {
+        list_box.connect_row_selected(glib::clone!(
+            #[strong]
+            state,
+            #[strong]
+            id_label,
+            #[strong]
+            updated_label,
+            #[strong]
+            content_view,
+            #[strong]
+            tags_entry,
+            #[strong]
+            metadata_view,
+            #[strong]
+            delete_button,
+            #[strong]
+            editor_status,
+            move |_, row| {
                 let Some(row) = row else {
                     return;
                 };
@@ -395,21 +423,30 @@ impl KnowledgeBrowser {
                     &delete_button,
                     entry,
                 );
-            });
-        }
+            }
+        ));
 
         // "+ New" button: clear the editor.
-        {
-            let state = Rc::clone(&state);
-            let id_label = id_label.clone();
-            let updated_label = updated_label.clone();
-            let content_view = content_view.clone();
-            let tags_entry = tags_entry.clone();
-            let metadata_view = metadata_view.clone();
-            let delete_button = delete_button.clone();
-            let editor_status = editor_status.clone();
-            let list_box = list_box.clone();
-            new_button.connect_clicked(move |_| {
+        new_button.connect_clicked(glib::clone!(
+            #[strong]
+            state,
+            #[strong]
+            id_label,
+            #[strong]
+            updated_label,
+            #[strong]
+            content_view,
+            #[strong]
+            tags_entry,
+            #[strong]
+            metadata_view,
+            #[strong]
+            delete_button,
+            #[strong]
+            editor_status,
+            #[strong]
+            list_box,
+            move |_| {
                 state.borrow_mut().editor.selected_id = None;
                 list_box.unselect_all();
                 clear_editor(
@@ -422,20 +459,28 @@ impl KnowledgeBrowser {
                 );
                 editor_status.set_text("New entry — fill in content and Save.");
                 content_view.grab_focus();
-            });
-        }
+            }
+        ));
 
         // Save button: create or update.
-        {
-            let transport = Arc::clone(&transport);
-            let bridge = Rc::clone(&bridge);
-            let msg_tx = msg_tx.clone();
-            let state = Rc::clone(&state);
-            let content_view = content_view.clone();
-            let tags_entry = tags_entry.clone();
-            let metadata_view = metadata_view.clone();
-            let editor_status = editor_status.clone();
-            save_button.connect_clicked(move |_| {
+        save_button.connect_clicked(glib::clone!(
+            #[strong]
+            transport,
+            #[strong]
+            bridge,
+            #[strong]
+            msg_tx,
+            #[strong]
+            state,
+            #[strong]
+            content_view,
+            #[strong]
+            tags_entry,
+            #[strong]
+            metadata_view,
+            #[strong]
+            editor_status,
+            move |_| {
                 let buffer = content_view.buffer();
                 let content = buffer
                     .text(&buffer.start_iter(), &buffer.end_iter(), false)
@@ -483,21 +528,27 @@ impl KnowledgeBrowser {
                         Err(e) => msg_tx.send(BrowserMsg::Error(e.to_string())),
                     };
                 });
-            });
-        }
+            }
+        ));
 
         // Delete button: confirm via a tiny modal Window, then delete.
         // (`AlertDialog` is gated behind gtk4-rs `v4_10` which the
         // crate doesn't currently enable; rolling our own keeps the
         // dependency surface unchanged.)
-        {
-            let transport = Arc::clone(&transport);
-            let bridge = Rc::clone(&bridge);
-            let msg_tx = msg_tx.clone();
-            let state = Rc::clone(&state);
-            let editor_status = editor_status.clone();
-            let parent_window = window.clone();
-            delete_button.connect_clicked(move |_| {
+        delete_button.connect_clicked(glib::clone!(
+            #[strong]
+            transport,
+            #[strong]
+            bridge,
+            #[strong]
+            msg_tx,
+            #[strong]
+            state,
+            #[strong]
+            editor_status,
+            #[weak(rename_to = parent_window)]
+            window,
+            move |_| {
                 let Some(id) = state.borrow().editor.selected_id.clone() else {
                     return;
                 };
@@ -527,17 +578,23 @@ impl KnowledgeBrowser {
                 layout.append(&buttons);
                 confirm.set_child(Some(&layout));
 
-                {
-                    let confirm = confirm.clone();
-                    cancel.connect_clicked(move |_| confirm.close());
-                }
-                {
-                    let transport = Arc::clone(&transport);
-                    let bridge = Rc::clone(&bridge);
-                    let msg_tx = msg_tx.clone();
-                    let editor_status = editor_status.clone();
-                    let confirm_window = confirm.clone();
-                    confirm_btn.connect_clicked(move |_| {
+                cancel.connect_clicked(glib::clone!(
+                    #[weak]
+                    confirm,
+                    move |_| confirm.close()
+                ));
+                confirm_btn.connect_clicked(glib::clone!(
+                    #[strong]
+                    transport,
+                    #[strong]
+                    bridge,
+                    #[strong]
+                    msg_tx,
+                    #[strong]
+                    editor_status,
+                    #[weak(rename_to = confirm_window)]
+                    confirm,
+                    move |_| {
                         confirm_window.close();
                         editor_status.set_text("Deleting…");
                         let id_for_async = id.clone();
@@ -552,12 +609,12 @@ impl KnowledgeBrowser {
                                 Err(e) => msg_tx.send(BrowserMsg::Error(e.to_string())),
                             };
                         });
-                    });
-                }
+                    }
+                ));
 
                 confirm.present();
-            });
-        }
+            }
+        ));
 
         Self { window }
     }

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -52,18 +52,16 @@ impl LoginScreen {
         brand_box.set_margin_bottom(16);
 
         const ICON_BYTES: &[u8] = include_bytes!("../../assets/adele_communicating.png");
-        let icon_path = dirs::cache_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("adele-gtk-brand-icon.png");
-        if let Err(e) = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&icon_path)
-            .and_then(|mut f| std::io::Write::write_all(&mut f, ICON_BYTES))
-            && e.kind() != std::io::ErrorKind::AlreadyExists
-        {
-            tracing::warn!("Failed to write brand icon: {e}");
-        }
+        let icon_path =
+            match crate::assets::extract_to_cache(ICON_BYTES, "adele-gtk-brand-icon.png") {
+                Ok(path) => path,
+                Err(e) => {
+                    tracing::warn!("Failed to write brand icon: {e}");
+                    dirs::cache_dir()
+                        .unwrap_or_else(std::env::temp_dir)
+                        .join("adele-gtk-brand-icon.png")
+                }
+            };
         let icon = Image::from_file(icon_path.to_str().unwrap_or_default());
         icon.set_pixel_size(56);
         brand_box.append(&icon);

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -127,150 +127,181 @@ impl LoginScreen {
         let populate: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
 
         {
-            let profiles = Rc::clone(&profiles);
-            let list_box = Rc::clone(&list_box);
-            let empty_label = Rc::clone(&empty_label);
-            let connect_btn = Rc::clone(&connect_btn);
-            let status_label = Rc::clone(&status_label);
-            let window_ref = window_ref.clone();
-            let populate_self = Rc::clone(&populate);
+            let f: Rc<dyn Fn()> = Rc::new(glib::clone!(
+                #[strong]
+                profiles,
+                #[strong]
+                list_box,
+                #[strong]
+                empty_label,
+                #[strong]
+                connect_btn,
+                #[strong]
+                status_label,
+                #[weak]
+                window_ref,
+                #[strong(rename_to = populate_self)]
+                populate,
+                move || {
+                    // Clear existing rows
+                    while let Some(child) = list_box.first_child() {
+                        list_box.remove(&child);
+                    }
 
-            let f: Rc<dyn Fn()> = Rc::new(move || {
-                // Clear existing rows
-                while let Some(child) = list_box.first_child() {
-                    list_box.remove(&child);
-                }
+                    let profs = profiles.borrow();
+                    empty_label.set_visible(profs.is_empty());
+                    connect_btn.set_sensitive(!profs.is_empty());
 
-                let profs = profiles.borrow();
-                empty_label.set_visible(profs.is_empty());
-                connect_btn.set_sensitive(!profs.is_empty());
+                    for (idx, profile) in profs.iter().enumerate() {
+                        let row = ListBoxRow::new();
+                        let hbox = GtkBox::new(Orientation::Horizontal, 8);
+                        hbox.set_margin_start(12);
+                        hbox.set_margin_end(12);
+                        hbox.set_margin_top(8);
+                        hbox.set_margin_bottom(8);
 
-                for (idx, profile) in profs.iter().enumerate() {
-                    let row = ListBoxRow::new();
-                    let hbox = GtkBox::new(Orientation::Horizontal, 8);
-                    hbox.set_margin_start(12);
-                    hbox.set_margin_end(12);
-                    hbox.set_margin_top(8);
-                    hbox.set_margin_bottom(8);
+                        let name_label = Label::new(Some(&profile.name));
+                        name_label.set_halign(Align::Start);
+                        name_label.set_hexpand(true);
+                        hbox.append(&name_label);
 
-                    let name_label = Label::new(Some(&profile.name));
-                    name_label.set_halign(Align::Start);
-                    name_label.set_hexpand(true);
-                    hbox.append(&name_label);
-
-                    let detail = match &profile.protocol {
-                        ProtocolConfig::Local { path: Some(p) } => {
-                            format!("local · {}", p.display())
-                        }
-                        ProtocolConfig::Local { path: None } => "Local socket".to_string(),
-                        ProtocolConfig::Websocket { url, .. } => url.clone(),
-                    };
-                    let url_label = Label::new(Some(&detail));
-                    url_label.add_css_class("dim-label");
-                    url_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
-                    url_label.set_max_width_chars(30);
-                    hbox.append(&url_label);
-
-                    row.set_child(Some(&hbox));
-
-                    // Right-click context menu
-                    let gesture = GestureClick::new();
-                    gesture.set_button(3);
-                    let profiles_ref = Rc::clone(&profiles);
-                    let status_ref = Rc::clone(&status_label);
-                    let window_inner = window_ref.clone();
-                    let populate_inner = Rc::clone(&populate_self);
-                    gesture.connect_pressed(move |gesture, _n, x, y| {
-                        let Some(widget) = gesture.widget() else {
-                            return;
+                        let detail = match &profile.protocol {
+                            ProtocolConfig::Local { path: Some(p) } => {
+                                format!("local · {}", p.display())
+                            }
+                            ProtocolConfig::Local { path: None } => "Local socket".to_string(),
+                            ProtocolConfig::Websocket { url, .. } => url.clone(),
                         };
+                        let url_label = Label::new(Some(&detail));
+                        url_label.add_css_class("dim-label");
+                        url_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+                        url_label.set_max_width_chars(30);
+                        hbox.append(&url_label);
 
-                        let popover = Popover::new();
-                        popover.add_css_class("context-popover");
-                        popover.set_parent(&widget);
-                        popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(
-                            x as i32, y as i32, 1, 1,
-                        )));
-                        popover.set_has_arrow(false);
+                        row.set_child(Some(&hbox));
 
-                        let menu_box = GtkBox::new(Orientation::Vertical, 0);
+                        // Right-click context menu
+                        let gesture = GestureClick::new();
+                        gesture.set_button(3);
+                        gesture.connect_pressed(glib::clone!(
+                            #[strong]
+                            profiles,
+                            #[strong(rename_to = status_ref)]
+                            status_label,
+                            #[weak(rename_to = window_inner)]
+                            window_ref,
+                            #[strong(rename_to = populate_inner)]
+                            populate_self,
+                            move |gesture, _n, x, y| {
+                                let Some(widget) = gesture.widget() else {
+                                    return;
+                                };
 
-                        // Edit button
-                        let edit_btn = Button::with_label("Edit");
-                        edit_btn.add_css_class("context-button");
-                        let profiles_inner = Rc::clone(&profiles_ref);
-                        let popover_ref = popover.clone();
-                        let window_edit = window_inner.clone();
-                        let populate_edit = Rc::clone(&populate_inner);
-                        edit_btn.connect_clicked(move |_| {
-                            popover_ref.popdown();
-                            let profile = {
-                                let profs = profiles_inner.borrow();
-                                profs.get(idx).cloned()
-                            };
-                            if let Some(profile) = profile {
-                                let profiles_save = Rc::clone(&profiles_inner);
-                                let populate_save = Rc::clone(&populate_edit);
-                                setup_dialog::show_setup_dialog(
-                                    &window_edit,
-                                    Some(&profile),
-                                    move |updated| {
-                                        let store = ProfileStore::new();
-                                        let _ = store.update(&updated);
-                                        *profiles_save.borrow_mut() =
-                                            store.load().unwrap_or_default();
-                                        if let Some(ref f) = *populate_save.borrow() {
-                                            f();
+                                let popover = Popover::new();
+                                popover.add_css_class("context-popover");
+                                popover.set_parent(&widget);
+                                popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(
+                                    x as i32, y as i32, 1, 1,
+                                )));
+                                popover.set_has_arrow(false);
+
+                                let menu_box = GtkBox::new(Orientation::Vertical, 0);
+
+                                // Edit button
+                                let edit_btn = Button::with_label("Edit");
+                                edit_btn.add_css_class("context-button");
+                                edit_btn.connect_clicked(glib::clone!(
+                                    #[strong(rename_to = profiles_inner)]
+                                    profiles,
+                                    #[weak]
+                                    popover,
+                                    #[weak(rename_to = window_edit)]
+                                    window_inner,
+                                    #[strong(rename_to = populate_edit)]
+                                    populate_inner,
+                                    move |_| {
+                                        popover.popdown();
+                                        let profile = {
+                                            let profs = profiles_inner.borrow();
+                                            profs.get(idx).cloned()
+                                        };
+                                        if let Some(profile) = profile {
+                                            setup_dialog::show_setup_dialog(
+                                                &window_edit,
+                                                Some(&profile),
+                                                glib::clone!(
+                                                    #[strong(rename_to = profiles_save)]
+                                                    profiles_inner,
+                                                    #[strong(rename_to = populate_save)]
+                                                    populate_edit,
+                                                    move |updated| {
+                                                        let store = ProfileStore::new();
+                                                        let _ = store.update(&updated);
+                                                        *profiles_save.borrow_mut() =
+                                                            store.load().unwrap_or_default();
+                                                        if let Some(ref f) = *populate_save.borrow()
+                                                        {
+                                                            f();
+                                                        }
+                                                    }
+                                                ),
+                                            );
                                         }
-                                    },
-                                );
+                                    }
+                                ));
+                                menu_box.append(&edit_btn);
+
+                                // Delete button
+                                let delete_btn = Button::with_label("Delete");
+                                delete_btn.add_css_class("context-button");
+                                delete_btn.add_css_class("destructive-action");
+                                delete_btn.connect_clicked(glib::clone!(
+                                    #[strong(rename_to = profiles_inner)]
+                                    profiles,
+                                    #[weak]
+                                    popover,
+                                    #[strong(rename_to = status_inner)]
+                                    status_ref,
+                                    #[strong(rename_to = populate_del)]
+                                    populate_inner,
+                                    move |_| {
+                                        popover.popdown();
+                                        let profile_id = {
+                                            let profs = profiles_inner.borrow();
+                                            profs.get(idx).map(|p| p.id.clone())
+                                        };
+                                        if let Some(id) = profile_id {
+                                            let _ = CredentialStore::delete_credentials(&id);
+                                            let store = ProfileStore::new();
+                                            let _ = store.delete(&id);
+                                            let new_profiles = store.load().unwrap_or_default();
+                                            *profiles_inner.borrow_mut() = new_profiles;
+                                            status_inner.set_text("Connection deleted");
+                                            if let Some(ref f) = *populate_del.borrow() {
+                                                f();
+                                            }
+                                        }
+                                    }
+                                ));
+                                menu_box.append(&delete_btn);
+
+                                popover.set_child(Some(&menu_box));
+                                popover.popup();
                             }
-                        });
-                        menu_box.append(&edit_btn);
+                        ));
+                        row.add_controller(gesture);
 
-                        // Delete button
-                        let delete_btn = Button::with_label("Delete");
-                        delete_btn.add_css_class("context-button");
-                        delete_btn.add_css_class("destructive-action");
-                        let profiles_inner = Rc::clone(&profiles_ref);
-                        let popover_ref = popover.clone();
-                        let status_inner = Rc::clone(&status_ref);
-                        let populate_del = Rc::clone(&populate_inner);
-                        delete_btn.connect_clicked(move |_| {
-                            popover_ref.popdown();
-                            let profile_id = {
-                                let profs = profiles_inner.borrow();
-                                profs.get(idx).map(|p| p.id.clone())
-                            };
-                            if let Some(id) = profile_id {
-                                let _ = CredentialStore::delete_credentials(&id);
-                                let store = ProfileStore::new();
-                                let _ = store.delete(&id);
-                                let new_profiles = store.load().unwrap_or_default();
-                                *profiles_inner.borrow_mut() = new_profiles;
-                                status_inner.set_text("Connection deleted");
-                                if let Some(ref f) = *populate_del.borrow() {
-                                    f();
-                                }
-                            }
-                        });
-                        menu_box.append(&delete_btn);
+                        list_box.append(&row);
+                    }
 
-                        popover.set_child(Some(&menu_box));
-                        popover.popup();
-                    });
-                    row.add_controller(gesture);
-
-                    list_box.append(&row);
+                    // Select first row if any
+                    if !profs.is_empty()
+                        && let Some(first_row) = list_box.row_at_index(0)
+                    {
+                        list_box.select_row(Some(&first_row));
+                    }
                 }
-
-                // Select first row if any
-                if !profs.is_empty()
-                    && let Some(first_row) = list_box.row_at_index(0)
-                {
-                    list_box.select_row(Some(&first_row));
-                }
-            });
+            ));
 
             *populate.borrow_mut() = Some(Rc::clone(&f));
         }
@@ -283,40 +314,57 @@ impl LoginScreen {
         }
 
         // Enable connect button when a row is selected
-        {
-            let connect_btn = Rc::clone(&connect_btn);
-            list_box.connect_row_selected(move |_, row| {
+        list_box.connect_row_selected(glib::clone!(
+            #[strong]
+            connect_btn,
+            move |_, row| {
                 connect_btn.set_sensitive(row.is_some());
-            });
-        }
+            }
+        ));
 
         // Add Connection button
-        {
-            let window_ref = window_ref.clone();
-            let profiles = Rc::clone(&profiles);
-            let populate = Rc::clone(&populate);
-            add_btn.connect_clicked(move |_| {
-                let profiles = Rc::clone(&profiles);
-                let populate = Rc::clone(&populate);
-                setup_dialog::show_setup_dialog(&window_ref, None, move |profile| {
-                    let store = ProfileStore::new();
-                    let _ = store.add(profile);
-                    *profiles.borrow_mut() = store.load().unwrap_or_default();
-                    if let Some(ref f) = *populate.borrow() {
-                        f();
-                    }
-                });
-            });
-        }
+        add_btn.connect_clicked(glib::clone!(
+            #[weak]
+            window_ref,
+            #[strong]
+            profiles,
+            #[strong]
+            populate,
+            move |_| {
+                setup_dialog::show_setup_dialog(
+                    &window_ref,
+                    None,
+                    glib::clone!(
+                        #[strong]
+                        profiles,
+                        #[strong]
+                        populate,
+                        move |profile| {
+                            let store = ProfileStore::new();
+                            let _ = store.add(profile);
+                            *profiles.borrow_mut() = store.load().unwrap_or_default();
+                            if let Some(ref f) = *populate.borrow() {
+                                f();
+                            }
+                        }
+                    ),
+                );
+            }
+        ));
 
         // Connect button
-        {
-            let profiles = Rc::clone(&profiles);
-            let list_box = Rc::clone(&list_box);
-            let status_label = Rc::clone(&status_label);
-            let app_ref = app.clone();
-            let window_ref = window_ref.clone();
-            connect_btn.connect_clicked(move |btn| {
+        connect_btn.connect_clicked(glib::clone!(
+            #[strong]
+            profiles,
+            #[strong]
+            list_box,
+            #[strong]
+            status_label,
+            #[weak(rename_to = app_ref)]
+            app,
+            #[weak]
+            window_ref,
+            move |btn| {
                 let Some(row) = list_box.selected_row() else {
                     return;
                 };
@@ -364,8 +412,8 @@ impl LoginScreen {
                         }
                     }
                 });
-            });
-        }
+            }
+        ));
 
         Self { window }
     }

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -470,15 +470,7 @@ pub async fn connect_to_profile(
                     if let Some(ref new_refresh) = tokens.refresh_token {
                         let _ = CredentialStore::store_refresh_token(&profile.id, new_refresh);
                     }
-                    return Ok(ConnectionConfig {
-                        transport_mode: TransportMode::Ws,
-                        ws_url: ws_url.clone(),
-                        ws_jwt: Some(tokens.access_token),
-                        ws_login_username: None,
-                        ws_login_password: None,
-                        ws_subject: ws_subject.clone(),
-                        ..Default::default()
-                    });
+                    return Ok(ws_jwt_config(&ws_url, &ws_subject, tokens.access_token));
                 }
                 Err(e) => {
                     tracing::info!("silent refresh failed, will try browser flow: {e}");
@@ -495,15 +487,7 @@ pub async fn connect_to_profile(
             let _ = CredentialStore::store_refresh_token(&profile.id, refresh_token);
         }
 
-        return Ok(ConnectionConfig {
-            transport_mode: TransportMode::Ws,
-            ws_url: ws_url.clone(),
-            ws_jwt: Some(tokens.access_token),
-            ws_login_username: None,
-            ws_login_password: None,
-            ws_subject: ws_subject.clone(),
-            ..Default::default()
-        });
+        return Ok(ws_jwt_config(&ws_url, &ws_subject, tokens.access_token));
     }
 
     // Fall back to password auth
@@ -525,4 +509,24 @@ pub async fn connect_to_profile(
     }
 
     anyhow::bail!("server does not offer any supported auth methods")
+}
+
+/// Build the WebSocket + bearer-JWT connection config shared by both OAuth
+/// success paths (silent refresh and full browser flow). The only thing that
+/// differs between those paths is where the `jwt` comes from.
+fn ws_jwt_config(
+    ws_url: &str,
+    ws_subject: &str,
+    jwt: String,
+) -> desktop_assistant_client_common::ConnectionConfig {
+    use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
+    ConnectionConfig {
+        transport_mode: TransportMode::Ws,
+        ws_url: ws_url.to_string(),
+        ws_jwt: Some(jwt),
+        ws_login_username: None,
+        ws_login_password: None,
+        ws_subject: ws_subject.to_string(),
+        ..Default::default()
+    }
 }

--- a/src/widgets/model_picker.rs
+++ b/src/widgets/model_picker.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
 use gtk4::{
-    Align, Box as GtkBox, Button, Label, MenuButton, Orientation, Popover, Separator, Window,
+    Align, Box as GtkBox, Button, Label, MenuButton, Orientation, Popover, Separator, Window, glib,
 };
 
 use crate::selected_models::{SelectedModel, SelectedModelsStore};
@@ -194,64 +194,71 @@ fn rebuild_popover_into(
     let select_btn = Button::with_label("Select Models…");
     select_btn.add_css_class("context-button");
     select_btn.set_halign(Align::Fill);
-    let popover_ref = popover.clone();
-    let popover_to_rebuild = popover.clone();
-    let menu_button_ref = menu_button.clone();
-    let available_ref = Rc::clone(available);
-    let selected_ref = Rc::clone(selected);
-    let active_ref = Rc::clone(active);
-    let store_ref = Rc::clone(store);
-    select_btn.connect_clicked(move |btn| {
-        popover_ref.popdown();
-        let Some(parent) = btn.root().and_then(|r| r.downcast::<Window>().ok()) else {
-            return;
-        };
-        let available_snapshot = available_ref.borrow().clone();
-        let currently_selected = selected_ref.borrow().clone();
-        let selected_for_save = Rc::clone(&selected_ref);
-        let active_for_save = Rc::clone(&active_ref);
-        let store_for_save = Rc::clone(&store_ref);
-        let popover_for_save = popover_to_rebuild.clone();
-        let menu_button_for_save = menu_button_ref.clone();
-        let available_for_save = Rc::clone(&available_ref);
-        show_select_models_dialog(
-            &parent,
-            &available_snapshot,
-            &currently_selected,
-            move |chosen| {
-                if let Err(e) = store_for_save.save(&chosen) {
-                    tracing::warn!("Failed to save selected_models.json: {e}");
-                }
-                // Drop the active selection if it's no longer in the
-                // user's curated list — keeping it would mean the
-                // button reflects a row that isn't shown in the popover.
-                // The conversation's stored selection on the daemon is
-                // untouched: we just stop overriding it from the client.
-                {
-                    let mut active = active_for_save.borrow_mut();
-                    if let Some(sel) = active.as_ref()
-                        && !chosen.iter().any(|c| c == sel)
-                    {
-                        *active = None;
+    select_btn.connect_clicked(glib::clone!(
+        #[weak]
+        popover,
+        #[weak(rename_to = menu_button_ref)]
+        menu_button,
+        #[strong(rename_to = available_ref)]
+        available,
+        #[strong(rename_to = selected_ref)]
+        selected,
+        #[strong(rename_to = active_ref)]
+        active,
+        #[strong(rename_to = store_ref)]
+        store,
+        move |btn| {
+            popover.popdown();
+            let Some(parent) = btn.root().and_then(|r| r.downcast::<Window>().ok()) else {
+                return;
+            };
+            let available_snapshot = available_ref.borrow().clone();
+            let currently_selected = selected_ref.borrow().clone();
+            let selected_for_save = Rc::clone(&selected_ref);
+            let active_for_save = Rc::clone(&active_ref);
+            let store_for_save = Rc::clone(&store_ref);
+            let popover_for_save = popover.clone();
+            let menu_button_for_save = menu_button_ref.clone();
+            let available_for_save = Rc::clone(&available_ref);
+            show_select_models_dialog(
+                &parent,
+                &available_snapshot,
+                &currently_selected,
+                move |chosen| {
+                    if let Err(e) = store_for_save.save(&chosen) {
+                        tracing::warn!("Failed to save selected_models.json: {e}");
                     }
-                }
-                *selected_for_save.borrow_mut() = chosen;
-                rebuild_popover_into(
-                    &popover_for_save,
-                    &menu_button_for_save,
-                    &available_for_save,
-                    &selected_for_save,
-                    &active_for_save,
-                    &store_for_save,
-                );
-                refresh_menu_button_label(
-                    &menu_button_for_save,
-                    &available_for_save,
-                    &active_for_save,
-                );
-            },
-        );
-    });
+                    // Drop the active selection if it's no longer in the
+                    // user's curated list — keeping it would mean the
+                    // button reflects a row that isn't shown in the popover.
+                    // The conversation's stored selection on the daemon is
+                    // untouched: we just stop overriding it from the client.
+                    {
+                        let mut active = active_for_save.borrow_mut();
+                        if let Some(sel) = active.as_ref()
+                            && !chosen.iter().any(|c| c == sel)
+                        {
+                            *active = None;
+                        }
+                    }
+                    *selected_for_save.borrow_mut() = chosen;
+                    rebuild_popover_into(
+                        &popover_for_save,
+                        &menu_button_for_save,
+                        &available_for_save,
+                        &selected_for_save,
+                        &active_for_save,
+                        &store_for_save,
+                    );
+                    refresh_menu_button_label(
+                        &menu_button_for_save,
+                        &available_for_save,
+                        &active_for_save,
+                    );
+                },
+            );
+        }
+    ));
     menu_box.append(&select_btn);
 
     menu_box.append(&Separator::new(Orientation::Horizontal));
@@ -273,16 +280,22 @@ fn rebuild_popover_into(
             btn.add_css_class("context-button");
             btn.set_halign(Align::Fill);
 
-            let active_ref = Rc::clone(active);
-            let popover_ref = popover.clone();
-            let menu_button_ref = menu_button.clone();
-            let available_ref = Rc::clone(available);
             let sel_owned = sel.clone();
-            btn.connect_clicked(move |_| {
-                *active_ref.borrow_mut() = Some(sel_owned.clone());
-                refresh_menu_button_label(&menu_button_ref, &available_ref, &active_ref);
-                popover_ref.popdown();
-            });
+            btn.connect_clicked(glib::clone!(
+                #[strong(rename_to = active_ref)]
+                active,
+                #[weak(rename_to = popover_ref)]
+                popover,
+                #[weak(rename_to = menu_button_ref)]
+                menu_button,
+                #[strong(rename_to = available_ref)]
+                available,
+                move |_| {
+                    *active_ref.borrow_mut() = Some(sel_owned.clone());
+                    refresh_menu_button_label(&menu_button_ref, &available_ref, &active_ref);
+                    popover_ref.popdown();
+                }
+            ));
             menu_box.append(&btn);
         }
     }

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 
 use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, DropDown, Label, Orientation, Separator, StringList};
+use gtk4::{Align, Box as GtkBox, DropDown, Label, Orientation, Separator, StringList, glib};
 
 type SetPurposeCb = Box<dyn Fn(api::PurposeKindApi, api::PurposeConfigView)>;
 type RequestModelsCb = Box<dyn Fn(String)>;
@@ -140,14 +140,20 @@ impl PurposesTab {
 
             // When connection changes: rebuild models dropdown and emit a
             // write if we're not currently reconciling.
-            {
-                let rows = Rc::clone(&rows);
-                let connections = Rc::clone(&connections);
-                let models_by_connection = Rc::clone(&models_by_connection);
-                let on_set_purpose = Rc::clone(&on_set_purpose);
-                let on_request_models = Rc::clone(&on_request_models);
-                let suppress = Rc::clone(&suppress);
-                connection_dd.connect_selected_notify(move |_| {
+            connection_dd.connect_selected_notify(glib::clone!(
+                #[strong]
+                rows,
+                #[strong]
+                connections,
+                #[strong]
+                models_by_connection,
+                #[strong]
+                on_set_purpose,
+                #[strong]
+                on_request_models,
+                #[strong]
+                suppress,
+                move |_| {
                     if *suppress.borrow() {
                         return;
                     }
@@ -161,32 +167,38 @@ impl PurposesTab {
                         &suppress,
                     );
                     emit_current(purpose, &rows, &on_set_purpose);
-                });
-            }
+                }
+            ));
 
-            {
-                let rows = Rc::clone(&rows);
-                let on_set_purpose = Rc::clone(&on_set_purpose);
-                let suppress = Rc::clone(&suppress);
-                model_dd.connect_selected_notify(move |_| {
+            model_dd.connect_selected_notify(glib::clone!(
+                #[strong]
+                rows,
+                #[strong]
+                on_set_purpose,
+                #[strong]
+                suppress,
+                move |_| {
                     if *suppress.borrow() {
                         return;
                     }
                     emit_current(purpose, &rows, &on_set_purpose);
-                });
-            }
+                }
+            ));
 
-            {
-                let rows = Rc::clone(&rows);
-                let on_set_purpose = Rc::clone(&on_set_purpose);
-                let suppress = Rc::clone(&suppress);
-                effort_dd.connect_selected_notify(move |_| {
+            effort_dd.connect_selected_notify(glib::clone!(
+                #[strong]
+                rows,
+                #[strong]
+                on_set_purpose,
+                #[strong]
+                suppress,
+                move |_| {
                     if *suppress.borrow() {
                         return;
                     }
                     emit_current(purpose, &rows, &on_set_purpose);
-                });
-            }
+                }
+            ));
 
             rows.borrow_mut().insert(purpose.as_key().to_string(), row);
         }

--- a/src/widgets/select_models_dialog.rs
+++ b/src/widgets/select_models_dialog.rs
@@ -4,7 +4,7 @@ use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Button, CheckButton, Label, Orientation, ScrolledWindow, Separator,
-    Window,
+    Window, glib,
 };
 
 use crate::selected_models::SelectedModel;
@@ -130,26 +130,33 @@ pub fn show_select_models_dialog<F>(
     btn_row.set_margin_end(16);
 
     let cancel = Button::with_label("Cancel");
-    let dialog_ref = dialog.clone();
-    cancel.connect_clicked(move |_| {
-        dialog_ref.close();
-    });
+    cancel.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
     btn_row.append(&cancel);
 
     let save = Button::with_label("Save");
     save.add_css_class("suggested-action");
-    let dialog_ref = dialog.clone();
-    let checks_ref = std::rc::Rc::clone(&checks);
-    save.connect_clicked(move |_| {
-        let chosen: Vec<SelectedModel> = checks_ref
-            .borrow()
-            .iter()
-            .filter(|&(_model, check)| check.is_active())
-            .map(|(model, _check)| model.clone())
-            .collect();
-        dialog_ref.close();
-        on_save(chosen);
-    });
+    save.connect_clicked(glib::clone!(
+        #[weak(rename_to = dialog_ref)]
+        dialog,
+        #[strong(rename_to = checks_ref)]
+        checks,
+        move |_| {
+            let chosen: Vec<SelectedModel> = checks_ref
+                .borrow()
+                .iter()
+                .filter(|&(_model, check)| check.is_active())
+                .map(|(model, _check)| model.clone())
+                .collect();
+            dialog_ref.close();
+            on_save(chosen);
+        }
+    ));
     btn_row.append(&save);
 
     outer.append(&btn_row);

--- a/src/widgets/settings_dialog.rs
+++ b/src/widgets/settings_dialog.rs
@@ -79,14 +79,20 @@ fn confirm<F>(
 
     dialog.set_child(Some(&content));
 
-    let dialog_ref = dialog.clone();
-    cancel.connect_clicked(move |_| dialog_ref.close());
+    cancel.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| dialog.close()
+    ));
 
-    let dialog_ref = dialog.clone();
-    confirm_btn.connect_clicked(move |_| {
-        dialog_ref.close();
-        on_confirm();
-    });
+    confirm_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+            on_confirm();
+        }
+    ));
 
     dialog.present();
 }
@@ -138,8 +144,11 @@ pub fn show_settings_dialog(
     footer.append(&*status_label);
 
     let close_btn = Button::with_label("Close");
-    let dialog_ref = dialog.clone();
-    close_btn.connect_clicked(move |_| dialog_ref.close());
+    close_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| dialog.close()
+    ));
     footer.append(&close_btn);
 
     vbox.append(&footer);
@@ -151,13 +160,18 @@ pub fn show_settings_dialog(
     // and after any mutation. Owns its own `list_available_models(None)`
     // fetch so embedding models reach the Purposes tab.
     // ---------------------------------------------------------------
-    let refresh: Rc<dyn Fn()> = {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let connections_tab = Rc::clone(&connections_tab);
-        let purposes_tab = Rc::clone(&purposes_tab);
-        let status_label = Rc::clone(&status_label);
-        Rc::new(move || {
+    let refresh: Rc<dyn Fn()> = Rc::new(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong]
+        connections_tab,
+        #[strong]
+        purposes_tab,
+        #[strong]
+        status_label,
+        move || {
             let connections_tab = Rc::clone(&connections_tab);
             let purposes_tab = Rc::clone(&purposes_tab);
             let status_label = Rc::clone(&status_label);
@@ -233,21 +247,22 @@ pub fn show_settings_dialog(
                     }
                 }
             });
-        })
-    };
+        }
+    ));
 
     // ---------------------------------------------------------------
     // Connections tab wiring.
     // ---------------------------------------------------------------
-    {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let refresh = Rc::clone(&refresh);
-        let dialog_weak = dialog.downgrade();
-        connections_tab.connect_add(move |connector| {
-            let Some(parent) = dialog_weak.upgrade() else {
-                return;
-            };
+    connections_tab.connect_add(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong]
+        refresh,
+        #[weak(rename_to = parent)]
+        dialog,
+        move |connector| {
             let transport = Arc::clone(&transport);
             let bridge = Rc::clone(&bridge);
             let refresh = Rc::clone(&refresh);
@@ -281,19 +296,21 @@ pub fn show_settings_dialog(
                 // Add-flow never has a connection to refresh yet.
                 |_id| {},
             );
-        });
-    }
+        }
+    ));
 
-    {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let connections_tab_cfg = Rc::clone(&connections_tab);
-        let refresh = Rc::clone(&refresh);
-        let dialog_weak = dialog.downgrade();
-        connections_tab.connect_configure(move |id| {
-            let Some(parent) = dialog_weak.upgrade() else {
-                return;
-            };
+    connections_tab.connect_configure(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong(rename_to = connections_tab_cfg)]
+        connections_tab,
+        #[strong]
+        refresh,
+        #[weak(rename_to = parent)]
+        dialog,
+        move |id| {
             let Some(existing) = connections_tab_cfg.find(&id) else {
                 return;
             };
@@ -362,18 +379,19 @@ pub fn show_settings_dialog(
                     });
                 },
             );
-        });
-    }
+        }
+    ));
 
-    {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let refresh = Rc::clone(&refresh);
-        let dialog_weak = dialog.downgrade();
-        connections_tab.connect_remove(move |id| {
-            let Some(parent) = dialog_weak.upgrade() else {
-                return;
-            };
+    connections_tab.connect_remove(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong]
+        refresh,
+        #[weak(rename_to = parent)]
+        dialog,
+        move |id| {
             let transport_for_confirm = Arc::clone(&transport);
             let bridge_for_confirm = Rc::clone(&bridge);
             let refresh_for_confirm = Rc::clone(&refresh);
@@ -396,17 +414,20 @@ pub fn show_settings_dialog(
                     );
                 },
             );
-        });
-    }
+        }
+    ));
 
     // ---------------------------------------------------------------
     // Purposes tab wiring.
     // ---------------------------------------------------------------
-    {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let refresh = Rc::clone(&refresh);
-        purposes_tab.connect_set_purpose(move |purpose, config| {
+    purposes_tab.connect_set_purpose(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong]
+        refresh,
+        move |purpose, config| {
             let transport = Arc::clone(&transport);
             let refresh = Rc::clone(&refresh);
             let ui_tx = bridge.ui_sender();
@@ -425,14 +446,17 @@ pub fn show_settings_dialog(
                     }
                 }
             });
-        });
-    }
+        }
+    ));
 
-    {
-        let transport = Arc::clone(&transport);
-        let bridge = Rc::clone(&bridge);
-        let purposes_tab_for_cb = Rc::clone(&purposes_tab);
-        purposes_tab.connect_request_models(move |connection_id| {
+    purposes_tab.connect_request_models(glib::clone!(
+        #[strong]
+        transport,
+        #[strong]
+        bridge,
+        #[strong(rename_to = purposes_tab_for_cb)]
+        purposes_tab,
+        move |connection_id| {
             let transport = Arc::clone(&transport);
             let ui_tx = bridge.ui_sender();
             let purposes_tab = Rc::clone(&purposes_tab_for_cb);
@@ -460,8 +484,8 @@ pub fn show_settings_dialog(
                     }
                 }
             });
-        });
-    }
+        }
+    ));
 
     // First refresh.
     refresh();

--- a/src/widgets/setup_dialog.rs
+++ b/src/widgets/setup_dialog.rs
@@ -1,5 +1,7 @@
 use gtk4::prelude::*;
-use gtk4::{Align, Box as GtkBox, Button, DropDown, Entry, Label, Orientation, StringList, Window};
+use gtk4::{
+    Align, Box as GtkBox, Button, DropDown, Entry, Label, Orientation, StringList, Window, glib,
+};
 
 use crate::credential_store::CredentialStore;
 use crate::profile::{ConnectionProfile, ProtocolConfig};
@@ -131,13 +133,15 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
         ws.set_visible(sel == PROTO_WEBSOCKET);
     };
     apply_visibility(proto_dropdown.selected(), &local_group, &ws_group);
-    {
-        let local_group = local_group.clone();
-        let ws_group = ws_group.clone();
-        proto_dropdown.connect_selected_notify(move |dd| {
+    proto_dropdown.connect_selected_notify(glib::clone!(
+        #[weak]
+        local_group,
+        #[weak]
+        ws_group,
+        move |dd| {
             apply_visibility(dd.selected(), &local_group, &ws_group);
-        });
-    }
+        }
+    ));
 
     // Buttons
     let button_box = GtkBox::new(Orientation::Horizontal, 8);
@@ -162,60 +166,65 @@ pub fn show_setup_dialog<F: Fn(ConnectionProfile) + 'static>(
     dialog.set_child(Some(&content));
 
     // Cancel
-    {
-        let dialog_ref = dialog.clone();
-        cancel_btn.connect_clicked(move |_| {
-            dialog_ref.close();
-        });
-    }
+    cancel_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
 
     // Save
     {
-        let dialog_ref = dialog.clone();
         let existing_id = existing.map(|p| p.id.clone());
-        save_btn.connect_clicked(move |_| {
-            let name = name_entry.text().trim().to_string();
-            if name.is_empty() {
-                status.set_text("Connection name is required");
-                return;
-            }
-
-            let id = existing_id
-                .clone()
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
-            let protocol = if proto_dropdown.selected() == PROTO_WEBSOCKET {
-                let url = url_entry.text().trim().to_string();
-                if url.is_empty() {
-                    status.set_text("Server URL is required for WebSocket");
+        save_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = dialog_ref)]
+            dialog,
+            move |_| {
+                let name = name_entry.text().trim().to_string();
+                if name.is_empty() {
+                    status.set_text("Connection name is required");
                     return;
                 }
-                // Store credentials in the keyring (never in the profile).
-                let username = user_entry.text().trim().to_string();
-                let password = pass_entry.text().to_string();
-                if !username.is_empty() {
-                    let _ = CredentialStore::store_password(&format!("{id}-username"), &username);
-                }
-                if !password.is_empty() {
-                    let _ = CredentialStore::store_password(&id, &password);
-                }
-                ProtocolConfig::Websocket {
-                    url,
-                    subject: "desktop-tui".to_string(),
-                }
-            } else {
-                let raw = sock_entry.text().trim().to_string();
-                let path = if raw.is_empty() {
-                    None
-                } else {
-                    Some(std::path::PathBuf::from(raw))
-                };
-                ProtocolConfig::Local { path }
-            };
 
-            on_save(ConnectionProfile { id, name, protocol });
-            dialog_ref.close();
-        });
+                let id = existing_id
+                    .clone()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+                let protocol = if proto_dropdown.selected() == PROTO_WEBSOCKET {
+                    let url = url_entry.text().trim().to_string();
+                    if url.is_empty() {
+                        status.set_text("Server URL is required for WebSocket");
+                        return;
+                    }
+                    // Store credentials in the keyring (never in the profile).
+                    let username = user_entry.text().trim().to_string();
+                    let password = pass_entry.text().to_string();
+                    if !username.is_empty() {
+                        let _ =
+                            CredentialStore::store_password(&format!("{id}-username"), &username);
+                    }
+                    if !password.is_empty() {
+                        let _ = CredentialStore::store_password(&id, &password);
+                    }
+                    ProtocolConfig::Websocket {
+                        url,
+                        subject: "desktop-tui".to_string(),
+                    }
+                } else {
+                    let raw = sock_entry.text().trim().to_string();
+                    let path = if raw.is_empty() {
+                        None
+                    } else {
+                        Some(std::path::PathBuf::from(raw))
+                    };
+                    ProtocolConfig::Local { path }
+                };
+
+                on_save(ConnectionProfile { id, name, protocol });
+                dialog_ref.close();
+            }
+        ));
     }
 
     dialog.present();

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -5,7 +5,7 @@ use desktop_assistant_client_common::ConversationSummary;
 use gtk4::prelude::*;
 use gtk4::{
     Box as GtkBox, Button, CheckButton, GestureClick, Image, Label, ListBox, ListBoxRow,
-    Orientation, Popover, ScrolledWindow, SelectionMode,
+    Orientation, Popover, ScrolledWindow, SelectionMode, glib,
 };
 
 type IndexCallback = Box<dyn Fn(usize)>;
@@ -99,15 +99,16 @@ impl Sidebar {
         let on_show_archived_toggled: Rc<RefCell<Option<ToggleCallback>>> =
             Rc::new(RefCell::new(None));
 
-        {
-            let cb = Rc::clone(&on_show_archived_toggled);
-            show_archived_check.connect_toggled(move |check| {
+        show_archived_check.connect_toggled(glib::clone!(
+            #[strong(rename_to = cb)]
+            on_show_archived_toggled,
+            move |check| {
                 let active = check.is_active();
                 if let Some(ref f) = *cb.borrow() {
                     f(active);
                 }
-            });
-        }
+            }
+        ));
 
         Self {
             container,
@@ -175,64 +176,83 @@ impl Sidebar {
             // Right-click context menu
             let gesture = GestureClick::new();
             gesture.set_button(3); // secondary (right) click
-            let on_rename = Rc::clone(&self.on_rename);
-            let on_delete = Rc::clone(&self.on_delete);
-            let on_archive = Rc::clone(&self.on_archive);
             let is_archived = conv.archived;
-            gesture.connect_pressed(move |gesture, _n_press, x, y| {
-                let Some(widget) = gesture.widget() else {
-                    return;
-                };
+            gesture.connect_pressed(glib::clone!(
+                #[strong(rename_to = on_rename)]
+                self.on_rename,
+                #[strong(rename_to = on_delete)]
+                self.on_delete,
+                #[strong(rename_to = on_archive)]
+                self.on_archive,
+                move |gesture, _n_press, x, y| {
+                    let Some(widget) = gesture.widget() else {
+                        return;
+                    };
 
-                let popover = Popover::new();
-                popover.add_css_class("context-popover");
-                popover.set_parent(&widget);
-                popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-                popover.set_has_arrow(false);
+                    let popover = Popover::new();
+                    popover.add_css_class("context-popover");
+                    popover.set_parent(&widget);
+                    popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(
+                        x as i32, y as i32, 1, 1,
+                    )));
+                    popover.set_has_arrow(false);
 
-                let menu_box = GtkBox::new(Orientation::Vertical, 0);
+                    let menu_box = GtkBox::new(Orientation::Vertical, 0);
 
-                let rename_btn = Button::with_label("Rename");
-                rename_btn.add_css_class("context-button");
-                let on_rename_inner = Rc::clone(&on_rename);
-                let popover_ref = popover.clone();
-                rename_btn.connect_clicked(move |_| {
-                    popover_ref.popdown();
-                    if let Some(ref cb) = *on_rename_inner.borrow() {
-                        cb(idx);
-                    }
-                });
-                menu_box.append(&rename_btn);
+                    let rename_btn = Button::with_label("Rename");
+                    rename_btn.add_css_class("context-button");
+                    rename_btn.connect_clicked(glib::clone!(
+                        #[strong(rename_to = on_rename_inner)]
+                        on_rename,
+                        #[weak]
+                        popover,
+                        move |_| {
+                            popover.popdown();
+                            if let Some(ref cb) = *on_rename_inner.borrow() {
+                                cb(idx);
+                            }
+                        }
+                    ));
+                    menu_box.append(&rename_btn);
 
-                let archive_label = if is_archived { "Unarchive" } else { "Archive" };
-                let archive_btn = Button::with_label(archive_label);
-                archive_btn.add_css_class("context-button");
-                let on_archive_inner = Rc::clone(&on_archive);
-                let popover_ref = popover.clone();
-                archive_btn.connect_clicked(move |_| {
-                    popover_ref.popdown();
-                    if let Some(ref cb) = *on_archive_inner.borrow() {
-                        cb(idx);
-                    }
-                });
-                menu_box.append(&archive_btn);
+                    let archive_label = if is_archived { "Unarchive" } else { "Archive" };
+                    let archive_btn = Button::with_label(archive_label);
+                    archive_btn.add_css_class("context-button");
+                    archive_btn.connect_clicked(glib::clone!(
+                        #[strong(rename_to = on_archive_inner)]
+                        on_archive,
+                        #[weak]
+                        popover,
+                        move |_| {
+                            popover.popdown();
+                            if let Some(ref cb) = *on_archive_inner.borrow() {
+                                cb(idx);
+                            }
+                        }
+                    ));
+                    menu_box.append(&archive_btn);
 
-                let delete_btn = Button::with_label("Delete");
-                delete_btn.add_css_class("context-button");
-                delete_btn.add_css_class("destructive-action");
-                let on_delete_inner = Rc::clone(&on_delete);
-                let popover_ref = popover.clone();
-                delete_btn.connect_clicked(move |_| {
-                    popover_ref.popdown();
-                    if let Some(ref cb) = *on_delete_inner.borrow() {
-                        cb(idx);
-                    }
-                });
-                menu_box.append(&delete_btn);
+                    let delete_btn = Button::with_label("Delete");
+                    delete_btn.add_css_class("context-button");
+                    delete_btn.add_css_class("destructive-action");
+                    delete_btn.connect_clicked(glib::clone!(
+                        #[strong(rename_to = on_delete_inner)]
+                        on_delete,
+                        #[weak]
+                        popover,
+                        move |_| {
+                            popover.popdown();
+                            if let Some(ref cb) = *on_delete_inner.borrow() {
+                                cb(idx);
+                            }
+                        }
+                    ));
+                    menu_box.append(&delete_btn);
 
-                popover.set_child(Some(&menu_box));
-                popover.popup();
-            });
+                    popover.set_child(Some(&menu_box));
+                    popover.popup();
+                }
+            ));
             row.add_controller(gesture);
 
             self.list_box.append(&row);

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -42,18 +42,16 @@ impl Sidebar {
         brand_box.set_margin_bottom(4);
 
         const ICON_BYTES: &[u8] = include_bytes!("../../assets/adele_communicating.png");
-        let icon_path = dirs::cache_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("adele-gtk-brand-icon.png");
-        if let Err(e) = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&icon_path)
-            .and_then(|mut f| std::io::Write::write_all(&mut f, ICON_BYTES))
-            && e.kind() != std::io::ErrorKind::AlreadyExists
-        {
-            tracing::warn!("Failed to write brand icon: {e}");
-        }
+        let icon_path =
+            match crate::assets::extract_to_cache(ICON_BYTES, "adele-gtk-brand-icon.png") {
+                Ok(path) => path,
+                Err(e) => {
+                    tracing::warn!("Failed to write brand icon: {e}");
+                    dirs::cache_dir()
+                        .unwrap_or_else(std::env::temp_dir)
+                        .join("adele-gtk-brand-icon.png")
+                }
+            };
         let icon = Image::from_file(icon_path.to_str().unwrap_or_default());
         icon.set_pixel_size(44);
         brand_box.append(&icon);

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -14,7 +14,7 @@ use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Button, Label, ListBox, ListBoxRow, Orientation, ScrolledWindow,
-    SelectionMode, TextBuffer, TextView, WrapMode,
+    SelectionMode, TextBuffer, TextView, WrapMode, glib,
 };
 
 // --- Pure-Rust model (no GTK types) ---------------------------------------
@@ -326,77 +326,93 @@ impl TasksPanel {
     }
 
     fn wire_selection(&self) {
-        let model = Rc::clone(&self.model);
-        let log_buffer = self.log_buffer.clone();
-        let cancel_button = self.cancel_button.clone();
-        let open_btn = self.open_conversation_button.clone();
-        self.list_box.connect_row_selected(move |_, row| {
-            let Some(row) = row else {
-                log_buffer.set_text("");
-                cancel_button.set_sensitive(false);
-                open_btn.set_sensitive(false);
-                return;
-            };
-            let idx = row.index() as usize;
-            let m = model.borrow();
-            let Some(task) = m.get(idx) else {
-                cancel_button.set_sensitive(false);
-                open_btn.set_sensitive(false);
-                return;
-            };
-            // Cancel only applies to non-terminal states.
-            let cancellable = matches!(
-                task.status,
-                api::TaskStatus::Pending | api::TaskStatus::Running
-            );
-            cancel_button.set_sensitive(cancellable);
-            open_btn.set_sensitive(conversation_id_for(&task.kind).is_some());
+        self.list_box.connect_row_selected(glib::clone!(
+            #[strong(rename_to = model)]
+            self.model,
+            #[weak(rename_to = log_buffer)]
+            self.log_buffer,
+            #[weak(rename_to = cancel_button)]
+            self.cancel_button,
+            #[weak(rename_to = open_btn)]
+            self.open_conversation_button,
+            move |_, row| {
+                let Some(row) = row else {
+                    log_buffer.set_text("");
+                    cancel_button.set_sensitive(false);
+                    open_btn.set_sensitive(false);
+                    return;
+                };
+                let idx = row.index() as usize;
+                let m = model.borrow();
+                let Some(task) = m.get(idx) else {
+                    cancel_button.set_sensitive(false);
+                    open_btn.set_sensitive(false);
+                    return;
+                };
+                // Cancel only applies to non-terminal states.
+                let cancellable = matches!(
+                    task.status,
+                    api::TaskStatus::Pending | api::TaskStatus::Running
+                );
+                cancel_button.set_sensitive(cancellable);
+                open_btn.set_sensitive(conversation_id_for(&task.kind).is_some());
 
-            let text = m
-                .logs_for(&task.id.0)
-                .iter()
-                .map(format_log_line)
-                .collect::<Vec<_>>()
-                .join("\n");
-            log_buffer.set_text(&text);
-        });
+                let text = m
+                    .logs_for(&task.id.0)
+                    .iter()
+                    .map(format_log_line)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                log_buffer.set_text(&text);
+            }
+        ));
     }
 
     fn wire_toolbar(&self) {
-        let model = Rc::clone(&self.model);
-        let list_box = self.list_box.clone();
-        let on_cancel = Rc::clone(&self.on_cancel);
-        self.cancel_button.connect_clicked(move |_| {
-            let Some(row) = list_box.selected_row() else {
-                return;
-            };
-            let idx = row.index() as usize;
-            let id = match model.borrow().get(idx) {
-                Some(t) => t.id.0.clone(),
-                None => return,
-            };
-            if let Some(ref cb) = *on_cancel.borrow() {
-                cb(id);
+        self.cancel_button.connect_clicked(glib::clone!(
+            #[strong(rename_to = model)]
+            self.model,
+            #[weak(rename_to = list_box)]
+            self.list_box,
+            #[strong(rename_to = on_cancel)]
+            self.on_cancel,
+            move |_| {
+                let Some(row) = list_box.selected_row() else {
+                    return;
+                };
+                let idx = row.index() as usize;
+                let id = match model.borrow().get(idx) {
+                    Some(t) => t.id.0.clone(),
+                    None => return,
+                };
+                if let Some(ref cb) = *on_cancel.borrow() {
+                    cb(id);
+                }
             }
-        });
+        ));
 
-        let model = Rc::clone(&self.model);
-        let list_box = self.list_box.clone();
-        let on_open = Rc::clone(&self.on_open_conversation);
-        self.open_conversation_button.connect_clicked(move |_| {
-            let Some(row) = list_box.selected_row() else {
-                return;
-            };
-            let idx = row.index() as usize;
-            let conv_id = match model.borrow().get(idx) {
-                Some(t) => conversation_id_for(&t.kind),
-                None => None,
-            };
-            let Some(conv_id) = conv_id else { return };
-            if let Some(ref cb) = *on_open.borrow() {
-                cb(conv_id);
+        self.open_conversation_button.connect_clicked(glib::clone!(
+            #[strong(rename_to = model)]
+            self.model,
+            #[weak(rename_to = list_box)]
+            self.list_box,
+            #[strong(rename_to = on_open)]
+            self.on_open_conversation,
+            move |_| {
+                let Some(row) = list_box.selected_row() else {
+                    return;
+                };
+                let idx = row.index() as usize;
+                let conv_id = match model.borrow().get(idx) {
+                    Some(t) => conversation_id_for(&t.kind),
+                    None => None,
+                };
+                let Some(conv_id) = conv_id else { return };
+                if let Some(ref cb) = *on_open.borrow() {
+                    cb(conv_id);
+                }
             }
-        });
+        ));
     }
 
     pub fn connect_cancel<F: Fn(String) + 'static>(&self, f: F) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -15,7 +15,7 @@ use gtk4::{
 };
 use tokio::sync::mpsc;
 
-use crate::async_bridge::{AsyncBridge, InternalMsg, UiMessage, connection_manager};
+use crate::async_bridge::{AsyncBridge, UiMessage, connection_manager};
 use crate::management_client;
 use crate::widgets::chat_view::ChatView;
 use crate::widgets::input_bar::InputBar;
@@ -32,8 +32,6 @@ struct WindowState {
     streaming_buffer: String,
     debug_enabled: bool,
 }
-
-// InternalMsg is now defined in async_bridge and re-imported.
 
 pub struct AdelieWindow {
     pub window: ApplicationWindow,
@@ -237,9 +235,6 @@ impl AdelieWindow {
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
 
-        // Internal channel for transport bootstrap (sends non-Send types via main thread)
-        let (internal_tx, mut internal_rx) = mpsc::unbounded_channel::<InternalMsg>();
-
         // Set up async bridge with UI message handler
         let bridge = AsyncBridge::new(glib::clone!(
             #[strong]
@@ -281,25 +276,13 @@ impl AdelieWindow {
         ));
         let bridge = Rc::new(bridge);
 
-        // Spawn a local future to receive the transport client on the main thread
-        glib::spawn_future_local(glib::clone!(
-            #[strong]
-            client,
-            async move {
-                while let Some(msg) = internal_rx.recv().await {
-                    match msg {
-                        InternalMsg::ClientReady(transport) => {
-                            *client.borrow_mut() = Some(transport);
-                        }
-                    }
-                }
-            }
-        ));
-
-        // Spawn persistent connection manager (connect → forward → reconnect)
+        // Spawn persistent connection manager (connect → forward → reconnect).
+        // It now delivers the freshly connected transport to the main thread
+        // via `UiMessage::ClientReady` on the same channel as every other UI
+        // message (handled in `handle_ui_message`).
         {
             let ui_tx = bridge.ui_sender();
-            bridge.spawn(connection_manager(config.clone(), ui_tx, internal_tx));
+            bridge.spawn(connection_manager(config.clone(), ui_tx));
         }
 
         // Sidebar row activation → load conversation
@@ -912,6 +895,12 @@ fn handle_ui_message(
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
     match msg {
+        UiMessage::ClientReady(transport) => {
+            // The connection_manager handed us a freshly connected transport.
+            // Stash it so the rest of the UI can issue RPCs; this arrives
+            // before `ConversationsLoaded`, which relies on the client cell.
+            *client.borrow_mut() = Some(transport);
+        }
         UiMessage::ConversationsLoaded(convs) => {
             sidebar.set_conversations(&convs);
             state.borrow_mut().conversations = convs;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1233,31 +1233,13 @@ pub fn install_app_icon() {
     let cache_root = dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join("adele-gtk-icons");
-    let icon_dir = cache_root.join("hicolor").join("512x512").join("apps");
-    let icon_path = icon_dir.join(format!("{ICON_NAME}.png"));
 
-    if let Err(e) = std::fs::create_dir_all(&icon_dir) {
-        tracing::warn!("Failed to create icon dir: {e}");
+    // Resolves to <cache_root>/hicolor/512x512/apps/<ICON_NAME>.png; the
+    // helper creates the parent dirs and writes idempotently.
+    let icon_rel = format!("adele-gtk-icons/hicolor/512x512/apps/{ICON_NAME}.png");
+    if let Err(e) = crate::assets::extract_to_cache(ICON_BYTES, &icon_rel) {
+        tracing::warn!("Failed to install icon: {e}");
         return;
-    }
-    // Use create_new to avoid TOCTOU: the write either atomically creates the
-    // file or harmlessly fails because it already exists.
-    match std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&icon_path)
-    {
-        Ok(mut file) => {
-            if let Err(e) = std::io::Write::write_all(&mut file, ICON_BYTES) {
-                tracing::warn!("Failed to write icon: {e}");
-                return;
-            }
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(e) => {
-            tracing::warn!("Failed to create icon file: {e}");
-            return;
-        }
     }
 
     let display = gdk::Display::default().expect("display");

--- a/src/window.rs
+++ b/src/window.rs
@@ -173,10 +173,11 @@ impl AdelieWindow {
         toast_row.append(&toast_label);
         let toast_dismiss = Button::from_icon_name("window-close-symbolic");
         toast_dismiss.add_css_class("flat");
-        {
-            let revealer_ref = toast_revealer.clone();
-            toast_dismiss.connect_clicked(move |_| revealer_ref.set_reveal_child(false));
-        }
+        toast_dismiss.connect_clicked(glib::clone!(
+            #[weak]
+            toast_revealer,
+            move |_| toast_revealer.set_reveal_child(false)
+        ));
         toast_row.append(&toast_dismiss);
         toast_revealer.set_child(Some(&toast_row));
         right_box.append(&toast_revealer);
@@ -240,19 +241,28 @@ impl AdelieWindow {
         let (internal_tx, mut internal_rx) = mpsc::unbounded_channel::<InternalMsg>();
 
         // Set up async bridge with UI message handler
-        let bridge = {
-            let state = Rc::clone(&state);
-            let sidebar = Rc::clone(&sidebar);
-            let chat_view = Rc::clone(&chat_view);
-            let status_label = Rc::clone(&status_label);
-            let client = Rc::clone(&client);
-            let input_bar = Rc::clone(&input_bar);
-            let model_picker = Rc::clone(&model_picker);
-            let tasks_panel = Rc::clone(&tasks_panel);
-            let toast_revealer = Rc::clone(&toast_revealer);
-            let toast_label = Rc::clone(&toast_label);
-
-            AsyncBridge::new(move |msg, ui_tx| {
+        let bridge = AsyncBridge::new(glib::clone!(
+            #[strong]
+            state,
+            #[strong]
+            sidebar,
+            #[strong]
+            chat_view,
+            #[strong]
+            status_label,
+            #[strong]
+            client,
+            #[strong]
+            input_bar,
+            #[strong]
+            model_picker,
+            #[strong]
+            tasks_panel,
+            #[strong]
+            toast_revealer,
+            #[strong]
+            toast_label,
+            move |msg, ui_tx| {
                 handle_ui_message(
                     msg,
                     &state,
@@ -267,23 +277,24 @@ impl AdelieWindow {
                     &toast_label,
                     ui_tx,
                 );
-            })
-        };
+            }
+        ));
         let bridge = Rc::new(bridge);
 
         // Spawn a local future to receive the transport client on the main thread
-        {
-            let client_ref = Rc::clone(&client);
-            glib::spawn_future_local(async move {
+        glib::spawn_future_local(glib::clone!(
+            #[strong]
+            client,
+            async move {
                 while let Some(msg) = internal_rx.recv().await {
                     match msg {
                         InternalMsg::ClientReady(transport) => {
-                            *client_ref.borrow_mut() = Some(transport);
+                            *client.borrow_mut() = Some(transport);
                         }
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // Spawn persistent connection manager (connect → forward → reconnect)
         {
@@ -292,18 +303,21 @@ impl AdelieWindow {
         }
 
         // Sidebar row activation → load conversation
-        {
-            let client_ref = Rc::clone(&client);
-            let state = Rc::clone(&state);
-            let bridge = Rc::clone(&bridge);
-            sidebar.list_box.connect_row_activated(move |_, row| {
+        sidebar.list_box.connect_row_activated(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            state,
+            #[strong]
+            bridge,
+            move |_, row| {
                 let idx = row.index() as usize;
                 let state_borrow = state.borrow();
                 if let Some(conv) = state_borrow.conversations.get(idx) {
                     let conv_id = conv.id.clone();
                     drop(state_borrow);
 
-                    if let Some(client) = client_ref.borrow().clone() {
+                    if let Some(client) = client.borrow().clone() {
                         let tx = bridge.ui_sender();
                         bridge.spawn(async move {
                             match client.get_conversation(&conv_id).await {
@@ -318,15 +332,17 @@ impl AdelieWindow {
                         });
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // New conversation button
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge = Rc::clone(&bridge);
-            sidebar.new_button.connect_clicked(move |_| {
-                if let Some(client) = client_ref.borrow().clone() {
+        sidebar.new_button.connect_clicked(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            move |_| {
+                if let Some(client) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     bridge.spawn(async move {
                         match client.create_conversation("New Conversation").await {
@@ -348,15 +364,18 @@ impl AdelieWindow {
                         }
                     });
                 }
-            });
-        }
+            }
+        ));
 
         // Context menu: Delete conversation
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge = Rc::clone(&bridge);
-            let state = Rc::clone(&state);
-            sidebar.connect_delete(move |idx| {
+        sidebar.connect_delete(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            state,
+            move |idx| {
                 let id = {
                     let s = state.borrow();
                     match s.conversations.get(idx) {
@@ -364,7 +383,7 @@ impl AdelieWindow {
                         None => return,
                     }
                 };
-                if let Some(client) = client_ref.borrow().clone() {
+                if let Some(client) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     let id = id.clone();
                     bridge.spawn(async move {
@@ -379,16 +398,20 @@ impl AdelieWindow {
                         }
                     });
                 }
-            });
-        }
+            }
+        ));
 
         // Context menu: Rename conversation
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge = Rc::clone(&bridge);
-            let state = Rc::clone(&state);
-            let window_ref = window.clone();
-            sidebar.connect_rename(move |idx| {
+        sidebar.connect_rename(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            state,
+            #[weak]
+            window,
+            move |idx| {
                 let (id, current_title) = {
                     let s = state.borrow();
                     match s.conversations.get(idx) {
@@ -399,7 +422,7 @@ impl AdelieWindow {
 
                 let dialog = Window::builder()
                     .title("Rename Conversation")
-                    .transient_for(&window_ref)
+                    .transient_for(&window)
                     .modal(true)
                     .default_width(360)
                     .default_height(10)
@@ -421,62 +444,78 @@ impl AdelieWindow {
                 btn_box.set_halign(gtk4::Align::End);
 
                 let cancel_btn = Button::with_label("Cancel");
-                let dialog_ref = dialog.clone();
-                cancel_btn.connect_clicked(move |_| {
-                    dialog_ref.close();
-                });
+                cancel_btn.connect_clicked(glib::clone!(
+                    #[weak]
+                    dialog,
+                    move |_| {
+                        dialog.close();
+                    }
+                ));
                 btn_box.append(&cancel_btn);
 
                 let confirm_btn = Button::with_label("Rename");
                 confirm_btn.add_css_class("suggested-action");
-                let client_ref_inner = Rc::clone(&client_ref);
-                let bridge_inner = Rc::clone(&bridge);
-                let dialog_ref = dialog.clone();
-                let entry_ref = entry.clone();
-                confirm_btn.connect_clicked(move |_| {
-                    let new_title = entry_ref.text().trim().to_string();
-                    if new_title.is_empty() {
-                        return;
-                    }
-                    dialog_ref.close();
-                    if let Some(client) = client_ref_inner.borrow().clone() {
-                        let tx = bridge_inner.ui_sender();
-                        let id = id.clone();
-                        let title = new_title.clone();
-                        bridge_inner.spawn(async move {
-                            match client.rename_conversation(&id, &title).await {
-                                Ok(()) => {
-                                    let _ = tx.send(UiMessage::ConversationRenamed { id, title });
+                confirm_btn.connect_clicked(glib::clone!(
+                    #[strong]
+                    client,
+                    #[strong]
+                    bridge,
+                    #[weak]
+                    dialog,
+                    #[weak]
+                    entry,
+                    move |_| {
+                        let new_title = entry.text().trim().to_string();
+                        if new_title.is_empty() {
+                            return;
+                        }
+                        dialog.close();
+                        if let Some(client) = client.borrow().clone() {
+                            let tx = bridge.ui_sender();
+                            let id = id.clone();
+                            let title = new_title.clone();
+                            bridge.spawn(async move {
+                                match client.rename_conversation(&id, &title).await {
+                                    Ok(()) => {
+                                        let _ =
+                                            tx.send(UiMessage::ConversationRenamed { id, title });
+                                    }
+                                    Err(e) => {
+                                        let _ = tx.send(UiMessage::Error(format!(
+                                            "Rename conversation: {e}"
+                                        )));
+                                    }
                                 }
-                                Err(e) => {
-                                    let _ = tx.send(UiMessage::Error(format!(
-                                        "Rename conversation: {e}"
-                                    )));
-                                }
-                            }
-                        });
+                            });
+                        }
                     }
-                });
+                ));
                 btn_box.append(&confirm_btn);
 
                 // Enter key in entry confirms
-                let confirm_ref = confirm_btn.clone();
-                entry.connect_activate(move |_| {
-                    confirm_ref.emit_clicked();
-                });
+                entry.connect_activate(glib::clone!(
+                    #[weak]
+                    confirm_btn,
+                    move |_| {
+                        confirm_btn.emit_clicked();
+                    }
+                ));
 
                 vbox.append(&btn_box);
                 dialog.set_child(Some(&vbox));
                 dialog.present();
-            });
-        }
+            }
+        ));
 
         // Context menu: Archive/unarchive conversation
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge = Rc::clone(&bridge);
-            let state = Rc::clone(&state);
-            sidebar.connect_archive(move |idx| {
+        sidebar.connect_archive(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            state,
+            move |idx| {
                 let (id, archived) = {
                     let s = state.borrow();
                     match s.conversations.get(idx) {
@@ -484,7 +523,7 @@ impl AdelieWindow {
                         None => return,
                     }
                 };
-                if let Some(client) = client_ref.borrow().clone() {
+                if let Some(client) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     let id = id.clone();
                     bridge.spawn(async move {
@@ -507,15 +546,17 @@ impl AdelieWindow {
                         }
                     });
                 }
-            });
-        }
+            }
+        ));
 
         // Show archived checkbox toggle
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge = Rc::clone(&bridge);
-            sidebar.connect_show_archived_toggled(move |include_archived| {
-                if let Some(client) = client_ref.borrow().clone() {
+        sidebar.connect_show_archived_toggled(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            move |include_archived| {
+                if let Some(client) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     bridge.spawn(async move {
                         let result = if include_archived {
@@ -534,145 +575,165 @@ impl AdelieWindow {
                         }
                     });
                 }
-            });
-        }
+            }
+        ));
 
         // Send button / Enter key → send prompt
         {
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            let state = Rc::clone(&state);
-            let input_bar_ref = Rc::clone(&input_bar);
-            let chat_view_ref = Rc::clone(&chat_view);
-            let model_picker_ref = Rc::clone(&model_picker);
+            let send_action = Rc::new(glib::clone!(
+                #[strong]
+                client,
+                #[strong(rename_to = bridge_ref)]
+                bridge,
+                #[strong]
+                state,
+                #[strong]
+                input_bar,
+                #[strong]
+                chat_view,
+                #[strong]
+                model_picker,
+                move || {
+                    let text = input_bar.take_text();
+                    let text = text.trim().to_string();
+                    if text.is_empty() {
+                        return;
+                    }
+                    let state_borrow = state.borrow();
+                    let conv_id = match &state_borrow.current_conversation_id {
+                        Some(id) => id.clone(),
+                        None => return,
+                    };
+                    drop(state_borrow);
 
-            let send_action = Rc::new(move || {
-                let text = input_bar_ref.take_text();
-                let text = text.trim().to_string();
-                if text.is_empty() {
-                    return;
-                }
-                let state_borrow = state.borrow();
-                let conv_id = match &state_borrow.current_conversation_id {
-                    Some(id) => id.clone(),
-                    None => return,
-                };
-                drop(state_borrow);
+                    // Show user message immediately
+                    chat_view.borrow_mut().add_user_message(&text);
 
-                // Show user message immediately
-                chat_view_ref.borrow_mut().add_user_message(&text);
+                    // Track in local conversation copy
+                    {
+                        let mut s = state.borrow_mut();
+                        if let Some(ref mut conv) = s.current_conversation {
+                            conv.messages.push(ChatMessage {
+                                role: "user".to_string(),
+                                content: text.clone(),
+                            });
+                        }
+                    }
 
-                // Track in local conversation copy
-                {
-                    let mut s = state.borrow_mut();
-                    if let Some(ref mut conv) = s.current_conversation {
-                        conv.messages.push(ChatMessage {
-                            role: "user".to_string(),
-                            content: text.clone(),
+                    let override_selection = model_picker.current_override();
+
+                    if let Some(client) = client.borrow().clone() {
+                        let tx = bridge_ref.ui_sender();
+                        let text = text.clone();
+                        bridge_ref.spawn(async move {
+                            // Use the WS-specific override path when available so
+                            // the picker's selection is honoured. The shared
+                            // AssistantClient trait can't carry the override
+                            // because the D-Bus surface doesn't expose it; on
+                            // D-Bus we fall through to the plain send_prompt.
+                            let result = match (client.as_ws(), override_selection) {
+                                (Some(ws), Some(over)) => {
+                                    ws.send_prompt_with_override(&conv_id, &text, Some(over))
+                                        .await
+                                }
+                                _ => client.send_prompt(&conv_id, &text).await,
+                            };
+                            match result {
+                                Ok(task_id) => {
+                                    let _ = tx.send(UiMessage::PromptSent { task_id });
+                                }
+                                Err(e) => {
+                                    let _ = tx.send(UiMessage::Error(format!("Send error: {e}")));
+                                }
+                            }
                         });
                     }
                 }
-
-                let override_selection = model_picker_ref.current_override();
-
-                if let Some(client) = client_ref.borrow().clone() {
-                    let tx = bridge_ref.ui_sender();
-                    let text = text.clone();
-                    bridge_ref.spawn(async move {
-                        // Use the WS-specific override path when available so
-                        // the picker's selection is honoured. The shared
-                        // AssistantClient trait can't carry the override
-                        // because the D-Bus surface doesn't expose it; on
-                        // D-Bus we fall through to the plain send_prompt.
-                        let result = match (client.as_ws(), override_selection) {
-                            (Some(ws), Some(over)) => {
-                                ws.send_prompt_with_override(&conv_id, &text, Some(over))
-                                    .await
-                            }
-                            _ => client.send_prompt(&conv_id, &text).await,
-                        };
-                        match result {
-                            Ok(task_id) => {
-                                let _ = tx.send(UiMessage::PromptSent { task_id });
-                            }
-                            Err(e) => {
-                                let _ = tx.send(UiMessage::Error(format!("Send error: {e}")));
-                            }
-                        }
-                    });
-                }
-            });
+            ));
 
             // Send button click
-            let send_action_click = Rc::clone(&send_action);
-            input_bar.send_button.connect_clicked(move |_| {
-                send_action_click();
-            });
+            input_bar.send_button.connect_clicked(glib::clone!(
+                #[strong]
+                send_action,
+                move |_| {
+                    send_action();
+                }
+            ));
 
             // Enter key in text view (Shift+Enter for newline)
-            let send_action_key = Rc::clone(&send_action);
             let key_controller = gtk4::EventControllerKey::new();
-            key_controller.connect_key_pressed(move |_, key, _, modifiers| {
-                if key == gdk::Key::Return
-                    && !modifiers.contains(gdk::ModifierType::SHIFT_MASK)
-                    && !modifiers.contains(gdk::ModifierType::CONTROL_MASK)
-                {
-                    send_action_key();
-                    glib::Propagation::Stop
-                } else {
-                    glib::Propagation::Proceed
+            key_controller.connect_key_pressed(glib::clone!(
+                #[strong]
+                send_action,
+                move |_, key, _, modifiers| {
+                    if key == gdk::Key::Return
+                        && !modifiers.contains(gdk::ModifierType::SHIFT_MASK)
+                        && !modifiers.contains(gdk::ModifierType::CONTROL_MASK)
+                    {
+                        send_action();
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
                 }
-            });
+            ));
             input_bar.text_view.add_controller(key_controller);
         }
 
         // Hamburger menu: Switch Connection → open the picker in a new
         // window. The current connection's window is intentionally left open;
         // selecting a profile spawns a fresh AdelieWindow alongside it.
-        {
-            let app_ref = app.clone();
-            let popover_ref = menu_popover.clone();
-            switch_conn_btn.connect_clicked(move |_| {
-                popover_ref.popdown();
-                let login = crate::widgets::login_screen::LoginScreen::new(&app_ref);
+        switch_conn_btn.connect_clicked(glib::clone!(
+            #[weak]
+            app,
+            #[weak]
+            menu_popover,
+            move |_| {
+                menu_popover.popdown();
+                let login = crate::widgets::login_screen::LoginScreen::new(&app);
                 login.present();
-            });
-        }
+            }
+        ));
 
         // Hamburger menu: Settings → Connections / Purposes tabs (#1). The
         // dialog is WS-only (named-connection management isn't exposed over
         // D-Bus); on a D-Bus transport we status-message and no-op — the
         // header model picker is already hidden there.
-        {
-            let popover_ref = menu_popover.clone();
-            let window_ref = window.clone();
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            let status_label_ref = Rc::clone(&status_label);
-            settings_btn.connect_clicked(move |_| {
-                popover_ref.popdown();
-                let Some(transport) = client_ref.borrow().clone() else {
-                    status_label_ref.set_text("Not connected — settings unavailable");
+        settings_btn.connect_clicked(glib::clone!(
+            #[weak]
+            menu_popover,
+            #[weak]
+            window,
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            status_label,
+            move |_| {
+                menu_popover.popdown();
+                let Some(transport) = client.borrow().clone() else {
+                    status_label.set_text("Not connected — settings unavailable");
                     return;
                 };
                 if transport.as_ws().is_none() {
-                    status_label_ref.set_text(
+                    status_label.set_text(
                         "Settings require the WebSocket transport (unavailable on D-Bus)",
                     );
                     return;
                 }
                 crate::widgets::settings_dialog::show_settings_dialog(
-                    &window_ref,
+                    &window,
                     Arc::clone(&transport),
-                    Rc::clone(&bridge_ref),
+                    Rc::clone(&bridge),
                 );
                 // The user may have added/removed connections; re-query the
                 // aggregated model list so the header picker reflects the new
                 // set. Fire-and-forget — errors are non-fatal. Runs once when
                 // Settings is opened (so it picks up the previous session's
                 // changes); the dialog itself keeps its own tabs in sync.
-                let tx = bridge_ref.ui_sender();
-                bridge_ref.spawn(async move {
+                let tx = bridge.ui_sender();
+                bridge.spawn(async move {
                     match management_client::list_available_models(&transport, None, false).await {
                         Ok(listings) => {
                             let _ = tx.send(UiMessage::ModelsLoaded(listings));
@@ -682,57 +743,68 @@ impl AdelieWindow {
                         }
                     }
                 });
-            });
-        }
+            }
+        ));
 
         // Hamburger menu: Knowledge Base → open the KB browser/editor (#74)
-        {
-            let popover_ref = menu_popover.clone();
-            let window_ref = window.clone();
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            let status_label_ref = Rc::clone(&status_label);
-            knowledge_btn.connect_clicked(move |_| {
-                popover_ref.popdown();
-                let Some(transport) = client_ref.borrow().clone() else {
-                    status_label_ref.set_text("Not connected — knowledge base unavailable");
+        knowledge_btn.connect_clicked(glib::clone!(
+            #[weak]
+            menu_popover,
+            #[weak]
+            window,
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            status_label,
+            move |_| {
+                menu_popover.popdown();
+                let Some(transport) = client.borrow().clone() else {
+                    status_label.set_text("Not connected — knowledge base unavailable");
                     return;
                 };
                 let browser = crate::widgets::knowledge_browser::KnowledgeBrowser::new(
-                    &window_ref,
+                    &window,
                     transport,
-                    Rc::clone(&bridge_ref),
+                    Rc::clone(&bridge),
                 );
                 browser.present();
-            });
-        }
+            }
+        ));
 
         // Hamburger menu: Disconnect → close this window, show login screen
-        {
-            let app_ref = app.clone();
-            let window_ref = window.clone();
-            let popover_ref = menu_popover.clone();
-            disconnect_btn.connect_clicked(move |_| {
-                popover_ref.popdown();
-                let login = crate::widgets::login_screen::LoginScreen::new(&app_ref);
+        disconnect_btn.connect_clicked(glib::clone!(
+            #[weak]
+            app,
+            #[weak]
+            window,
+            #[weak]
+            menu_popover,
+            move |_| {
+                menu_popover.popdown();
+                let login = crate::widgets::login_screen::LoginScreen::new(&app);
                 login.present();
-                window_ref.close();
-            });
-        }
+                window.close();
+            }
+        ));
 
         // Debug checkbox toggle → re-fetch conversation with filtering
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            let state = Rc::clone(&state);
-            debug_check.connect_toggled(move |btn| {
+        debug_check.connect_toggled(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            state,
+            move |btn| {
                 state.borrow_mut().debug_enabled = btn.is_active();
                 let conv_id = state.borrow().current_conversation_id.clone();
                 if let Some(conv_id) = conv_id
-                    && let Some(client) = client_ref.borrow().clone()
+                    && let Some(client) = client.borrow().clone()
                 {
-                    let tx = bridge_ref.ui_sender();
-                    bridge_ref.spawn(async move {
+                    let tx = bridge.ui_sender();
+                    bridge.spawn(async move {
                         match client.get_conversation(&conv_id).await {
                             Ok(detail) => {
                                 let _ = tx.send(UiMessage::ConversationLoaded(detail));
@@ -744,8 +816,8 @@ impl AdelieWindow {
                         }
                     });
                 }
-            });
-        }
+            }
+        ));
 
         // Tasks panel: toolbar wiring (#19).
         //
@@ -753,15 +825,17 @@ impl AdelieWindow {
         // routes the user back to the Conversations stack page and loads the
         // task's conversation so the streaming output keeps flowing into the
         // chat view.
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            tasks_panel.connect_cancel(move |task_id| {
-                let Some(transport) = client_ref.borrow().clone() else {
+        tasks_panel.connect_cancel(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            move |task_id| {
+                let Some(transport) = client.borrow().clone() else {
                     return;
                 };
-                let tx = bridge_ref.ui_sender();
-                bridge_ref.spawn(async move {
+                let tx = bridge.ui_sender();
+                bridge.spawn(async move {
                     let Some(ws) = transport.as_ws() else {
                         let _ = tx.send(UiMessage::Error(
                             "Background tasks require the WebSocket transport".to_string(),
@@ -775,20 +849,23 @@ impl AdelieWindow {
                         let _ = tx.send(UiMessage::Error(format!("Cancel task: {e}")));
                     }
                 });
-            });
-        }
+            }
+        ));
 
-        {
-            let client_ref = Rc::clone(&client);
-            let bridge_ref = Rc::clone(&bridge);
-            let stack_ref = Rc::clone(&stack);
-            tasks_panel.connect_open_conversation(move |conv_id| {
-                stack_ref.set_visible_child_name("conversations");
-                let Some(transport) = client_ref.borrow().clone() else {
+        tasks_panel.connect_open_conversation(glib::clone!(
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            stack,
+            move |conv_id| {
+                stack.set_visible_child_name("conversations");
+                let Some(transport) = client.borrow().clone() else {
                     return;
                 };
-                let tx = bridge_ref.ui_sender();
-                bridge_ref.spawn(async move {
+                let tx = bridge.ui_sender();
+                bridge.spawn(async move {
                     match transport.get_conversation(&conv_id).await {
                         Ok(detail) => {
                             let _ = tx.send(UiMessage::ConversationLoaded(detail));
@@ -798,8 +875,8 @@ impl AdelieWindow {
                         }
                     }
                 });
-            });
-        }
+            }
+        ));
 
         Self { window }
     }


### PR DESCRIPTION
Behavior-preserving refactor. The theme bullet from #29 was **split to #45** (it's a visual change needing manual QA; draft in commit `2810868`).

Closes #29

- **glib::clone!** — migrated 74 hand-rolled `Rc/Arc::clone` closure-prep sites across 12 files to the gtk4 0.11 `glib::clone!` macro (`#[strong]` for `Rc`/`Arc` state, `#[weak]` for GTK objects).
- **icon-cache** — extracted the duplicated embedded-PNG cache write into `assets::extract_to_cache`; 3 call sites deduped.
- **InternalMsg** — folded the single-variant `InternalMsg` + its secondary channel into `UiMessage::ClientReady(Arc<TransportClient>)` (ordering preserved; now single ordered channel).
- **oauth** — deduped the two identical WS+JWT `ConnectionConfig` literals into one helper.

Behavior preserved: 83 tests pass (1 ignored = pre-existing keyring integration test), fmt/clippy/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)