### PR TITLE
feat(gtk): model picker shows & pins the resolved default model (#53)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -88,6 +88,14 @@ pub enum UiMessage {
     /// Available (connection, model) pairs, fetched once on connect.
     /// Empty list means the picker should hide (e.g. D-Bus transport).
     ModelsLoaded(Vec<api::ModelListing>),
+    /// The resolved interactive-purpose default model, fetched via
+    /// `GetPurposes` on connect (and re-fetched after Settings edits). The
+    /// picker uses it as the fallback selection for conversations with no
+    /// stored selection, so the button always shows a concrete model instead
+    /// of a "(default)" placeholder. `None` when it can't be resolved (the
+    /// command failed, the interactive purpose is unset, or it uses the
+    /// "primary"/inherit sentinel) — the picker then degrades to "Model".
+    DefaultModelLoaded(Option<crate::selected_models::SelectedModel>),
     Connected {
         label: String,
     },
@@ -198,6 +206,9 @@ impl std::fmt::Debug for UiMessage {
                 .field("task_id", task_id)
                 .finish(),
             UiMessage::ModelsLoaded(v) => f.debug_tuple("ModelsLoaded").field(v).finish(),
+            UiMessage::DefaultModelLoaded(v) => {
+                f.debug_tuple("DefaultModelLoaded").field(v).finish()
+            }
             UiMessage::Connected { label } => {
                 f.debug_struct("Connected").field("label", label).finish()
             }
@@ -343,6 +354,25 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
                     return;
                 }
 
+                // Resolve the interactive-purpose default model so the picker
+                // can show a concrete fallback for conversations with no stored
+                // selection (issue #53). Graceful: on failure (or a D-Bus
+                // transport that doesn't carry GetPurposes) we send `None` and
+                // the picker degrades to its last-resort "Model" label.
+                let default_model = match crate::management_client::get_purposes(&transport).await {
+                    Ok(purposes) => interactive_default_from_purposes(&purposes),
+                    Err(e) => {
+                        tracing::warn!("get_purposes failed; default model unresolved: {e}");
+                        None
+                    }
+                };
+                if ui_tx
+                    .send(UiMessage::DefaultModelLoaded(default_model))
+                    .is_err()
+                {
+                    return;
+                }
+
                 // Subscribe to background-task events and fetch the initial
                 // snapshot over the command channel (Uds and Ws). The D-Bus
                 // surface does not expose background tasks (issue #116 covers
@@ -423,6 +453,33 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
     }
 }
 
+/// The daemon sentinel meaning "inherit from the interactive purpose"; it
+/// never appears for the *interactive* purpose itself, but we guard against it
+/// (and empty fields) defensively so a malformed config degrades to "no
+/// default" rather than pinning a non-resolvable model.
+const PRIMARY_SENTINEL: &str = "primary";
+
+/// Extract the interactive purpose's concrete `(connection, model)` as a
+/// [`SelectedModel`]. Returns `None` when the interactive purpose is unset, has
+/// an empty connection/model, or uses the `"primary"` inherit sentinel — any of
+/// which means there's no concrete model to pin. Pure; unit-tested below.
+///
+/// Shared with `window.rs`, which re-resolves the default after Settings edits.
+pub(crate) fn interactive_default_from_purposes(
+    purposes: &api::PurposesView,
+) -> Option<crate::selected_models::SelectedModel> {
+    let cfg = purposes.interactive.as_ref()?;
+    let is_resolvable = |field: &str| !field.is_empty() && field != PRIMARY_SENTINEL;
+    if is_resolvable(&cfg.connection) && is_resolvable(&cfg.model) {
+        Some(crate::selected_models::SelectedModel {
+            connection_id: cfg.connection.clone(),
+            model_id: cfg.model.clone(),
+        })
+    } else {
+        None
+    }
+}
+
 /// Translate a `SignalEvent` from `client-common` into the corresponding
 /// `UiMessage` the GTK main thread consumes. Pure mapping; tested below.
 fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
@@ -487,6 +544,52 @@ mod tests {
             title: "demo".to_string(),
             progress_hint: None,
         }
