### PR TITLE
theme: pin Adwaita base theme so GTK-drawn widgets follow light/dark (#55)

### DIFF
--- a/src/style-light.css
+++ b/src/style-light.css
@@ -190,7 +190,20 @@ entry:focus {
     color: #1a1d2e;
 }
 
+/* When the window is inactive (backdrop), the base theme dims the switcher
+   label; without an explicit light value the unselected text washed out to
+   near-white over the light surface. Re-assert a readable, palette-consistent
+   dim foreground so the tabs stay visible. */
+.sidebar-stack-switcher button:backdrop {
+    color: #5b6473;
+}
+
 .sidebar-stack-switcher button:checked {
+    background-color: #3a57a8;
+    color: #ffffff;
+}
+
+.sidebar-stack-switcher button:checked:backdrop {
     background-color: #3a57a8;
     color: #ffffff;
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -15,6 +15,24 @@
 //!   then win over the dark base; in dark mode it is removed entirely, leaving
 //!   the original dark appearance untouched.
 //!
+//! ## Pinned base theme
+//!
+//! The app's own CSS only styles widgets that carry an app style class; every
+//! other GTK-drawn control (list-box surfaces, `MenuButton`s, `CheckButton`s,
+//! the task list, the task panel's plain buttons, the sidebar stack-switcher,
+//! …) falls back to the ambient GTK theme. Most third-party system themes do
+//! **not** honour `gtk-application-prefer-dark-theme`, so those controls would
+//! stay in whatever palette the system theme paints (typically dark) regardless
+//! of the desktop's light/dark preference. To make the whole window follow the
+//! preference, [`install_for_display`] pins the base GTK theme to GTK4's
+//! built-in **Adwaita** (`gtk-theme-name = "Adwaita"`), which is the one theme
+//! guaranteed to switch between its light and dark variants from
+//! `gtk-application-prefer-dark-theme`. Accepted trade-off: in dark mode those
+//! unstyled GTK controls render as Adwaita-dark rather than the system theme;
+//! the app's custom accent palette (below) is unaffected either way.
+//!
+//! ## Live preference tracking
+//!
 //! We treat `gtk-application-prefer-dark-theme` as the source of truth and
 //! re-apply the provider choice whenever it changes. GTK4 reads that property
 //! from the `org.freedesktop.appearance color-scheme` portal setting only
@@ -108,6 +126,15 @@ pub fn install_for_display(display: &gdk::Display) {
     );
 
     let settings = gtk4::Settings::for_display(display);
+
+    // Pin the base GTK theme to the built-in Adwaita, which honours
+    // `gtk-application-prefer-dark-theme` by switching between its light and
+    // dark variants. This makes every GTK-drawn control that has no app style
+    // class follow the desktop's light/dark preference instead of staying in
+    // the system theme's (typically non-switching) palette. Idempotent across
+    // windows: setting the property repeatedly to the same value is harmless.
+    settings.set_gtk_theme_name(Some("Adwaita"));
+
     let light_applied = Rc::new(Cell::new(false));
 
     let apply = {


### PR DESCRIPTION
Closes #55.

## The fix
App CSS (`style.css` / `style-light.css`) only styles widgets that carry an app style class. Every other GTK-DRAWN control — conversation list (listbox surface), model-picker MenuButton, show-archived CheckButton, hamburger MenuButton, task list, the task panel's Cancel / Open-conversation buttons, and the sidebar stack-switcher — falls back to the ambient GTK theme. Most system GTK themes do **not** honour `gtk-application-prefer-dark-theme`, so those controls stayed dark in light mode no matter the desktop preference.

**Fix 1 — pin a switchable base theme.** In `theme.rs` `install_for_display`, before the first `apply()`:

```rust
settings.set_gtk_theme_name(Some("Adwaita"));
```

GTK4's built-in Adwaita is the one theme guaranteed to switch between its light and dark variants from `gtk-application-prefer-dark-theme`. The existing portal listener already toggles that property live and `apply()` already swaps the light/dark CSS overlay on top — Adwaita is just the base they now sit on, so every unstyled GTK control follows the desktop. Idempotent across windows (re-setting the same value is harmless). The provider logic and portal listener are otherwise untouched.

**Fix 2 — light-mode text-color override.** Added to `style-light.css` only (dark `style.css` untouched): a `:backdrop` (inactive-window) override for the sidebar stack-switcher, where the unselected label washed out to near-white over the light surface:

```css
.sidebar-stack-switcher button:backdrop { color: #5b6473; }
.sidebar-stack-switcher button:checked:backdrop { background-color: #3a57a8; color: #ffffff; }
```

The rest of the CSS audit found every other hardcoded light/symbolic `color:` in `style.css` already has a matching light-mode override; the backdrop state was the only gap.

## Trade-off
In dark mode the unstyled GTK chrome now renders as Adwaita-dark rather than the system theme. The app's custom accent palette is unaffected in both modes.

## Needs maintainer visual re-QA
Verify in both light and dark, active and inactive window: conversation list, model-picker, show-archived check, hamburger menu, task list, task-panel Cancel / Open-conversation buttons, and the stack-switcher text (incl. inactive window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)