### PR TITLE
theme: honour system light/dark; add light accent palette (#45)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod markdown;
 mod oauth;
 mod profile;
 mod selected_models;
+mod theme;
 #[cfg(feature = "linux")]
 mod webview;
 mod widgets;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -348,6 +348,84 @@ body {{
     0%, 100% {{ opacity: 0.4; }}
     50% {{ opacity: 1; }}
 }}
+
+/* Light theme. WebKitGTK drives `prefers-color-scheme` from the GTK dark
+   preference, so this block applies whenever the app is not in dark mode. The
+   dark palette above remains the default; these rules override only the
+   colour-bearing properties so chat content stays legible and on-brand in
+   light mode. Mirrors the GTK light palette in `style-light.css`:
+   bg #1a1d2e->#ffffff, fg #e0e0e0->#1a1d2e, surface #232740->#f0f2f7,
+   border #3a3f5c->#cdd3e0, user accent #ffbd59->#9a6b00,
+   assistant accent #5cce9a->#178a6e, link #7aa3ff->#2456c8. */
+@media (prefers-color-scheme: light) {{
+    body {{
+        background: #ffffff;
+        color: #1a1d2e;
+    }}
+
+    .avatar-fallback {{
+        background: #d6dae6;
+        color: #555c6b;
+    }}
+
+    .user-message .bubble {{
+        background: rgba(154, 107, 0, 0.07);
+        border-left-color: #9a6b00;
+    }}
+
+    .user-message .label {{
+        color: #9a6b00;
+    }}
+
+    .assistant-message .bubble {{
+        background: rgba(23, 138, 110, 0.07);
+        border-left-color: #178a6e;
+    }}
+
+    .assistant-message .label {{
+        color: #178a6e;
+    }}
+
+    .assistant-message.streaming .bubble {{
+        border-left-color: #1f9e7c;
+    }}
+
+    .assistant-message.streaming .label {{
+        color: #1f9e7c;
+    }}
+
+    .content pre {{
+        background: #f0f2f7;
+    }}
+
+    .content :not(pre) > code {{
+        background: #f0f2f7;
+    }}
+
+    .content th, .content td {{
+        border: 1px solid #cdd3e0;
+    }}
+
+    .content th {{
+        background: #f0f2f7;
+    }}
+
+    .content a {{
+        color: #2456c8;
+    }}
+
+    .cursor {{
+        color: #1f9e7c;
+    }}
+
+    #status-indicator {{
+        color: #555c6b;
+    }}
+
+    #status-indicator .dot {{
+        background: #1f9e7c;
+    }}
+}}
 </style>
 </head>
 <body>

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -1,0 +1,198 @@
+/* Adelie GTK Client Styles — LIGHT overrides.
+ *
+ * These rules mirror the accent / background / border / selection colours of
+ * the dark palette in `style.css` with light-mode equivalents, and are applied
+ * (via a higher-priority CssProvider in `crate::theme`) only when the system /
+ * GTK preference is light. The dark `style.css` is the default and is left
+ * untouched; only the colour-bearing properties are re-asserted here so the
+ * chrome stays legible and on-brand in light mode.
+ *
+ * Colour map (dark -> light):
+ *   window bg      #1a1d2e -> #f7f8fb   window fg      #e0e0e0 -> #1a1d2e
+ *   surface bg     #232740 -> #ffffff   border         #3a3f5c -> #cdd3e0
+ *   brand teal     #84dac1 -> #178a6e   header blue    #88d6f0 -> #1f6f97
+ *   selection bg   #4866b4 -> #3a57a8   selection fg   #f5f8ff -> #ffffff
+ *   dim/status     #7c8494 -> #5b6473   hover bg       #3a3f5c -> #e6eaf3
+ *   toast/sep      #2a2e45 -> #eceef4   log bg         #181b29 -> #f0f2f7
+ */
+
+window {
+    background-color: #f7f8fb;
+    color: #1a1d2e;
+}
+
+.brand-title {
+    color: #178a6e;
+}
+
+.sidebar-header {
+    color: #1f6f97;
+}
+
+.conversation-list row:selected {
+    background-color: #3a57a8;
+    color: #ffffff;
+}
+
+.dim-label {
+    color: #5b6473;
+}
+
+.input-textview {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    caret-color: #178a6e;
+}
+
+.input-textview text {
+    background-color: #ffffff;
+    color: #1a1d2e;
+}
+
+.status-bar {
+    color: #5b6473;
+}
+
+.toast-row {
+    background-color: #eceef4;
+    color: #1a1d2e;
+}
+
+.debug-check {
+    color: #1a1d2e;
+}
+
+separator {
+    background-color: #dde1ea;
+}
+
+paned > separator {
+    background-color: #dde1ea;
+}
+
+popover > contents,
+popover.menu > contents {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    border: 1px solid #cdd3e0;
+}
+
+popover > arrow {
+    background-color: #ffffff;
+    border: 1px solid #cdd3e0;
+}
+
+popover modelbutton,
+popover modelbutton label {
+    color: #1a1d2e;
+}
+
+popover modelbutton:hover {
+    background-color: #e6eaf3;
+    color: #1a1d2e;
+}
+
+popover modelbutton:disabled,
+popover modelbutton:disabled label {
+    color: #5b6473;
+}
+
+.context-popover > contents {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    border: 1px solid #cdd3e0;
+}
+
+.context-button {
+    color: #1a1d2e;
+}
+
+.context-button:hover {
+    background-color: #e6eaf3;
+    color: #1a1d2e;
+}
+
+.context-button:disabled,
+.context-button:disabled label {
+    color: #5b6473;
+}
+
+dropdown > popover > contents {
+    background-color: #ffffff;
+    border: 1px solid #cdd3e0;
+}
+
+dropdown listview > row {
+    color: #1a1d2e;
+}
+
+dropdown listview > row:hover {
+    background-color: #e6eaf3;
+    color: #1a1d2e;
+}
+
+dropdown listview > row:selected {
+    background-color: #3a57a8;
+    color: #ffffff;
+}
+
+dropdown > button {
+    color: #1a1d2e;
+}
+
+entry {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    border: 1px solid #cdd3e0;
+    caret-color: #178a6e;
+}
+
+entry:focus {
+    border-color: #3a57a8;
+}
+
+.sidebar-stack-switcher button {
+    color: #1a1d2e;
+}
+
+.sidebar-stack-switcher button:checked {
+    background-color: #3a57a8;
+    color: #ffffff;
+}
+
+.task-list row:selected {
+    background-color: #3a57a8;
+    color: #ffffff;
+}
+
+/* Status dots: keep the semantic hues but darken the neutral/amber ones so
+   they read against the light log/list surfaces. */
+.task-dot-pending {
+    background-color: #9a7d00; /* amber, darkened for light bg */
+}
+
+.task-dot-running {
+    background-color: #2e8f4f; /* green */
+}
+
+.task-dot-completed {
+    background-color: #5b6473; /* neutral grey for "done" */
+}
+
+.task-dot-failed {
+    background-color: #c2403c; /* red */
+}
+
+.task-dot-cancelled {
+    background-color: #8b93a3; /* dim grey */
+}
+
+.task-log-view {
+    background-color: #f0f2f7;
+    color: #2a2e3a;
+}
+
+.task-log-view text {
+    background-color: #f0f2f7;
+    color: #2a2e3a;
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,90 @@
+//! Theme handling.
+//!
+//! The app ships a custom accent palette split across two files:
+//!
+//! - `style.css` — the historical **dark** palette, applied unchanged.
+//! - `style-light.css` — **light**-mode overrides that re-assert the
+//!   colour-bearing properties with a light palette.
+//!
+//! Two `CssProvider`s carry them:
+//!
+//! - A *base* provider loaded from `style.css` is always installed, so dark
+//!   mode is byte-for-byte what it was before this module existed.
+//! - A *light* provider loaded from `style-light.css` is installed at a higher
+//!   priority only while the system/GTK preference is *not* dark. Its overrides
+//!   then win over the dark base; in dark mode it is removed entirely, leaving
+//!   the original dark appearance untouched.
+//!
+//! GTK4 populates `gtk-application-prefer-dark-theme` from the
+//! `org.freedesktop.appearance color-scheme` portal setting, so we treat that
+//! property as the source of truth and re-apply on change — toggling the
+//! desktop color scheme flips the app live without a restart.
+//!
+//! The chat WebView renders its own palette via a `prefers-color-scheme` media
+//! query (see `markdown::html_template`), which WebKitGTK drives from the same
+//! GTK dark preference.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use gtk4::{CssProvider, gdk, glib};
+
+const STYLE_CSS: &str = include_str!("style.css");
+const STYLE_LIGHT_CSS: &str = include_str!("style-light.css");
+
+/// Install the app's theme handling for `display`.
+///
+/// Installs the dark base palette unconditionally and the light overrides only
+/// while the GTK light preference is active, then keeps the choice in sync
+/// with `gtk-application-prefer-dark-theme`.
+///
+/// Idempotent across windows: each call installs its own providers, but
+/// `style_context_add_provider_for_display` is a set keyed on the provider, so
+/// re-adding from a second window is harmless.
+pub fn install_for_display(display: &gdk::Display) {
+    let base_provider = CssProvider::new();
+    base_provider.load_from_data(STYLE_CSS);
+
+    let light_provider = CssProvider::new();
+    light_provider.load_from_data(STYLE_LIGHT_CSS);
+
+    // The dark base palette is always present.
+    gtk4::style_context_add_provider_for_display(
+        display,
+        &base_provider,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+
+    let settings = gtk4::Settings::for_display(display);
+    let light_applied = Rc::new(Cell::new(false));
+
+    let apply = {
+        let display = display.clone();
+        let light_provider = light_provider.clone();
+        let settings = settings.clone();
+        let light_applied = Rc::clone(&light_applied);
+        move || {
+            let want_dark = settings.is_gtk_application_prefer_dark_theme();
+            if !want_dark && !light_applied.get() {
+                gtk4::style_context_add_provider_for_display(
+                    &display,
+                    &light_provider,
+                    // Above the base provider so the light overrides win.
+                    gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION + 1,
+                );
+                light_applied.set(true);
+            } else if want_dark && light_applied.get() {
+                gtk4::style_context_remove_provider_for_display(&display, &light_provider);
+                light_applied.set(false);
+            }
+        }
+    };
+
+    apply();
+
+    settings.connect_gtk_application_prefer_dark_theme_notify(glib::clone!(
+        #[strong]
+        apply,
+        move |_| apply()
+    ));
+}

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -31,14 +31,10 @@ impl LoginScreen {
         // Install app icon
         window::install_app_icon();
 
-        // Apply CSS
-        let provider = gtk4::CssProvider::new();
-        provider.load_from_data(include_str!("../style.css"));
-        gtk4::style_context_add_provider_for_display(
-            &gdk::Display::default().expect("display"),
-            &provider,
-            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
-        );
+        // Apply theme-aware CSS (see `crate::theme`): the dark palette is
+        // installed unconditionally and the light overrides are layered on
+        // only when the system/GTK preference is light.
+        crate::theme::install_for_display(&gdk::Display::default().expect("display"));
 
         let outer = GtkBox::new(Orientation::Vertical, 0);
         outer.set_margin_start(24);

--- a/src/window.rs
+++ b/src/window.rs
@@ -406,14 +406,10 @@ impl AdelieWindow {
         // Set application icon for taskbar
         install_app_icon();
 
-        // Apply CSS
-        let provider = gtk4::CssProvider::new();
-        provider.load_from_data(include_str!("style.css"));
-        gtk4::style_context_add_provider_for_display(
-            &gdk::Display::default().expect("display"),
-            &provider,
-            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
-        );
+        // Apply theme-aware CSS: the dark palette is always installed; the
+        // light overrides (see `crate::theme`) are layered on only when the
+        // system/GTK preference is light, and re-applied on preference change.
+        crate::theme::install_for_display(&gdk::Display::default().expect("display"));
 
         // Layout: resizable paned split between sidebar and chat. The left
         // pane is a `Stack` that swaps between the conversation list and the


### PR DESCRIPTION
Closes #45.

Split out of #29 (the theme commit was dropped because it's a behavior change needing visual QA). This recovers the core wiring from the dropped draft `2810868`, re-applied by hand onto current `main` (the cherry-pick conflicts because #28 restructured `window.rs`), and goes beyond it by adding a full light accent palette.

## What changed
- **`src/theme.rs` (new)** — `install_for_display(display)`. Installs the dark `style.css` provider unconditionally as the base, then layers a *higher-priority* light provider (`style-light.css`) on top **only while light is preferred**. Watches the GTK setting and re-applies on change for live toggling. In dark mode the light provider is removed entirely.
- **`src/style-light.css` (new)** — full light accent palette: a light-mode equivalent for every dark accent / background / border / selection colour in `style.css`.
- **`src/window.rs`, `src/widgets/login_screen.rs`** — call `theme::install_for_display` instead of force-adding the dark CSS provider.
- **`src/markdown.rs`** — add a `@media (prefers-color-scheme: light)` block to the chat WebView CSS with a real light palette (dark default unchanged).
- **`src/main.rs`** — register `mod theme`.

## How light/dark is selected
- **GTK chrome:** the GTK setting **`gtk-application-prefer-dark-theme`** is the source of truth. GTK4 populates it from the `org.freedesktop.appearance color-scheme` portal. Dark preferred → only the dark base provider applies. Light preferred → the light provider (priority `APPLICATION + 1`) is added on top and its overrides win. The `notify` signal re-applies on runtime change.
- **WebView chat content:** a `@media (prefers-color-scheme: light)` block; WebKitGTK drives `prefers-color-scheme` from the same GTK dark preference, so chat follows the chrome.

## Light palette (key colors)
window `#1a1d2e`→`#f7f8fb` bg / `#e0e0e0`→`#1a1d2e` fg; surface `#232740`→`#ffffff`; border `#3a3f5c`→`#cdd3e0`; selection `#4866b4`→`#3a57a8` (white fg); brand teal `#84dac1`→`#178a6e`; header blue `#88d6f0`→`#1f6f97`; hover `#3a3f5c`→`#e6eaf3`; log surface `#181b29`→`#f0f2f7`. WebView mirrors these (user accent `#ffbd59`→`#9a6b00`, assistant `#5cce9a`→`#178a6e`, link `#7aa3ff`→`#2456c8`).

## Dark mode is unchanged
`style.css` is **byte-for-byte unchanged** (zero diff). In dark mode the light provider is never installed, and the WebView dark palette is the default (light rules live only inside the media query). The CSP script-hash is unaffected — only `<style>` changed, not `<script>` — verified by the existing test.

## Verification
- `cargo fmt -p adele-gtk -- --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0
- `cargo build --all-targets` → ok
- `cargo test` → 117 passed, 0 failed, 1 ignored (pre-existing keyring integration test). No `#[allow]` added.

## Needs the maintainer's visual QA
Per the accepted merge-then-visual-QA plan: eyeball the **light-mode** GTK chrome (sidebar, popovers/dropdowns, entries, login screen, task list/log) and the **light-mode** chat WebView against a live daemon, and confirm a runtime light↔dark toggle flips cleanly. Dark mode should look identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)