+    }
+
+    fn purpose_cfg(connection: &str, model: &str) -> api::PurposeConfigView {
+        api::PurposeConfigView {
+            connection: connection.to_string(),
+            model: model.to_string(),
+            effort: None,
+            max_context_tokens: None,
+        }
+    }
+
+    #[test]
+    fn interactive_default_resolves_concrete_connection_and_model() {
+        let purposes = api::PurposesView {
+            interactive: Some(purpose_cfg("work", "claude")),
+            ..Default::default()
+        };
+        let resolved = interactive_default_from_purposes(&purposes).expect("resolvable");
+        assert_eq!(resolved.connection_id, "work");
+        assert_eq!(resolved.model_id, "claude");
+    }
+
+    #[test]
+    fn interactive_default_is_none_when_interactive_purpose_unset() {
+        let purposes = api::PurposesView::default();
+        assert!(interactive_default_from_purposes(&purposes).is_none());
+    }
+
+    #[test]
+    fn interactive_default_is_none_for_primary_inherit_sentinel() {
+        // The interactive purpose shouldn't use the inherit sentinel, but a
+        // malformed config must degrade to "no default" rather than pin it.
+        let purposes = api::PurposesView {
+            interactive: Some(purpose_cfg("primary", "primary")),
+            ..Default::default()
+        };
+        assert!(interactive_default_from_purposes(&purposes).is_none());
+    }
+
+    #[test]
+    fn interactive_default_is_none_when_model_field_empty() {
+        let purposes = api::PurposesView {
+            interactive: Some(purpose_cfg("work", "")),
+            ..Default::default()
+        };
+        assert!(interactive_default_from_purposes(&purposes).is_none());
     }
 
     #[test]

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -146,6 +146,12 @@ popover modelbutton:disabled label {
     color: #5b6473;
 }
 
