### PR TITLE
theme: fix patchy light-mode components + live color-scheme switching (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "url",
  "uuid",
  "webkit6",
+ "zbus",
  "zbus-secret-service-keyring-store",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rustls = { version = "0.23.37", features = ["ring"] }
+# Already in the dependency tree (via the D-Bus transport / secret-service
+# keyring store at 5.15.0); pinned to the same major. Used by `theme.rs` to
+# track the XDG Settings portal `color-scheme` preference live. The `tokio`
+# feature matches the runtime the portal task is spawned on.
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [dependencies.webkit6]
 version = "0.6"

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -29,6 +29,13 @@ window {
     color: #1f6f97;
 }
 
+/* Unselected rows: GTK's default row chrome is dark against the light
+   window, so re-assert a transparent surface with the light foreground. */
+.conversation-list row {
+    background-color: transparent;
+    color: #1a1d2e;
+}
+
 .conversation-list row:selected {
     background-color: #3a57a8;
     color: #ffffff;
@@ -36,6 +43,18 @@ window {
 
 .dim-label {
     color: #5b6473;
+}
+
+/* Plain GTK buttons render with a dark default surface in light mode; give
+   them the light surface, foreground and border used elsewhere here. */
+.new-conversation-button {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    border: 1px solid #cdd3e0;
+}
+
+.new-conversation-button:hover {
+    background-color: #e6eaf3;
 }
 
 .input-textview {
@@ -47,6 +66,16 @@ window {
 .input-textview text {
     background-color: #ffffff;
     color: #1a1d2e;
+}
+
+.send-button {
+    background-color: #ffffff;
+    color: #1a1d2e;
+    border: 1px solid #cdd3e0;
+}
+
+.send-button:hover {
+    background-color: #e6eaf3;
 }
 
 .status-bar {
@@ -160,9 +189,23 @@ entry:focus {
     color: #ffffff;
 }
 
+/* Unselected task rows: same dark-default-chrome fix as the conversation
+   list — transparent surface with the light foreground. */
+.task-list row {
+    background-color: transparent;
+    color: #1a1d2e;
+}
+
 .task-list row:selected {
     background-color: #3a57a8;
     color: #ffffff;
+}
+
+/* The dot is an empty label whose fill comes from the per-status classes
+   below; re-assert a transparent base surface so the unstyled dot never
+   shows GTK's dark default behind the status colour in light mode. */
+.task-dot {
+    background-color: transparent;
 }
 
 /* Status dots: keep the semantic hues but darken the neutral/amber ones so

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -15,10 +15,20 @@
 //!   then win over the dark base; in dark mode it is removed entirely, leaving
 //!   the original dark appearance untouched.
 //!
-//! GTK4 populates `gtk-application-prefer-dark-theme` from the
-//! `org.freedesktop.appearance color-scheme` portal setting, so we treat that
-//! property as the source of truth and re-apply on change — toggling the
-//! desktop color scheme flips the app live without a restart.
+//! We treat `gtk-application-prefer-dark-theme` as the source of truth and
+//! re-apply the provider choice whenever it changes. GTK4 reads that property
+//! from the `org.freedesktop.appearance color-scheme` portal setting only
+//! **once at startup**, though — it does not follow later changes — so on its
+//! own the app would only pick up a new desktop color scheme after a restart.
+//!
+//! To switch live, we subscribe to the XDG **Settings portal**
+//! (`org.freedesktop.portal.Settings`, namespace `org.freedesktop.appearance`,
+//! key `color-scheme`: 0 = no preference, 1 = prefer dark, 2 = prefer light),
+//! read it at startup and listen for the `SettingChanged` signal, then push
+//! each change into `gtk-application-prefer-dark-theme` on the GTK main thread.
+//! Writing that property drives the existing provider swap **and** WebKit's
+//! `prefers-color-scheme`. If the portal is unavailable (no portal, read
+//! fails, etc.) we log and fall back to the startup-only behaviour above.
 //!
 //! The chat WebView renders its own palette via a `prefers-color-scheme` media
 //! query (see `markdown::html_template`), which WebKitGTK drives from the same
@@ -27,10 +37,52 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use gtk4::{CssProvider, gdk, glib};
+use gtk4::{CssProvider, Settings, gdk, glib};
+use tokio::sync::mpsc;
+
+use crate::async_bridge::spawn_on_runtime;
 
 const STYLE_CSS: &str = include_str!("style.css");
 const STYLE_LIGHT_CSS: &str = include_str!("style-light.css");
+
+/// XDG desktop appearance namespace served by `org.freedesktop.portal.Settings`.
+const APPEARANCE_NS: &str = "org.freedesktop.appearance";
+/// Key within [`APPEARANCE_NS`] carrying the system color-scheme preference.
+const COLOR_SCHEME_KEY: &str = "color-scheme";
+
+/// Typed proxy for the XDG Settings portal.
+///
+/// `ReadOne` is the modern accessor (one un-nested variant); the
+/// `SettingChanged` signal fires with the namespace, key and new value
+/// whenever a tracked setting changes.
+#[zbus::proxy(
+    interface = "org.freedesktop.portal.Settings",
+    default_service = "org.freedesktop.portal.Desktop",
+    default_path = "/org/freedesktop/portal/desktop"
+)]
+trait Settings {
+    /// Read a single setting value (portal interface v2+).
+    #[zbus(name = "ReadOne")]
+    fn read_one(&self, namespace: &str, key: &str) -> zbus::Result<zbus::zvariant::OwnedValue>;
+
+    /// Emitted when a tracked setting changes.
+    #[zbus(signal)]
+    fn setting_changed(
+        &self,
+        namespace: &str,
+        key: &str,
+        value: zbus::zvariant::Value<'_>,
+    ) -> zbus::Result<()>;
+}
+
+/// Map the portal `color-scheme` enum to "prefer dark?".
+///
+/// `1` = prefer dark; everything else (`0` = no preference, `2` = prefer
+/// light, or any future value) is treated as not-dark, matching GTK's own
+/// interpretation of the setting.
+fn color_scheme_prefers_dark(value: u32) -> bool {
+    value == 1
+}
 
 /// Install the app's theme handling for `display`.
 ///
@@ -87,4 +139,157 @@ pub fn install_for_display(display: &gdk::Display) {
         apply,
         move |_| apply()
     ));
+
+    // Track the system color scheme live. `install_for_display` runs once per
+    // window, but the GTK preference is process-global and the notify above
+    // re-applies for every display, so a single portal listener is enough.
+    install_color_scheme_listener(settings);
+}
+
+thread_local! {
+    /// Whether the portal listener has already been spawned this process.
+    static PORTAL_LISTENER_STARTED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Subscribe to the XDG Settings portal and mirror `color-scheme` changes into
+/// `gtk-application-prefer-dark-theme` on the GTK main thread.
+///
+/// The zbus connection and signal stream live on the shared Tokio runtime
+/// (where zbus has a reactor); only plain `bool` "prefer dark" values cross
+/// back to the main thread, where the non-`Send` [`Settings`] is mutated.
+///
+/// Idempotent: only the first call per process spawns the listener. If the
+/// portal is unavailable or a read fails, it logs and returns, leaving the
+/// startup-derived GTK preference in place.
+fn install_color_scheme_listener(settings: Settings) {
+    if PORTAL_LISTENER_STARTED.with(|started| started.replace(true)) {
+        return;
+    }
+
+    // Plain `bool`s ride this channel; `Settings` never leaves the main thread.
+    let (tx, mut rx) = mpsc::unbounded_channel::<bool>();
+
+    // Apply updates on the GTK main thread. Skip no-op writes so we don't
+    // churn the provider swap when the portal re-announces the current value.
+    glib::spawn_future_local(async move {
+        while let Some(want_dark) = rx.recv().await {
+            if settings.is_gtk_application_prefer_dark_theme() != want_dark {
+                tracing::debug!(want_dark, "applying live color-scheme change");
+                settings.set_gtk_application_prefer_dark_theme(want_dark);
+            }
+        }
+    });
+
+    // Own the portal connection + signal stream on the Tokio runtime.
+    spawn_on_runtime(async move {
+        if let Err(error) = run_color_scheme_listener(&tx).await {
+            tracing::warn!(
+                %error,
+                "XDG Settings portal unavailable; color scheme will not switch live \
+                 (startup preference kept)"
+            );
+        }
+    });
+}
+
+/// Connect to the Settings portal, push the initial `color-scheme`, then
+/// forward every `SettingChanged` for it. Returns when the bus drops or the
+/// receiver ([`tx`]) is closed (window gone).
+async fn run_color_scheme_listener(tx: &mpsc::UnboundedSender<bool>) -> zbus::Result<()> {
+    // `futures_core` is re-exported by zbus, so the signal stream can be driven
+    // without taking on a separate `futures-util` dependency for `StreamExt`.
+    use std::pin::pin;
+
+    use zbus::export::futures_core::Stream;
+
+    let connection = zbus::Connection::session().await?;
+    let proxy = SettingsProxy::new(&connection).await?;
+
+    // Initial value: a successful read seeds the preference; failure here is
+    // not fatal — we still attach the signal listener below.
+    match proxy.read_one(APPEARANCE_NS, COLOR_SCHEME_KEY).await {
+        Ok(value) => {
+            if let Some(dark) = color_scheme_value(&value) {
+                let _ = tx.send(dark);
+            }
+        }
+        Err(error) => {
+            tracing::debug!(%error, "initial color-scheme read failed; relying on signal");
+        }
+    }
+
+    let changes = proxy.receive_setting_changed().await?;
+    let mut changes = pin!(changes);
+    while let Some(change) =
+        std::future::poll_fn(|cx| Stream::poll_next(changes.as_mut(), cx)).await
+    {
+        let Ok(args) = change.args() else { continue };
+        if args.namespace != APPEARANCE_NS || args.key != COLOR_SCHEME_KEY {
+            continue;
+        }
+        if let Some(dark) = color_scheme_value(&args.value)
+            && tx.send(dark).is_err()
+        {
+            // Receiver gone (window closed) — stop listening.
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode a `color-scheme` portal value into "prefer dark?".
+///
+/// The value is normally a bare `u32`, but some portal versions hand it back
+/// still wrapped in a variant; `downcast_ref` transparently unwraps one level
+/// of that nesting. Returns `None` (logged) for any other shape rather than
+/// guessing.
+fn color_scheme_value(value: &zbus::zvariant::Value<'_>) -> Option<bool> {
+    match value.downcast_ref::<u32>() {
+        Ok(scheme) => Some(color_scheme_prefers_dark(scheme)),
+        Err(error) => {
+            tracing::debug!(%error, "unexpected color-scheme value type from portal");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zbus::zvariant::Value;
+
+    use super::*;
+
+    #[test]
+    fn only_prefer_dark_enum_value_means_dark() {
+        // Portal enum: 0 = no preference, 1 = prefer dark, 2 = prefer light.
+        assert!(!color_scheme_prefers_dark(0));
+        assert!(color_scheme_prefers_dark(1));
+        assert!(!color_scheme_prefers_dark(2));
+    }
+
+    #[test]
+    fn unknown_future_enum_values_are_not_dark() {
+        // Anything we don't recognise stays light, matching GTK's own reading.
+        assert!(!color_scheme_prefers_dark(3));
+        assert!(!color_scheme_prefers_dark(u32::MAX));
+    }
+
+    #[test]
+    fn bare_u32_value_decodes() {
+        assert_eq!(color_scheme_value(&Value::U32(1)), Some(true));
+        assert_eq!(color_scheme_value(&Value::U32(2)), Some(false));
+    }
+
+    #[test]
+    fn variant_wrapped_value_decodes() {
+        // Some portal versions return the value still nested in a variant.
+        let nested = Value::Value(Box::new(Value::U32(1)));
+        assert_eq!(color_scheme_value(&nested), Some(true));
+    }
+
+    #[test]
+    fn wrong_type_yields_none() {
+        assert_eq!(color_scheme_value(&Value::Str("dark".into())), None);
+    }
 }


### PR DESCRIPTION
Closes #50. Follow-up to #45 (maintainer visual QA).

## Fix 1 — patchy light-mode components
`style.css` (dark) is the always-on base provider; `style-light.css` overrides colour-bearing properties only in light mode. Five dark-styled selectors had **no** light override, so they kept GTK's dark default chrome on the light window background. Added light overrides for all five, reusing the existing light palette (surface `#ffffff`, fg `#1a1d2e`, border `#cdd3e0`, hover `#e6eaf3`, accent `#3a57a8`) — no new colours invented:

- `.conversation-list row` → transparent bg, fg `#1a1d2e`
- `.new-conversation-button` (+`:hover`) → bg `#ffffff`, fg `#1a1d2e`, border `#cdd3e0`, hover `#e6eaf3`
- `.send-button` (+`:hover`) → bg `#ffffff`, fg `#1a1d2e`, border `#cdd3e0`, hover `#e6eaf3`
- `.task-dot` → transparent bg (per-status fill colours already overridden)
- `.task-list row` → transparent bg, fg `#1a1d2e`

`comm` of the two files' selector sets now shows **no** dark selector without a light override.

## Fix 2 — live color-scheme switching
GTK reads `gtk-application-prefer-dark-theme` from the `org.freedesktop.appearance color-scheme` portal setting only at startup, so the desktop color scheme previously only took effect after a restart. `theme.rs` now subscribes to the XDG Settings portal (`org.freedesktop.portal.Settings`) with a typed `zbus::proxy`: the connection + `SettingChanged` signal stream run on the shared Tokio runtime, and a plain "prefer dark" `bool` crosses back to the GTK main thread (tokio mpsc drained by `glib::spawn_future_local`, the bridge pattern `async_bridge` already uses) where it writes `gtk-application-prefer-dark-theme`. That write drives both the existing provider swap and WebKit's `prefers-color-scheme`.

- **Dependency:** `zbus` added as a direct dep at `5` — the exact version already in the tree (5.15.0, via the D-Bus transport / secret-service keyring store). No new package or major version lands in the lockfile; the only `Cargo.lock` change is adding `zbus` to this crate's dep list. CVE scan (OSV) clean.
- **Fallback:** if the portal is unavailable or the read fails, it logs at debug/warn and keeps the startup-derived preference — no crash, no hang. Listener spawned once per process.
- Fixed the stale module doc that claimed live switching already worked.

## Dark mode unchanged
`style.css` (dark) has a byte-for-byte empty diff vs `main`, and Fix 2 only changes *when* the dark preference updates, not the dark palette or provider logic.

## Verify
- `cargo fmt -p adele-gtk -- --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0
- `cargo build --all-targets` → ok
- `cargo test` → 126 passed, 0 failed, 1 ignored (pre-existing `#[ignore]` keyring integration test)

No `#[allow]` attributes added.

## Needs maintainer re-QA
Both fixes are visual / desktop-integration behaviours that automated checks can't confirm: (1) that the five components now render cleanly in light mode and no *other* component is still patchy, and (2) that flipping the desktop color scheme switches the app (chrome + WebView) live without a restart, on a real portal-backed desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)