### PR TITLE
fix(gtk): gate transport features on as_commands() (UDS) not as_ws() — restores Settings + model picker on local socket (#49)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::SignalEvent;
 use desktop_assistant_client_common::{
-    AssistantClient, AssistantCommands, ConnectionConfig, TransportClient, connect_transport,
+    AssistantClient, ConnectionConfig, TransportClient, connect_transport,
     transport::transport_label,
 };
 use gtk4::glib;
@@ -327,9 +327,10 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
                 }
 
                 // Fetch available models when the transport supports it
-                // (WS only — the D-Bus interface doesn't expose this command).
-                let listings = match transport.as_ws() {
-                    Some(ws) => ws
+                // (the command channel — Uds and Ws; the D-Bus interface
+                // doesn't expose this command).
+                let listings = match transport.as_commands() {
+                    Some(cmds) => cmds
                         .list_available_models(None, false)
                         .await
                         .unwrap_or_else(|e| {
@@ -343,16 +344,17 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
                 }
 
                 // Subscribe to background-task events and fetch the initial
-                // snapshot. WS-only: the D-Bus surface does not expose
-                // background tasks (issue #116 covers that path).
-                if let Some(ws) = transport.as_ws() {
-                    if let Err(e) = ws
+                // snapshot over the command channel (Uds and Ws). The D-Bus
+                // surface does not expose background tasks (issue #116 covers
+                // that path).
+                if let Some(cmds) = transport.as_commands() {
+                    if let Err(e) = cmds
                         .send_command(api::Command::SubscribeBackgroundTasks)
                         .await
                     {
                         tracing::warn!("SubscribeBackgroundTasks failed: {e}");
                     }
-                    match ws
+                    match cmds
                         .send_command(api::Command::ListBackgroundTasks {
                             include_finished: false,
                             limit: None,

--- a/src/management_client.rs
+++ b/src/management_client.rs
@@ -1,24 +1,29 @@
 //! Thin wrappers over the live `TransportClient` for named-connection and
 //! purpose management commands (Settings dialog).
 //!
-//! These use the WebSocket connection's `send_command` escape hatch (the
+//! These use the command channel's `send_command` escape hatch (the
 //! `AssistantCommands` trait), which the D-Bus surface doesn't expose — the
-//! Settings dialog is WS-only, matching the per-conversation model picker.
-//! Each wrapper returns a typed result so callers don't pattern-match the
-//! protocol envelope.
+//! Settings dialog needs a local-socket or WebSocket connection, matching the
+//! per-conversation model picker. Each wrapper returns a typed result so
+//! callers don't pattern-match the protocol envelope.
 
 use anyhow::{Result, anyhow};
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{AssistantCommands, TransportClient};
 
-/// Resolve the WebSocket client, erroring on transports that can't carry
+/// Error surfaced when the live transport can't carry the command channel
+/// (the D-Bus surface, which speaks a separate typed zbus interface and so
+/// does not implement `AssistantCommands`). Shared with the gate's test so the
+/// reworded wording stays in lock-step.
+const NO_COMMAND_CHANNEL: &str = "named-connection management requires a local-socket or \
+                                  WebSocket connection (not available over D-Bus)";
+
+/// Resolve the command channel, erroring on transports that can't carry
 /// these management commands (D-Bus).
-fn ws(
-    transport: &TransportClient,
-) -> Result<&desktop_assistant_client_common::ws_client::WsClient> {
+fn commands(transport: &TransportClient) -> Result<&(dyn AssistantCommands + '_)> {
     transport
-        .as_ws()
-        .ok_or_else(|| anyhow!("named-connection management requires a WebSocket transport"))
+        .as_commands()
+        .ok_or_else(|| anyhow!(NO_COMMAND_CHANNEL))
 }
 
 /// Coerce a `CommandResult` that should be a bare `Ack` into `()`, turning
@@ -33,7 +38,7 @@ fn expect_ack(command: &str, result: api::CommandResult) -> Result<()> {
 }
 
 pub async fn list_connections(transport: &TransportClient) -> Result<Vec<api::ConnectionView>> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::ListConnections)
         .await?;
     match result {
@@ -49,7 +54,7 @@ pub async fn create_connection(
     id: String,
     config: api::ConnectionConfigView,
 ) -> Result<()> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::CreateConnection { id, config })
         .await?;
     expect_ack("CreateConnection", result)
@@ -60,14 +65,14 @@ pub async fn update_connection(
     id: String,
     config: api::ConnectionConfigView,
 ) -> Result<()> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::UpdateConnection { id, config })
         .await?;
     expect_ack("UpdateConnection", result)
 }
 
 pub async fn delete_connection(transport: &TransportClient, id: String, force: bool) -> Result<()> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::DeleteConnection { id, force })
         .await?;
     expect_ack("DeleteConnection", result)
@@ -78,7 +83,7 @@ pub async fn list_available_models(
     connection_id: Option<String>,
     refresh: bool,
 ) -> Result<Vec<api::ModelListing>> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::ListAvailableModels {
             connection_id,
             refresh,
@@ -93,7 +98,7 @@ pub async fn list_available_models(
 }
 
 pub async fn get_purposes(transport: &TransportClient) -> Result<api::PurposesView> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::GetPurposes)
         .await?;
     match result {
@@ -107,7 +112,7 @@ pub async fn set_purpose(
     purpose: api::PurposeKindApi,
     config: api::PurposeConfigView,
 ) -> Result<()> {
-    let result = ws(transport)?
+    let result = commands(transport)?
         .send_command(api::Command::SetPurpose { purpose, config })
         .await?;
     expect_ack("SetPurpose", result)
@@ -139,5 +144,27 @@ mod tests {
     #[test]
     fn expect_ack_passes_through_ack() {
         assert!(expect_ack("SetPurpose", api::CommandResult::Ack).is_ok());
+    }
+
+    /// adele-gtk#49: the gate now keys on the command channel
+    /// (`as_commands`, available on UDS *and* WS) rather than `as_ws`. When no
+    /// command channel is present (D-Bus), the wrapper must reject with a
+    /// message that names both accepted transports and flags D-Bus as
+    /// excluded. Asserting the shared `NO_COMMAND_CHANNEL` constant keeps the
+    /// reworded wording from silently regressing; the per-variant
+    /// `as_commands` mapping itself is unit-tested daemon-side
+    /// (`transport_command_channel.rs`) where a live socket is cheap.
+    #[test]
+    fn command_channel_gate_message_names_both_socket_transports() {
+        let err = anyhow!(NO_COMMAND_CHANNEL).to_string();
+        assert!(
+            err.contains("local-socket"),
+            "must name the UDS path: {err}"
+        );
+        assert!(err.contains("WebSocket"), "must name the WS path: {err}");
+        assert!(
+            err.contains("not available over D-Bus"),
+            "must flag D-Bus as excluded: {err}"
+        );
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{
-    AssistantClient, AssistantCommands, ChatMessage, ConnectionConfig, ConversationDetail,
-    ConversationSummary, TransportClient,
+    AssistantClient, ChatMessage, ConnectionConfig, ConversationDetail, ConversationSummary,
+    TransportClient,
 };
 use gtk4::prelude::*;
 use gtk4::{
@@ -962,14 +962,15 @@ impl AdelieWindow {
                         let tx = bridge_ref.ui_sender();
                         let text = text.clone();
                         bridge_ref.spawn(async move {
-                            // Use the WS-specific override path when available so
-                            // the picker's selection is honoured. The shared
-                            // AssistantClient trait can't carry the override
-                            // because the D-Bus surface doesn't expose it; on
-                            // D-Bus we fall through to the plain send_prompt.
-                            let result = match (client.as_ws(), override_selection) {
-                                (Some(ws), Some(over)) => {
-                                    ws.send_prompt_with_override(&conv_id, &text, Some(over))
+                            // Use the command-channel override path when
+                            // available so the picker's selection is honoured.
+                            // The shared AssistantClient trait can't carry the
+                            // override because the D-Bus surface doesn't expose
+                            // it; on D-Bus we fall through to the plain
+                            // send_prompt.
+                            let result = match (client.as_commands(), override_selection) {
+                                (Some(cmds), Some(over)) => {
+                                    cmds.send_prompt_with_override(&conv_id, &text, Some(over))
                                         .await
                                 }
                                 _ => client.send_prompt(&conv_id, &text).await,
@@ -1052,9 +1053,9 @@ impl AdelieWindow {
                     status_label.set_text("Not connected — settings unavailable");
                     return;
                 };
-                if transport.as_ws().is_none() {
+                if transport.as_commands().is_none() {
                     status_label.set_text(
-                        "Settings require the WebSocket transport (unavailable on D-Bus)",
+                        "Settings require a local-socket or WebSocket connection (not available over D-Bus)",
                     );
                     return;
                 }
@@ -1157,7 +1158,8 @@ impl AdelieWindow {
 
         // Tasks panel: toolbar wiring (#19).
         //
-        // `Cancel` sends `CancelBackgroundTask` over WS; `Open Conversation`
+        // `Cancel` sends `CancelBackgroundTask` over the command channel;
+        // `Open Conversation`
         // routes the user back to the Conversations stack page and loads the
         // task's conversation so the streaming output keeps flowing into the
         // chat view.
@@ -1172,13 +1174,15 @@ impl AdelieWindow {
                 };
                 let tx = bridge.ui_sender();
                 bridge.spawn(async move {
-                    let Some(ws) = transport.as_ws() else {
+                    let Some(cmds) = transport.as_commands() else {
                         let _ = tx.send(UiMessage::Error(
-                            "Background tasks require the WebSocket transport".to_string(),
+                            "Background tasks require a local-socket or WebSocket connection \
+                             (not available over D-Bus)"
+                                .to_string(),
                         ));
                         return;
                     };
-                    if let Err(e) = ws
+                    if let Err(e) = cmds
                         .send_command(api::Command::CancelBackgroundTask { id: task_id })
                         .await
                     {


### PR DESCRIPTION
Closes #49. Depends on desktop-assistant#169 (merged) — `TransportClient::as_commands()` plus the promoted `AssistantCommands` trait methods.

Migrates every transport gate from the WebSocket-only `as_ws()` accessor to the transport-agnostic `as_commands()` command channel, which is `Some` for both the Unix-domain-socket and WebSocket variants and `None` only for D-Bus. None of these features are genuinely WS-only, so all now work over the default local Unix-socket transport.

## Converted gates
- **`src/management_client.rs`** — `ws()` helper renamed to `commands()`, now returns `&dyn AssistantCommands` via `as_commands()`. All call sites (`list_connections`/`create`/`update`/`delete_connection`/`list_available_models`/`get_purposes`/`set_purpose`) call trait methods on the dyn ref unchanged.
- **`src/async_bridge.rs:331`** — the on-connect model fetch. **This is the dropdown fix:** on UDS, `as_commands()` now yields the channel, `list_available_models` runs → `ModelsLoaded(non-empty)` → the header model picker shows on the default local socket (previously empty because `as_ws()` was `None` over UDS).
- **`src/async_bridge.rs:348`** — background-task subscribe + initial-snapshot list.
- **`src/window.rs:970`** — per-conversation model override on send (`send_prompt_with_override`).
- **`src/window.rs:1055`** — the Settings gate.
- **`src/window.rs:1175`** — background-task cancel.

`grep -rn 'as_ws' src/` is now clean (the only match is a doc comment in the new test explaining the migration). D-Bus stays excluded — it speaks a separate typed zbus interface and does not implement `AssistantCommands`.

## Reworded messages
- management_client gate: "named-connection management requires a local-socket or WebSocket connection (not available over D-Bus)"
- Settings: "Settings require a local-socket or WebSocket connection (not available over D-Bus)"
- Background-task cancel: "Background tasks require a local-socket or WebSocket connection (not available over D-Bus)"

## Other
- Dropped now-unused `AssistantCommands` imports from `async_bridge.rs` and `window.rs` (trait methods resolve through the dyn vtable; the import is no longer needed). `management_client.rs` keeps it for the `&dyn AssistantCommands` return type.
- Added a GTK-free unit test (`command_channel_gate_message_names_both_socket_transports`) asserting the reworded gate wording names both socket transports and flags D-Bus as excluded. The per-variant `as_commands` mapping is unit-tested daemon-side.

## Verify
- `cargo fmt -p adele-gtk -- --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0
- `cargo build --all-targets` → ok
- `cargo test` → 127 passed, 0 failed, 1 ignored (pre-existing keyring integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)