+.context-button.selected-model,
+.context-button.selected-model label {
+    font-weight: bold;
+    color: #1a1d2e;
+}
+
 dropdown > popover > contents {
     background-color: #ffffff;
     border: 1px solid #cdd3e0;

--- a/src/style.css
+++ b/src/style.css
@@ -142,6 +142,14 @@ popover modelbutton:disabled label {
     color: #7c8494;
 }
 
+/* The model-picker row matching the active selection (the conversation's
+   stored pick, or the resolved interactive-purpose default). */
+.context-button.selected-model,
+.context-button.selected-model label {
+    font-weight: bold;
+    color: #f5f8ff;
+}
+
 /* DropDown popup: rendered as a popover containing a ListView. Without
    these rules the rows inherit the window's light foreground but render on
    the default white popover surface — the gray-on-white contrast bug. */

--- a/src/widgets/model_picker.rs
+++ b/src/widgets/model_picker.rs
@@ -28,11 +28,28 @@ pub struct ModelPicker {
     available: Rc<RefCell<Vec<api::ModelListing>>>,
     /// User's curated subset, mirrored to `selected_models.json`.
     selected: Rc<RefCell<Vec<SelectedModel>>>,
-    /// Currently active selection. `None` means "use the daemon default" —
-    /// we leave the override field empty and let the daemon fall back to
-    /// the conversation's stored selection or the interactive purpose.
+    /// Currently active selection. Normally `Some` — either the conversation's
+    /// stored selection or, when it has none, the resolved interactive-purpose
+    /// default (see `resolve_active`). `current_override` returns this verbatim,
+    /// so a conversation on the default pins it on the first send. Only `None`
+    /// when even the default can't be resolved (the button then shows "Model").
     active: Rc<RefCell<Option<SelectedModel>>>,
+    /// The interactive-purpose default model, resolved from `GetPurposes` on
+    /// connect (and after Settings edits). Used as the fallback selection for
+    /// conversations with no stored selection. `None` until resolved (or when
+    /// it can't be — e.g. the interactive purpose uses the inherit sentinel).
+    default_model: Rc<RefCell<Option<SelectedModel>>>,
     store: Rc<SelectedModelsStore>,
+}
+
+/// Resolve the picker's active selection: a conversation's stored selection
+/// wins; otherwise fall back to the resolved interactive-purpose default. Pure
+/// so the precedence can be unit-tested without a live GTK context.
+fn resolve_active(
+    stored: Option<SelectedModel>,
+    default: Option<SelectedModel>,
+) -> Option<SelectedModel> {
+    stored.or(default)
 }
 
 impl ModelPicker {
@@ -45,7 +62,7 @@ impl ModelPicker {
         container.append(&label);
 
         let menu_button = MenuButton::new();
-        menu_button.set_label("(default)");
+        menu_button.set_label("Model");
         menu_button.set_tooltip_text(Some(
             "Pick a model for this conversation. The choice is remembered \
              until you change it again.",
@@ -65,6 +82,7 @@ impl ModelPicker {
             available: Rc::new(RefCell::new(Vec::new())),
             selected: Rc::new(RefCell::new(Vec::new())),
             active: Rc::new(RefCell::new(None)),
+            default_model: Rc::new(RefCell::new(None)),
             store: Rc::new(SelectedModelsStore::new()),
         }
     }
@@ -120,16 +138,41 @@ impl ModelPicker {
         self.refresh_button_label();
     }
 
-    /// Apply the active conversation's stored selection (or clear when the
-    /// argument is `None`). Updates the visible label without rebuilding
-    /// the popover; callers are expected to have already populated the
-    /// available list.
+    /// Apply the active conversation's stored selection. When the argument is
+    /// `None` (no stored selection), the picker falls back to the resolved
+    /// interactive-purpose default so the button still shows a concrete model.
+    /// Updates the visible label without rebuilding the popover; callers are
+    /// expected to have already populated the available list.
     pub fn set_selection(&self, selection: Option<&api::ConversationModelSelectionView>) {
-        let active = selection.map(|s| SelectedModel {
+        let stored = selection.map(|s| SelectedModel {
             connection_id: s.connection_id.clone(),
             model_id: s.model_id.clone(),
         });
-        *self.active.borrow_mut() = active;
+        let default = self.default_model.borrow().clone();
+        *self.active.borrow_mut() = resolve_active(stored, default);
+        self.refresh_button_label();
+    }
+
+    /// Set the resolved interactive-purpose default, used as the fallback
+    /// selection for conversations with no stored selection. Stores the value
+    /// and, when nothing is actively selected yet, adopts it so the button
+    /// shows a concrete model even before a conversation finishes loading.
+    /// `None` clears the default (e.g. `GetPurposes` failed or the interactive
+    /// purpose uses the inherit sentinel) — the button then shows the
+    /// last-resort "Model" text unless a stored selection is present.
+    ///
+    /// Re-application on conversation change is driven by `set_selection`,
+    /// which re-resolves `stored.or(default)` on every conversation load; this
+    /// method only needs to fill in the default when no selection is active
+    /// (connect, or after a Settings edit on a conversation still on the
+    /// default — the `ModelsLoaded` flow re-runs `set_selection` there).
+    pub fn set_default_model(&self, default: Option<SelectedModel>) {
+        *self.default_model.borrow_mut() = default.clone();
+        // Adopt the default only when nothing is actively selected — never
+        // clobber a conversation's explicit selection.
+        if self.active.borrow().is_none() {
+            *self.active.borrow_mut() = default;
+        }
         self.refresh_button_label();
     }
 
@@ -157,7 +200,9 @@ impl ModelPicker {
         let active = self.active.borrow();
         let label_text = match active.as_ref() {
             Some(sel) => self.label_for(sel),
-            None => "(default)".to_string(),
+            // Last resort only: neither a stored selection nor a resolved
+            // default is known (e.g. before connect, or GetPurposes failed).
+            None => "Model".to_string(),
         };
         self.menu_button.set_label(&label_text);
     }
@@ -274,11 +319,17 @@ fn rebuild_popover_into(
         empty.set_margin_bottom(6);
         menu_box.append(&empty);
     } else {
+        let active_now = active.borrow().clone();
         for sel in selected_list.iter() {
             let label_text = label_for(sel, available);
             let btn = Button::with_label(&label_text);
             btn.add_css_class("context-button");
             btn.set_halign(Align::Fill);
+            // Mark the row matching the active selection (whether that's the
+            // conversation's stored pick or the resolved default).
+            if active_now.as_ref() == Some(sel) {
+                btn.add_css_class("selected-model");
+            }
 
             let sel_owned = sel.clone();
             btn.connect_clicked(glib::clone!(
@@ -310,7 +361,7 @@ fn refresh_menu_button_label(
 ) {
     let text = match active.borrow().as_ref() {
         Some(sel) => label_for(sel, available),
-        None => "(default)".to_string(),
+        None => "Model".to_string(),
     };
     menu_button.set_label(&text);
 }
@@ -337,4 +388,37 @@ fn format_label(listing: &api::ModelListing) -> String {
         listing.model.display_name.as_str()
     };
     format!("{} · {}", model_label, listing.connection_label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(connection_id: &str, model_id: &str) -> SelectedModel {
+        SelectedModel {
+            connection_id: connection_id.to_string(),
+            model_id: model_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_active_prefers_stored_selection_over_default() {
+        let stored = model("work", "claude");
+        let default = model("openai", "gpt-4o");
+        assert_eq!(
+            resolve_active(Some(stored.clone()), Some(default)),
+            Some(stored)
+        );
+    }
+
+    #[test]
+    fn resolve_active_falls_back_to_default_when_no_stored_selection() {
+        let default = model("openai", "gpt-4o");
+        assert_eq!(resolve_active(None, Some(default.clone())), Some(default));
+    }
+
+    #[test]
+    fn resolve_active_is_none_when_neither_is_present() {
+        assert_eq!(resolve_active(None, None), None);
+    }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -77,6 +77,10 @@ enum Effect {
     SetModelSelection(Option<api::ConversationModelSelectionView>),
     /// Replace the model-picker's available models.
     SetModels(Vec<api::ModelListing>),
+    /// Set the picker's resolved interactive-purpose default (issue #53). Used
+    /// as the fallback selection for conversations with no stored selection so
+    /// the button shows a concrete model instead of "(default)".
+    SetDefaultModel(Option<crate::selected_models::SelectedModel>),
     /// Show/hide the model picker.
     SetModelPickerVisible(bool),
     /// Reveal a passive toast with the given message.
@@ -122,6 +126,7 @@ impl std::fmt::Debug for Effect {
             Effect::CompleteStreaming(c) => f.debug_tuple("CompleteStreaming").field(c).finish(),
             Effect::SetModelSelection(s) => f.debug_tuple("SetModelSelection").field(s).finish(),
             Effect::SetModels(m) => f.debug_tuple("SetModels").field(m).finish(),
+            Effect::SetDefaultModel(m) => f.debug_tuple("SetDefaultModel").field(m).finish(),
             Effect::SetModelPickerVisible(v) => {
                 f.debug_tuple("SetModelPickerVisible").field(v).finish()
             }
@@ -348,6 +353,14 @@ impl WindowState {
                 }
                 effects.push(Effect::SetModelPickerVisible(visible));
                 effects
+            }
+            UiMessage::DefaultModelLoaded(default) => {
+                // The picker uses this as the fallback selection for
+                // conversations with no stored selection. Set it independently
+                // of `set_selection`; the picker re-resolves
+                // stored-or-default on every conversation load, so ordering
+                // between the two only requires both to have run.
+                vec![Effect::SetDefaultModel(default)]
             }
             UiMessage::Connected { label } => {
                 vec![Effect::SetStatusText(label), Effect::SetSendSensitive(true)]
@@ -1079,6 +1092,23 @@ impl AdelieWindow {
                             tracing::warn!("Failed to refresh models after settings: {e}");
                         }
                     }
+                    // The user may have changed the interactive purpose; re-fetch
+                    // purposes so the picker's default updates for conversations
+                    // still on the default (issue #53). Graceful: on failure we
+                    // emit `None` (picker degrades to "Model").
+                    let default_model =
+                        match management_client::get_purposes(&transport).await {
+                            Ok(purposes) => {
+                                crate::async_bridge::interactive_default_from_purposes(&purposes)
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to refresh purposes after settings: {e}"
+                                );
+                                None
+                            }
+                        };
+                    let _ = tx.send(UiMessage::DefaultModelLoaded(default_model));
                 });
             }
         ));
@@ -1298,6 +1328,9 @@ fn handle_ui_message(
             }
             Effect::SetModels(listings) => {
                 model_picker.set_models(&listings);
+            }
+            Effect::SetDefaultModel(default) => {
+                model_picker.set_default_model(default);
             }
             Effect::SetModelPickerVisible(visible) => {
                 model_picker.set_visible(visible);
@@ -1923,6 +1956,33 @@ mod tests {
             }
             other => panic!("unexpected effects (no conversation => no reapply): {other:?}"),
         }
+    }
+
+    #[test]
+    fn default_model_loaded_emits_set_default_model_effect() {
+        let mut state = WindowState::default();
+        let default = crate::selected_models::SelectedModel {
+            connection_id: "work".to_string(),
+            model_id: "claude".to_string(),
+        };
+        let effects = state.apply(UiMessage::DefaultModelLoaded(Some(default.clone())));
+        match effects.as_slice() {
+            [Effect::SetDefaultModel(Some(got))] => {
+                assert_eq!(got.connection_id, "work");
+                assert_eq!(got.model_id, "claude");
+            }
+            other => panic!("unexpected effects: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn default_model_loaded_none_emits_set_default_model_none() {
+        let mut state = WindowState::default();
+        let effects = state.apply(UiMessage::DefaultModelLoaded(None));
+        assert!(
+            matches!(effects.as_slice(), [Effect::SetDefaultModel(None)]),
+            "unresolved default must still emit a (None) effect: {effects:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #53.

The header model picker showed `(default)` whenever a conversation had no explicit `model_selection`. It now shows the REAL interactive-purpose default and pins it on the first send.

## How the interactive default is resolved
On connect, `connection_manager` calls `management_client::get_purposes(&transport)` and feeds the result to the pure helper `interactive_default_from_purposes`, which reads `PurposesView.interactive` (`PurposeConfigView { connection, model, .. }`) and maps it to a `SelectedModel`. It returns `None` when the interactive purpose is unset, has an empty connection/model, or uses the `"primary"`/inherit sentinel — defensive, since the interactive purpose itself should never inherit. The result rides the new `UiMessage::DefaultModelLoaded(Option<SelectedModel>)`. On `get_purposes` failure (including D-Bus, which has no `GetPurposes`) we send `None` and `warn` — graceful.

## New UiMessage / Effect / wiring
- `UiMessage::DefaultModelLoaded(Option<SelectedModel>)` (async_bridge).
- `WindowState::apply` maps it to the new `Effect::SetDefaultModel(Option<SelectedModel>)`.
- The executor calls `model_picker.set_default_model(..)`. Manual `Debug` impls for both `UiMessage` and `Effect` updated.

## Pin-on-send semantics
`model_picker` gains `default_model` + `set_default_model`. The pure `resolve_active(stored, default) = stored.or(default)` drives `set_selection`, so a conversation with no stored selection now resolves to the default. Since `active` is now usually `Some`, `current_override()` returns the concrete model unchanged in shape — the existing first-send `SendPrompt` override path then pins it to the daemon-stored `model_selection`. `set_selection` re-resolves on every conversation load, so switching conversations updates the picker per-conversation; ordering between `set_default_model` and `set_selection` only requires both to have run (label refreshes after either).

## Graceful fallback
The button label drops the hardcoded `(default)` — it shows the resolved model, and only falls back to `"Model"` as a last resort when neither a stored selection nor a resolved default is known.

## After Settings edits
The Settings handler already re-fetches models; it now also re-fetches purposes and re-emits `DefaultModelLoaded`, so changing the interactive purpose updates the shown default for conversations still on the default.

## Polish
The popover row matching the active selection is marked with a `.selected-model` CSS class (added to both dark and light themes).

## Tests
- `resolve_active`: stored wins / falls back to default / both `None`.
- `interactive_default_from_purposes`: resolvable / unset / `"primary"` sentinel / empty model field.
- apply-level: `DefaultModelLoaded(Some)` and `(None)` emit `Effect::SetDefaultModel`.

`cargo fmt -p adele-gtk -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --all-targets` all exit 0; `cargo test` 136 pass / 1 pre-existing keyring test ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)