### PR TITLE
Conversation side pane: live filtered tasks + interactive scratchpad

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -128,6 +128,22 @@ pub enum UiMessage {
     TaskCompleted {
         id: String,
     },
+
+    // --- Conversation scratchpad (issue #60) ------------------------------
+    /// The scratchpad notes for a conversation, fetched via
+    /// `GetConversationScratchpad` after a load / turn-complete / change event.
+    /// The window applies it to the side pane only when it matches the active
+    /// conversation.
+    ConversationScratchpadLoaded {
+        conversation_id: String,
+        notes: Vec<api::ScratchpadNoteView>,
+    },
+    /// A conversation's scratchpad changed (the LLM's tools or a client command
+    /// mutated it). Carried from `SignalEvent::ScratchpadChanged`; the window
+    /// re-fetches when it matches the active conversation.
+    ScratchpadChanged {
+        conversation_id: String,
+    },
 }
 
 // Manual `Debug` (can't derive: `TransportClient` is not `Debug`). Only
@@ -233,6 +249,18 @@ impl std::fmt::Debug for UiMessage {
             UiMessage::TaskCompleted { id } => {
                 f.debug_struct("TaskCompleted").field("id", id).finish()
             }
+            UiMessage::ConversationScratchpadLoaded {
+                conversation_id,
+                notes,
+            } => f
+                .debug_struct("ConversationScratchpadLoaded")
+                .field("conversation_id", conversation_id)
+                .field("notes", notes)
+                .finish(),
+            UiMessage::ScratchpadChanged { conversation_id } => f
+                .debug_struct("ScratchpadChanged")
+                .field("conversation_id", conversation_id)
+                .finish(),
         }
     }
 }
@@ -520,6 +548,9 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
         }
         SignalEvent::TaskLogAppended { id, entry } => UiMessage::TaskLogAppended { id, entry },
         SignalEvent::TaskCompleted { id, .. } => UiMessage::TaskCompleted { id },
+        SignalEvent::ScratchpadChanged { conversation_id } => {
+            UiMessage::ScratchpadChanged { conversation_id }
+        }
         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
     }
 }

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -258,3 +258,36 @@ entry:focus {
     background-color: #f0f2f7;
     color: #2a2e3a;
 }
+
+/* Conversation side pane (issue #60) */
+.side-pane-heading {
+    font-weight: bold;
+    font-size: 13px;
+}
+
+.side-pane-section {
+    font-weight: bold;
+    color: #5b6472;
+    font-size: 12px;
+}
+
+.side-pane-group {
+    font-weight: bold;
+    color: #7c8494;
+    font-size: 11px;
+}
+
+.side-pane-goal {
+    color: #2b303b;
+    font-style: italic;
+}
+
+.side-pane-note-key {
+    color: #7c8494;
+    font-size: 12px;
+}
+
+.side-pane-note-done {
+    color: #9aa3b2;
+    text-decoration: line-through;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -257,3 +257,36 @@ entry:focus {
     background-color: #181b29;
     color: #cfd6e4;
 }
+
+/* Conversation side pane (issue #60) */
+.side-pane-heading {
+    font-weight: bold;
+    font-size: 13px;
+}
+
+.side-pane-section {
+    font-weight: bold;
+    color: #9aa3b2;
+    font-size: 12px;
+}
+
+.side-pane-group {
+    font-weight: bold;
+    color: #7c8494;
+    font-size: 11px;
+}
+
+.side-pane-goal {
+    color: #cfd6e4;
+    font-style: italic;
+}
+
+.side-pane-note-key {
+    color: #7c8494;
+    font-size: 12px;
+}
+
+.side-pane-note-done {
+    color: #6b7a90;
+    text-decoration: line-through;
+}

--- a/src/widgets/conversation_side_pane.rs
+++ b/src/widgets/conversation_side_pane.rs
@@ -1,0 +1,512 @@
+//! Conversation-scoped side pane (issue #60).
+//!
+//! A collapsible panel, revealed to the right of the chat, bound to the
+//! currently-open conversation. It shows two sections:
+//!
+//! 1. **Tasks** — a filtered view of the global background-task list (only
+//!    tasks belonging to this conversation). The pane renders
+//!    [`TaskRowViewModel`]s the window projects out of the authoritative
+//!    `TasksModel`, so there is no duplicated task-lifecycle state here.
+//! 2. **Scratchpad** — the conversation's scratchpad notes, grouped by
+//!    `note_type` with `todo`s ordered by `sequence`. Interactive: a todo's
+//!    checkbox toggles `done`, a pencil edits the content, a trash deletes it.
+//!    Edits/toggles/deletes are surfaced as [`SidePaneAction`]s; the window
+//!    translates them into daemon commands and the resulting `ScratchpadChanged`
+//!    event refreshes the pane.
+//!
+//! As elsewhere in this app, the testable logic (note grouping/ordering) is a
+//! set of pure functions; the GTK widget is a thin renderer over them.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, Button, CheckButton, Entry, Label, ListBox, ListBoxRow, Orientation,
+    Popover, ScrolledWindow, SelectionMode, Separator,
+};
+
+use crate::widgets::tasks_panel::TaskRowViewModel;
+
+/// The reserved goal note key — surfaced with a distinct prefix so it reads as
+/// the objective rather than a plain note.
+const GOAL_KEY: &str = "goal";
+
+/// An interaction the user performed in the pane. The pane is client-agnostic;
+/// the window installs a handler (capturing the live client + current
+/// conversation) that turns each action into a daemon command.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SidePaneAction {
+    /// Upsert a note. Used both for check-off (`done` flipped) and content
+    /// edits; the unchanged fields are echoed back so the daemon upsert keeps
+    /// them.
+    SetNote {
+        key: String,
+        content: String,
+        note_type: String,
+        sequence: Option<i32>,
+        done: bool,
+    },
+    /// Delete a single note by key.
+    DeleteNote { key: String },
+}
+
+/// A group of scratchpad notes sharing a `note_type`, in display order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoteGroup {
+    pub note_type: String,
+    pub notes: Vec<api::ScratchpadNoteView>,
+}
+
+/// Group notes by `note_type` and order them for display, independently of the
+/// order the server returned them in (so the rendering is stable and testable):
+///
+/// - within a group, by `sequence` ascending with `None` last, then by `key`;
+/// - groups ordered `todo` first (the working plan), then the rest
+///   alphabetically.
+///
+/// The reserved `goal` note is pulled out of its group and is **not** returned
+/// here — the caller renders it separately above the groups.
+pub fn group_notes(notes: &[api::ScratchpadNoteView]) -> Vec<NoteGroup> {
+    use std::collections::BTreeMap;
+
+    let mut by_type: BTreeMap<String, Vec<api::ScratchpadNoteView>> = BTreeMap::new();
+    for note in notes {
+        if note.key == GOAL_KEY {
+            continue;
+        }
+        by_type
+            .entry(note.note_type.clone())
+            .or_default()
+            .push(note.clone());
+    }
+
+    let mut groups: Vec<NoteGroup> = by_type
+        .into_iter()
+        .map(|(note_type, mut notes)| {
+            notes.sort_by(|a, b| {
+                seq_key(a.sequence)
+                    .cmp(&seq_key(b.sequence))
+                    .then_with(|| a.key.cmp(&b.key))
+            });
+            NoteGroup { note_type, notes }
+        })
+        .collect();
+
+    // `todo` first, then the remaining types alphabetically (BTreeMap already
+    // yields them sorted, so a stable sort with a todo-first key suffices).
+    groups.sort_by_key(|g| (g.note_type != "todo", g.note_type.clone()));
+    groups
+}
+
+/// Find the reserved `goal` note, if present.
+pub fn goal_note(notes: &[api::ScratchpadNoteView]) -> Option<&api::ScratchpadNoteView> {
+    notes.iter().find(|n| n.key == GOAL_KEY)
+}
+
+/// Sort key making `None` sequences sort after any concrete value.
+fn seq_key(seq: Option<i32>) -> (bool, i32) {
+    match seq {
+        Some(v) => (false, v),
+        None => (true, 0),
+    }
+}
+
+type ActionCallback = Box<dyn Fn(SidePaneAction)>;
+type StringCallback = Box<dyn Fn(String)>;
+
+/// The conversation side-pane widget.
+pub struct ConversationSidePane {
+    pub container: GtkBox,
+    tasks_list: ListBox,
+    tasks_empty: Label,
+    goal_label: Label,
+    notes_list: ListBox,
+    notes_empty: Label,
+    /// Cache of the current notes so a per-row toggle/edit can reconstruct the
+    /// full `SetNote` (which must echo the unchanged fields).
+    notes: Rc<RefCell<Vec<api::ScratchpadNoteView>>>,
+    on_action: Rc<RefCell<Option<ActionCallback>>>,
+    on_cancel_task: Rc<RefCell<Option<StringCallback>>>,
+}
+
+impl ConversationSidePane {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 0);
+        container.set_size_request(300, -1);
+        container.add_css_class("side-pane");
+
+        let heading = Label::new(Some("This conversation"));
+        heading.add_css_class("side-pane-heading");
+        heading.set_halign(Align::Start);
+        heading.set_margin_start(12);
+        heading.set_margin_top(8);
+        heading.set_margin_bottom(4);
+        container.append(&heading);
+
+        // --- Tasks section ------------------------------------------------
+        let tasks_header = section_label("Tasks");
+        container.append(&tasks_header);
+
+        let tasks_scrolled = ScrolledWindow::new();
+        tasks_scrolled.set_vexpand(true);
+        tasks_scrolled.set_min_content_height(100);
+        let tasks_list = ListBox::new();
+        tasks_list.set_selection_mode(SelectionMode::None);
+        tasks_list.add_css_class("side-pane-tasks");
+        tasks_scrolled.set_child(Some(&tasks_list));
+        container.append(&tasks_scrolled);
+
+        let tasks_empty = Label::new(Some("No tasks for this conversation"));
+        tasks_empty.add_css_class("dim-label");
+        tasks_empty.set_halign(Align::Center);
+        tasks_empty.set_margin_top(4);
+        tasks_empty.set_margin_bottom(4);
+        container.append(&tasks_empty);
+
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        // --- Scratchpad section ------------------------------------------
+        let notes_header = section_label("Scratchpad");
+        container.append(&notes_header);
+
+        let goal_label = Label::new(None);
+        goal_label.add_css_class("side-pane-goal");
+        goal_label.set_halign(Align::Start);
+        goal_label.set_wrap(true);
+        goal_label.set_margin_start(12);
+        goal_label.set_margin_end(12);
+        goal_label.set_margin_bottom(4);
+        goal_label.set_visible(false);
+        container.append(&goal_label);
+
+        let notes_scrolled = ScrolledWindow::new();
+        notes_scrolled.set_vexpand(true);
+        notes_scrolled.set_min_content_height(140);
+        let notes_list = ListBox::new();
+        notes_list.set_selection_mode(SelectionMode::None);
+        notes_list.add_css_class("side-pane-notes");
+        notes_scrolled.set_child(Some(&notes_list));
+        container.append(&notes_scrolled);
+
+        let notes_empty = Label::new(Some("Scratchpad is empty"));
+        notes_empty.add_css_class("dim-label");
+        notes_empty.set_halign(Align::Center);
+        notes_empty.set_margin_top(4);
+        notes_empty.set_margin_bottom(8);
+        container.append(&notes_empty);
+
+        Self {
+            container,
+            tasks_list,
+            tasks_empty,
+            goal_label,
+            notes_list,
+            notes_empty,
+            notes: Rc::new(RefCell::new(Vec::new())),
+            on_action: Rc::new(RefCell::new(None)),
+            on_cancel_task: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    /// Install the handler that turns a [`SidePaneAction`] into a daemon
+    /// command. Called once by the window.
+    pub fn set_on_action<F: Fn(SidePaneAction) + 'static>(&self, f: F) {
+        *self.on_action.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Install the handler for the per-task Cancel button.
+    pub fn set_on_cancel_task<F: Fn(String) + 'static>(&self, f: F) {
+        *self.on_cancel_task.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Replace the tasks section with the given (already conversation-filtered)
+    /// rows.
+    pub fn set_tasks(&self, rows: &[TaskRowViewModel]) {
+        clear_list(&self.tasks_list);
+        self.tasks_empty.set_visible(rows.is_empty());
+        for vm in rows {
+            self.tasks_list.append(&self.build_task_row(vm));
+        }
+    }
+
+    /// Replace the scratchpad section with the given notes.
+    pub fn set_scratchpad(&self, notes: Vec<api::ScratchpadNoteView>) {
+        // Goal note surfaced separately above the groups.
+        match goal_note(&notes) {
+            Some(goal) => {
+                self.goal_label.set_text(&format!("Goal: {}", goal.content));
+                self.goal_label.set_visible(true);
+            }
+            None => {
+                self.goal_label.set_text("");
+                self.goal_label.set_visible(false);
+            }
+        }
+
+        clear_list(&self.notes_list);
+        let groups = group_notes(&notes);
+        let non_goal = notes.iter().filter(|n| n.key != GOAL_KEY).count();
+        self.notes_empty
+            .set_visible(non_goal == 0 && goal_note(&notes).is_none());
+
+        for group in &groups {
+            self.notes_list.append(&group_header_row(&group.note_type));
+            for note in &group.notes {
+                self.notes_list.append(&self.build_note_row(note));
+            }
+        }
+
+        *self.notes.borrow_mut() = notes;
+    }
+
+    fn build_task_row(&self, vm: &TaskRowViewModel) -> ListBoxRow {
+        let row = ListBoxRow::new();
+        row.set_selectable(false);
+        let hbox = GtkBox::new(Orientation::Horizontal, 8);
+        hbox.set_margin_start(12);
+        hbox.set_margin_end(8);
+        hbox.set_margin_top(4);
+        hbox.set_margin_bottom(4);
+
+        // Status dot — empty label coloured entirely by CSS (mirrors the
+        // tasks panel's dot).
+        let dot = Label::new(None);
+        dot.add_css_class("task-dot");
+        dot.add_css_class(&vm.status_class);
+        dot.set_width_chars(2);
+        hbox.append(&dot);
+
+        let text = Label::new(Some(&format!(
+            "{}  ·  {} · {}",
+            vm.title, vm.status_text, vm.age_text
+        )));
+        text.set_halign(Align::Start);
+        text.set_hexpand(true);
+        text.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        hbox.append(&text);
+
+        // Cancel is only meaningful for in-flight tasks.
+        if vm.status_text == "Running" || vm.status_text == "Pending" {
+            let cancel = Button::from_icon_name("process-stop-symbolic");
+            cancel.add_css_class("flat");
+            cancel.set_tooltip_text(Some("Cancel task"));
+            let id = vm.id.clone();
+            let on_cancel = Rc::clone(&self.on_cancel_task);
+            cancel.connect_clicked(move |_| {
+                if let Some(cb) = on_cancel.borrow().as_ref() {
+                    cb(id.clone());
+                }
+            });
+            hbox.append(&cancel);
+        }
+
+        row.set_child(Some(&hbox));
+        row
+    }
+
+    fn build_note_row(&self, note: &api::ScratchpadNoteView) -> ListBoxRow {
+        let row = ListBoxRow::new();
+        row.set_selectable(false);
+        let hbox = GtkBox::new(Orientation::Horizontal, 6);
+        hbox.set_margin_start(12);
+        hbox.set_margin_end(8);
+        hbox.set_margin_top(2);
+        hbox.set_margin_bottom(2);
+
+        // A todo gets a check-off box that toggles `done`.
+        if note.note_type == "todo" {
+            let check = CheckButton::new();
+            check.set_active(note.done);
+            let n = note.clone();
+            let on_action = Rc::clone(&self.on_action);
+            check.connect_toggled(move |c| {
+                if let Some(cb) = on_action.borrow().as_ref() {
+                    cb(SidePaneAction::SetNote {
+                        key: n.key.clone(),
+                        content: n.content.clone(),
+                        note_type: n.note_type.clone(),
+                        sequence: n.sequence,
+                        done: c.is_active(),
+                    });
+                }
+            });
+            hbox.append(&check);
+        }
+
+        let key_label = Label::new(Some(&note.key));
+        key_label.add_css_class("side-pane-note-key");
+        key_label.set_halign(Align::Start);
+        hbox.append(&key_label);
+
+        let content = Label::new(Some(&note.content));
+        content.set_halign(Align::Start);
+        content.set_hexpand(true);
+        content.set_wrap(true);
+        content.set_xalign(0.0);
+        if note.done {
+            content.add_css_class("side-pane-note-done");
+        }
+        hbox.append(&content);
+
+        // Edit (pencil) — opens a small popover entry, commits on activate.
+        let edit = Button::from_icon_name("document-edit-symbolic");
+        edit.add_css_class("flat");
+        edit.set_tooltip_text(Some("Edit note"));
+        self.wire_edit(&edit, note);
+        hbox.append(&edit);
+
+        // Delete (trash).
+        let delete = Button::from_icon_name("user-trash-symbolic");
+        delete.add_css_class("flat");
+        delete.set_tooltip_text(Some("Delete note"));
+        let key = note.key.clone();
+        let on_action = Rc::clone(&self.on_action);
+        delete.connect_clicked(move |_| {
+            if let Some(cb) = on_action.borrow().as_ref() {
+                cb(SidePaneAction::DeleteNote { key: key.clone() });
+            }
+        });
+        hbox.append(&delete);
+
+        row.set_child(Some(&hbox));
+        row
+    }
+
+    /// Wire the pencil button to a popover containing a prefilled entry; on
+    /// activate it emits a `SetNote` echoing the note's other fields with the
+    /// edited content.
+    fn wire_edit(&self, edit: &Button, note: &api::ScratchpadNoteView) {
+        let popover = Popover::new();
+        popover.set_parent(edit);
+        let pbox = GtkBox::new(Orientation::Horizontal, 6);
+        pbox.set_margin_start(6);
+        pbox.set_margin_end(6);
+        pbox.set_margin_top(6);
+        pbox.set_margin_bottom(6);
+        let entry = Entry::new();
+        entry.set_text(&note.content);
+        entry.set_width_chars(28);
+        pbox.append(&entry);
+        popover.set_child(Some(&pbox));
+
+        let n = note.clone();
+        let on_action = Rc::clone(&self.on_action);
+        let pop_for_commit = popover.clone();
+        entry.connect_activate(move |e| {
+            if let Some(cb) = on_action.borrow().as_ref() {
+                cb(SidePaneAction::SetNote {
+                    key: n.key.clone(),
+                    content: e.text().to_string(),
+                    note_type: n.note_type.clone(),
+                    sequence: n.sequence,
+                    done: n.done,
+                });
+            }
+            pop_for_commit.popdown();
+        });
+
+        edit.connect_clicked(move |_| {
+            entry.grab_focus();
+            popover.popup();
+        });
+    }
+}
+
+impl Default for ConversationSidePane {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn section_label(text: &str) -> Label {
+    let label = Label::new(Some(text));
+    label.add_css_class("side-pane-section");
+    label.set_halign(Align::Start);
+    label.set_margin_start(12);
+    label.set_margin_top(6);
+    label.set_margin_bottom(2);
+    label
+}
+
+fn group_header_row(note_type: &str) -> ListBoxRow {
+    let row = ListBoxRow::new();
+    row.set_selectable(false);
+    row.set_activatable(false);
+    let label = Label::new(Some(note_type));
+    label.add_css_class("side-pane-group");
+    label.set_halign(Align::Start);
+    label.set_margin_start(8);
+    label.set_margin_top(4);
+    row.set_child(Some(&label));
+    row
+}
+
+fn clear_list(list: &ListBox) {
+    while let Some(child) = list.first_child() {
+        list.remove(&child);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn note(
+        key: &str,
+        content: &str,
+        note_type: &str,
+        seq: Option<i32>,
+        done: bool,
+    ) -> api::ScratchpadNoteView {
+        api::ScratchpadNoteView {
+            id: format!("id-{key}"),
+            key: key.to_string(),
+            content: content.to_string(),
+            note_type: note_type.to_string(),
+            sequence: seq,
+            done,
+            updated_at: "t".to_string(),
+        }
+    }
+
+    #[test]
+    fn group_notes_orders_todos_by_sequence_then_groups_todo_first() {
+        let notes = vec![
+            note("b", "second", "todo", Some(2), false),
+            note("misc", "a plain note", "note", None, false),
+            note("a", "first", "todo", Some(1), false),
+            note("c", "third", "todo", None, false), // no sequence -> last
+        ];
+        let groups = group_notes(&notes);
+        assert_eq!(groups.len(), 2);
+        // todo group comes first.
+        assert_eq!(groups[0].note_type, "todo");
+        let keys: Vec<&str> = groups[0].notes.iter().map(|n| n.key.as_str()).collect();
+        assert_eq!(keys, vec!["a", "b", "c"], "seq asc, nulls last");
+        assert_eq!(groups[1].note_type, "note");
+    }
+
+    #[test]
+    fn goal_note_is_extracted_and_excluded_from_groups() {
+        let notes = vec![
+            note("goal", "ship the pane", "note", None, false),
+            note("n1", "a note", "note", None, false),
+        ];
+        assert_eq!(goal_note(&notes).unwrap().content, "ship the pane");
+        let groups = group_notes(&notes);
+        // The goal note must not appear in any group.
+        assert!(
+            groups
+                .iter()
+                .all(|g| g.notes.iter().all(|n| n.key != "goal")),
+            "goal is rendered separately, not in a group"
+        );
+    }
+
+    #[test]
+    fn group_notes_empty_is_empty() {
+        assert!(group_notes(&[]).is_empty());
+    }
+}

--- a/src/widgets/conversation_side_pane.rs
+++ b/src/widgets/conversation_side_pane.rs
@@ -24,7 +24,7 @@ use desktop_assistant_api_model as api;
 use gtk4::prelude::*;
 use gtk4::{
     Align, Box as GtkBox, Button, CheckButton, Entry, Label, ListBox, ListBoxRow, Orientation,
-    Popover, ScrolledWindow, SelectionMode, Separator,
+    PolicyType, Popover, ScrolledWindow, SelectionMode, Separator,
 };
 
 use crate::widgets::tasks_panel::TaskRowViewModel;
@@ -135,6 +135,9 @@ impl ConversationSidePane {
     pub fn new() -> Self {
         let container = GtkBox::new(Orientation::Vertical, 0);
         container.set_size_request(300, -1);
+        // The pane is a fixed-width column: it must not grow to fit its content
+        // (long notes/goals wrap instead — see the labels below).
+        container.set_hexpand(false);
         container.add_css_class("side-pane");
 
         let heading = Label::new(Some("This conversation"));
@@ -152,6 +155,9 @@ impl ConversationSidePane {
         let tasks_scrolled = ScrolledWindow::new();
         tasks_scrolled.set_vexpand(true);
         tasks_scrolled.set_min_content_height(100);
+        // Never scroll horizontally: wide rows wrap/ellipsize to the column
+        // width instead of stretching it or growing a horizontal scrollbar.
+        tasks_scrolled.set_policy(PolicyType::Never, PolicyType::Automatic);
         let tasks_list = ListBox::new();
         tasks_list.set_selection_mode(SelectionMode::None);
         tasks_list.add_css_class("side-pane-tasks");
@@ -174,7 +180,13 @@ impl ConversationSidePane {
         let goal_label = Label::new(None);
         goal_label.add_css_class("side-pane-goal");
         goal_label.set_halign(Align::Start);
+        goal_label.set_xalign(0.0);
         goal_label.set_wrap(true);
+        goal_label.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
+        // The goal sits directly in the column (not in a scrolled window), so
+        // cap its natural width or a long goal drags the whole column wide. It
+        // wraps within the column; the full text is also on the tooltip.
+        goal_label.set_max_width_chars(32);
         goal_label.set_margin_start(12);
         goal_label.set_margin_end(12);
         goal_label.set_margin_bottom(4);
@@ -184,6 +196,7 @@ impl ConversationSidePane {
         let notes_scrolled = ScrolledWindow::new();
         notes_scrolled.set_vexpand(true);
         notes_scrolled.set_min_content_height(140);
+        notes_scrolled.set_policy(PolicyType::Never, PolicyType::Automatic);
         let notes_list = ListBox::new();
         notes_list.set_selection_mode(SelectionMode::None);
         notes_list.add_css_class("side-pane-notes");
@@ -237,10 +250,12 @@ impl ConversationSidePane {
         match goal_note(&notes) {
             Some(goal) => {
                 self.goal_label.set_text(&format!("Goal: {}", goal.content));
+                self.goal_label.set_tooltip_text(Some(&goal.content));
                 self.goal_label.set_visible(true);
             }
             None => {
                 self.goal_label.set_text("");
+                self.goal_label.set_tooltip_text(None);
                 self.goal_label.set_visible(false);
             }
         }
@@ -285,6 +300,7 @@ impl ConversationSidePane {
         text.set_halign(Align::Start);
         text.set_hexpand(true);
         text.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        text.set_tooltip_text(Some(&vm.title));
         hbox.append(&text);
 
         // Cancel is only meaningful for in-flight tasks.
@@ -335,16 +351,23 @@ impl ConversationSidePane {
             hbox.append(&check);
         }
 
+        // Keys are short handles; ellipsize a stray long one so it can't widen
+        // the row.
         let key_label = Label::new(Some(&note.key));
         key_label.add_css_class("side-pane-note-key");
         key_label.set_halign(Align::Start);
+        key_label.set_ellipsize(gtk4::pango::EllipsizeMode::End);
+        key_label.set_max_width_chars(16);
         hbox.append(&key_label);
 
         let content = Label::new(Some(&note.content));
         content.set_halign(Align::Start);
         content.set_hexpand(true);
         content.set_wrap(true);
+        content.set_wrap_mode(gtk4::pango::WrapMode::WordChar);
         content.set_xalign(0.0);
+        // Full text on hover (the label itself wraps to the column width).
+        content.set_tooltip_text(Some(&note.content));
         if note.done {
             content.add_css_class("side-pane-note-done");
         }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,6 +1,7 @@
 pub mod chat_view;
 pub mod connection_config_dialog;
 pub mod connections_tab;
+pub mod conversation_side_pane;
 pub mod input_bar;
 pub mod knowledge_browser;
 pub mod login_screen;

--- a/src/widgets/tasks_panel.rs
+++ b/src/widgets/tasks_panel.rs
@@ -530,6 +530,26 @@ impl TasksPanel {
     pub fn model(&self) -> std::cell::Ref<'_, TasksModel> {
         self.model.borrow()
     }
+
+    /// Project the current tasks into row view-models, filtered to
+    /// `conversation_id` (or all tasks when `None`). The conversation side pane
+    /// (issue #60) uses this to render only the active conversation's tasks
+    /// without duplicating the authoritative `TasksModel`.
+    pub fn task_view_models_for(
+        &self,
+        conversation_id: Option<&str>,
+        now_ms: i64,
+    ) -> Vec<TaskRowViewModel> {
+        self.model
+            .borrow()
+            .iter()
+            .map(|task| view_model_for(task, now_ms))
+            .filter(|vm| match conversation_id {
+                Some(cid) => vm.conversation_id.as_deref() == Some(cid),
+                None => true,
+            })
+            .collect()
+    }
 }
 
 fn build_row(vm: &TaskRowViewModel, progress_hint: Option<&str>) -> ListBoxRow {

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc;
 use crate::async_bridge::{AsyncBridge, UiMessage, connection_manager};
 use crate::management_client;
 use crate::widgets::chat_view::ChatView;
+use crate::widgets::conversation_side_pane::{ConversationSidePane, SidePaneAction};
 use crate::widgets::input_bar::InputBar;
 use crate::widgets::model_picker::ModelPicker;
 use crate::widgets::sidebar::Sidebar;
@@ -101,6 +102,17 @@ enum Effect {
     },
     /// A task completed (terminal).
     TaskCompleted { id: String },
+
+    // --- Conversation side pane (issue #60) -------------------------------
+    /// Fetch the scratchpad for the given conversation (async RPC + ui_tx),
+    /// mirroring `EnsureActiveConversation`. The reply arrives as
+    /// `UiMessage::ConversationScratchpadLoaded`.
+    FetchScratchpad(String),
+    /// Replace the side pane's scratchpad notes (empty clears it).
+    SidePaneSetScratchpad(Vec<api::ScratchpadNoteView>),
+    /// Recompute the side pane's task list from the authoritative `TasksModel`,
+    /// filtered to the active conversation.
+    RefreshSidePaneTasks,
 }
 
 // Manual `Debug` (can't derive: `TransportClient` is not `Debug`, mirroring
@@ -146,6 +158,11 @@ impl std::fmt::Debug for Effect {
             Effect::TaskCompleted { id } => {
                 f.debug_struct("TaskCompleted").field("id", id).finish()
             }
+            Effect::FetchScratchpad(c) => f.debug_tuple("FetchScratchpad").field(c).finish(),
+            Effect::SidePaneSetScratchpad(n) => {
+                f.debug_tuple("SidePaneSetScratchpad").field(n).finish()
+            }
+            Effect::RefreshSidePaneTasks => f.write_str("RefreshSidePaneTasks"),
         }
     }
 }
@@ -179,10 +196,16 @@ impl WindowState {
                 let filtered = filter_messages(&detail, self.debug_enabled);
                 let selection = detail.model_selection.clone();
                 self.current_conversation = Some(detail);
-                self.current_conversation_id = Some(id);
+                self.current_conversation_id = Some(id.clone());
                 vec![
                     Effect::SetModelSelection(selection),
                     Effect::LoadConversationIntoChat(filtered),
+                    // Rebind the side pane to the new conversation: clear stale
+                    // notes until the fetch returns, refresh the filtered task
+                    // list, and fetch this conversation's scratchpad.
+                    Effect::SidePaneSetScratchpad(Vec::new()),
+                    Effect::RefreshSidePaneTasks,
+                    Effect::FetchScratchpad(id),
                 ]
             }
             UiMessage::ConversationCreated { id } => {
@@ -200,6 +223,8 @@ impl WindowState {
                 let mut effects = vec![Effect::SetConversations(convs)];
                 if is_active {
                     effects.push(Effect::ClearChat);
+                    effects.push(Effect::SidePaneSetScratchpad(Vec::new()));
+                    effects.push(Effect::RefreshSidePaneTasks);
                     effects.push(Effect::EnsureActiveConversation);
                 }
                 effects
@@ -269,10 +294,18 @@ impl WindowState {
                             content: full_response.clone(),
                         });
                     }
-                    vec![
+                    let mut effects = vec![
                         Effect::ClearChatStatus,
                         Effect::CompleteStreaming(full_response),
-                    ]
+                    ];
+                    // The turn may have changed the scratchpad (Adele's todos);
+                    // refresh the pane. (The live `ScratchpadChanged` event also
+                    // covers this, but a turn-boundary refetch is a cheap
+                    // backstop if the event was missed.)
+                    if let Some(id) = self.current_conversation_id.clone() {
+                        effects.push(Effect::FetchScratchpad(id));
+                    }
+                    effects
                 } else {
                     vec![]
                 }
@@ -365,15 +398,45 @@ impl WindowState {
             UiMessage::Connected { label } => {
                 vec![Effect::SetStatusText(label), Effect::SetSendSensitive(true)]
             }
-            UiMessage::TasksLoaded(tasks) => vec![Effect::TasksReplaceAll(tasks)],
-            UiMessage::TaskStarted(task) => vec![Effect::TaskStarted(task)],
+            UiMessage::TasksLoaded(tasks) => {
+                vec![Effect::TasksReplaceAll(tasks), Effect::RefreshSidePaneTasks]
+            }
+            UiMessage::TaskStarted(task) => {
+                vec![Effect::TaskStarted(task), Effect::RefreshSidePaneTasks]
+            }
             UiMessage::TaskProgress { id, progress_hint } => {
-                vec![Effect::TaskProgress { id, progress_hint }]
+                vec![
+                    Effect::TaskProgress { id, progress_hint },
+                    Effect::RefreshSidePaneTasks,
+                ]
             }
             UiMessage::TaskLogAppended { id, entry } => {
+                // Log lines don't change the row set, so the side pane (which
+                // shows no logs) needs no refresh here.
                 vec![Effect::TaskLogAppended { id, entry }]
             }
-            UiMessage::TaskCompleted { id } => vec![Effect::TaskCompleted { id }],
+            UiMessage::TaskCompleted { id } => {
+                vec![Effect::TaskCompleted { id }, Effect::RefreshSidePaneTasks]
+            }
+            UiMessage::ConversationScratchpadLoaded {
+                conversation_id,
+                notes,
+            } => {
+                // Apply only if it's still the active conversation (a fetch may
+                // race a conversation switch).
+                if self.current_conversation_id.as_deref() == Some(conversation_id.as_str()) {
+                    vec![Effect::SidePaneSetScratchpad(notes)]
+                } else {
+                    vec![]
+                }
+            }
+            UiMessage::ScratchpadChanged { conversation_id } => {
+                if self.current_conversation_id.as_deref() == Some(conversation_id.as_str()) {
+                    vec![Effect::FetchScratchpad(conversation_id)]
+                } else {
+                    vec![]
+                }
+            }
             UiMessage::Disconnected { reason } => {
                 let mut effects = vec![
                     Effect::ClearClient,
@@ -476,6 +539,13 @@ impl AdelieWindow {
         spacer.set_hexpand(true);
         header_bar.append(&spacer);
 
+        // Toggle for the conversation side pane (issue #60). Wired to the
+        // revealer once it's constructed below.
+        let side_pane_toggle = Button::from_icon_name("sidebar-show-right-symbolic");
+        side_pane_toggle.add_css_class("flat");
+        side_pane_toggle.set_tooltip_text(Some("Toggle conversation panel"));
+        header_bar.append(&side_pane_toggle);
+
         // Hamburger menu button
         let menu_button = MenuButton::new();
         menu_button.set_icon_name("open-menu-symbolic");
@@ -514,8 +584,18 @@ impl AdelieWindow {
         let header_sep = Separator::new(Orientation::Horizontal);
         right_box.append(&header_sep);
 
+        // The chat column and the conversation side pane sit side by side below
+        // the (full-width) header, so the pane stays visible while chatting.
+        let body = GtkBox::new(Orientation::Horizontal, 0);
+        body.set_hexpand(true);
+        body.set_vexpand(true);
+
+        let chat_column = GtkBox::new(Orientation::Vertical, 0);
+        chat_column.set_hexpand(true);
+        chat_column.set_vexpand(true);
+
         let chat_view = ChatView::new();
-        right_box.append(&chat_view.container);
+        chat_column.append(&chat_view.container);
 
         // Passive toast for advisory warnings (e.g. a dangling model
         // selection cleared by the daemon). The revealer is always in the
@@ -544,14 +624,14 @@ impl AdelieWindow {
         ));
         toast_row.append(&toast_dismiss);
         toast_revealer.set_child(Some(&toast_row));
-        right_box.append(&toast_revealer);
+        chat_column.append(&toast_revealer);
 
         let input_sep = Separator::new(Orientation::Horizontal);
-        right_box.append(&input_sep);
+        chat_column.append(&input_sep);
 
         let input_bar = InputBar::new();
         input_bar.send_button.set_sensitive(false); // disabled until connected
-        right_box.append(&input_bar.container);
+        chat_column.append(&input_bar.container);
 
         let status_bar = GtkBox::new(Orientation::Horizontal, 0);
         status_bar.set_margin_top(4);
@@ -570,7 +650,29 @@ impl AdelieWindow {
         debug_check.add_css_class("debug-check");
         status_bar.append(&debug_check);
 
-        right_box.append(&status_bar);
+        chat_column.append(&status_bar);
+
+        // Conversation side pane (issue #60): tasks + scratchpad for the active
+        // conversation, revealed from the right via the header toggle. The
+        // divider lives inside the revealer so it only shows when revealed.
+        let side_pane = ConversationSidePane::new();
+        let side_revealer = Revealer::new();
+        side_revealer.set_transition_type(RevealerTransitionType::SlideLeft);
+        side_revealer.set_reveal_child(false);
+        let side_box = GtkBox::new(Orientation::Horizontal, 0);
+        side_box.append(&Separator::new(Orientation::Vertical));
+        side_box.append(&side_pane.container);
+        side_revealer.set_child(Some(&side_box));
+
+        body.append(&chat_column);
+        body.append(&side_revealer);
+        right_box.append(&body);
+
+        side_pane_toggle.connect_clicked(glib::clone!(
+            #[weak]
+            side_revealer,
+            move |_| side_revealer.set_reveal_child(!side_revealer.reveals_child())
+        ));
 
         paned.set_end_child(Some(&right_box));
         paned.set_resize_end_child(true);
@@ -594,6 +696,7 @@ impl AdelieWindow {
         let status_label = Rc::new(status_label);
         let model_picker = Rc::new(model_picker);
         let tasks_panel = Rc::new(tasks_panel);
+        let side_pane = Rc::new(side_pane);
         let stack = Rc::new(stack);
         let toast_revealer = Rc::new(toast_revealer);
         let toast_label = Rc::new(toast_label);
@@ -620,6 +723,8 @@ impl AdelieWindow {
             #[strong]
             tasks_panel,
             #[strong]
+            side_pane,
+            #[strong]
             toast_revealer,
             #[strong]
             toast_label,
@@ -634,6 +739,7 @@ impl AdelieWindow {
                     &input_bar,
                     &model_picker,
                     &tasks_panel,
+                    &side_pane,
                     &toast_revealer,
                     &toast_label,
                     ui_tx,
@@ -641,6 +747,63 @@ impl AdelieWindow {
             }
         ));
         let bridge = Rc::new(bridge);
+
+        // Wire the side pane's interactions to daemon commands. Edits/toggles/
+        // deletes issue scratchpad commands; the daemon's `ScratchpadChanged`
+        // event then refreshes the pane (issue #60).
+        side_pane.set_on_action(glib::clone!(
+            #[strong]
+            state,
+            #[strong]
+            client,
+            move |action: SidePaneAction| {
+                let Some(conv) = state.borrow().current_conversation_id.clone() else {
+                    return;
+                };
+                let Some(transport) = client.borrow().clone() else {
+                    return;
+                };
+                crate::async_bridge::spawn_on_runtime(async move {
+                    let Some(cmds) = transport.as_commands() else {
+                        return;
+                    };
+                    let result = match action {
+                        SidePaneAction::SetNote {
+                            key,
+                            content,
+                            note_type,
+                            sequence,
+                            done,
+                        } => cmds
+                            .set_scratchpad_note(&conv, &key, &content, &note_type, sequence, done)
+                            .await
+                            .map(|_| ()),
+                        SidePaneAction::DeleteNote { key } => {
+                            cmds.delete_scratchpad_notes(&conv, vec![key], false).await
+                        }
+                    };
+                    if let Err(e) = result {
+                        tracing::warn!("scratchpad action failed: {e}");
+                    }
+                });
+            }
+        ));
+        side_pane.set_on_cancel_task(glib::clone!(
+            #[strong]
+            client,
+            move |id: String| {
+                let Some(transport) = client.borrow().clone() else {
+                    return;
+                };
+                crate::async_bridge::spawn_on_runtime(async move {
+                    if let Some(cmds) = transport.as_commands() {
+                        let _ = cmds
+                            .send_command(api::Command::CancelBackgroundTask { id })
+                            .await;
+                    }
+                });
+            }
+        ));
 
         // Spawn persistent connection manager (connect → forward → reconnect).
         // It now delivers the freshly connected transport to the main thread
@@ -1277,6 +1440,7 @@ fn handle_ui_message(
     input_bar: &Rc<InputBar>,
     model_picker: &Rc<ModelPicker>,
     tasks_panel: &Rc<TasksPanel>,
+    side_pane: &Rc<ConversationSidePane>,
     toast_revealer: &Rc<Revealer>,
     toast_label: &Rc<Label>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
@@ -1353,6 +1517,38 @@ fn handle_ui_message(
             }
             Effect::TaskCompleted { id } => {
                 tasks_panel.handle_task_completed(id, now_epoch_ms());
+            }
+            Effect::FetchScratchpad(conversation_id) => {
+                if let Some(transport) = client.borrow().clone() {
+                    let tx = ui_tx.clone();
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        let Some(cmds) = transport.as_commands() else {
+                            return;
+                        };
+                        match cmds
+                            .get_conversation_scratchpad(&conversation_id, None)
+                            .await
+                        {
+                            Ok(notes) => {
+                                let _ = tx.send(UiMessage::ConversationScratchpadLoaded {
+                                    conversation_id,
+                                    notes,
+                                });
+                            }
+                            Err(e) => {
+                                tracing::warn!("get_conversation_scratchpad failed: {e}");
+                            }
+                        }
+                    });
+                }
+            }
+            Effect::SidePaneSetScratchpad(notes) => {
+                side_pane.set_scratchpad(notes);
+            }
+            Effect::RefreshSidePaneTasks => {
+                let conv = state.borrow().current_conversation_id.clone();
+                let rows = tasks_panel.task_view_models_for(conv.as_deref(), now_epoch_ms());
+                side_pane.set_tasks(&rows);
             }
         }
     }
@@ -1646,7 +1842,14 @@ mod tests {
         assert_eq!(conv.messages.last().unwrap().role, "assistant");
         assert_eq!(conv.messages.last().unwrap().content, "the answer");
         assert!(
-            matches!(effects.as_slice(), [Effect::ClearChatStatus, Effect::CompleteStreaming(c)] if c == "the answer"),
+            matches!(
+                effects.as_slice(),
+                [
+                    Effect::ClearChatStatus,
+                    Effect::CompleteStreaming(c),
+                    Effect::FetchScratchpad(conv),
+                ] if c == "the answer" && conv == "c1"
+            ),
             "unexpected effects: {effects:?}"
         );
     }
@@ -1776,11 +1979,77 @@ mod tests {
                 [
                     Effect::SetConversations(_),
                     Effect::ClearChat,
+                    Effect::SidePaneSetScratchpad(_),
+                    Effect::RefreshSidePaneTasks,
                     Effect::EnsureActiveConversation
                 ]
             ),
-            "deleting the active conversation must clear chat + re-ensure: {effects:?}"
+            "deleting the active conversation must clear chat + side pane + re-ensure: {effects:?}"
         );
+    }
+
+    fn note_view(key: &str) -> api::ScratchpadNoteView {
+        api::ScratchpadNoteView {
+            id: format!("id-{key}"),
+            key: key.to_string(),
+            content: "x".to_string(),
+            note_type: "note".to_string(),
+            sequence: None,
+            done: false,
+            updated_at: "t".to_string(),
+        }
+    }
+
+    #[test]
+    fn scratchpad_loaded_applies_only_for_active_conversation() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        // Matching conversation → set the pane.
+        let effects = state.apply(UiMessage::ConversationScratchpadLoaded {
+            conversation_id: "c1".to_string(),
+            notes: vec![note_view("goal")],
+        });
+        assert!(
+            matches!(effects.as_slice(), [Effect::SidePaneSetScratchpad(n)] if n.len() == 1),
+            "unexpected: {effects:?}"
+        );
+        // A fetch that resolves after a conversation switch is ignored.
+        let effects = state.apply(UiMessage::ConversationScratchpadLoaded {
+            conversation_id: "stale".to_string(),
+            notes: vec![note_view("goal")],
+        });
+        assert!(effects.is_empty(), "stale scratchpad must be dropped");
+    }
+
+    #[test]
+    fn scratchpad_changed_refetches_only_for_active_conversation() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::ScratchpadChanged {
+            conversation_id: "c1".to_string(),
+        });
+        assert!(matches!(effects.as_slice(), [Effect::FetchScratchpad(c)] if c == "c1"));
+        let effects = state.apply(UiMessage::ScratchpadChanged {
+            conversation_id: "other".to_string(),
+        });
+        assert!(
+            effects.is_empty(),
+            "a change to another conversation is ignored"
+        );
+    }
+
+    #[test]
+    fn tasks_loaded_also_refreshes_the_side_pane() {
+        let mut state = WindowState::default();
+        let effects = state.apply(UiMessage::TasksLoaded(vec![]));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::TasksReplaceAll(_), Effect::RefreshSidePaneTasks]
+        ));
     }
 
     #[test]
@@ -1861,6 +2130,9 @@ mod tests {
             [
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
+                Effect::SidePaneSetScratchpad(_),
+                Effect::RefreshSidePaneTasks,
+                Effect::FetchScratchpad(_),
             ] => {
                 let roles: Vec<&str> = filtered.messages.iter().map(|m| m.role.as_str()).collect();
                 assert_eq!(roles, vec!["user", "assistant"]);
@@ -1889,6 +2161,9 @@ mod tests {
             [
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
+                Effect::SidePaneSetScratchpad(_),
+                Effect::RefreshSidePaneTasks,
+                Effect::FetchScratchpad(_),
             ] => {
                 // Debug on: nothing is filtered out.
                 assert_eq!(filtered.messages.len(), 3);
@@ -1908,9 +2183,13 @@ mod tests {
             [
                 Effect::SetModelSelection(Some(sel)),
                 Effect::LoadConversationIntoChat(_),
+                Effect::SidePaneSetScratchpad(_),
+                Effect::RefreshSidePaneTasks,
+                Effect::FetchScratchpad(conv),
             ] => {
                 assert_eq!(sel.connection_id, "work");
                 assert_eq!(sel.model_id, "claude");
+                assert_eq!(conv, "c9");
             }
             other => panic!("unexpected effects: {other:?}"),
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -541,9 +541,22 @@ impl AdelieWindow {
 
         // Toggle for the conversation side pane (issue #60). Wired to the
         // revealer once it's constructed below.
-        let side_pane_toggle = Button::from_icon_name("sidebar-show-right-symbolic");
+        //
+        // Themed-icon fallback chain so the toggle renders across icon themes:
+        // Breeze (KDE) lacks the GNOME `sidebar-show-*-symbolic` names (it shows
+        // a broken glyph), so prefer Breeze's `tools-symbolic` (a wrench), then
+        // fall back to `applications-utilities-symbolic` /
+        // `applications-engineering-symbolic`, which exist in both Breeze and
+        // Adwaita.
+        let toggle_icon = gtk4::gio::ThemedIcon::from_names(&[
+            "tools-symbolic",
+            "applications-utilities-symbolic",
+            "applications-engineering-symbolic",
+        ]);
+        let side_pane_toggle = Button::new();
+        side_pane_toggle.set_child(Some(&gtk4::Image::from_gicon(&toggle_icon)));
         side_pane_toggle.add_css_class("flat");
-        side_pane_toggle.set_tooltip_text(Some("Toggle conversation panel"));
+        side_pane_toggle.set_tooltip_text(Some("Tasks & scratchpad for this conversation"));
         header_bar.append(&side_pane_toggle);
 
         // Hamburger menu button


### PR DESCRIPTION
## What & why

A collapsible side pane, revealed to the right of the chat via a header toggle, bound to the active conversation. Final PR of three (data model `desktop-assistant#189`, client commands `desktop-assistant#190`, this UI).

It shows:
1. **Tasks** — only *this conversation's* background tasks (a filtered projection of the global task manager), each with a Cancel button.
2. **Scratchpad** — the conversation's notes grouped by type, **todos checkboxed and ordered by `sequence`**, the reserved `goal` surfaced on top, `done` shown struck-through. **Interactive**: toggle a todo's checkbox (sets `done`), edit content (pencil → popover entry), delete (trash).

## How it fits the existing architecture

- Follows the pure `WindowState::apply -> Vec<Effect>` + thin-executor pattern. New `UiMessage`s (`ConversationScratchpadLoaded`, `ScratchpadChanged`), a `SignalEvent::ScratchpadChanged` mapping, and new `Effect`s (`FetchScratchpad`, `SidePaneSetScratchpad`, `RefreshSidePaneTasks`).
- **No duplicated task state**: the tasks section is a filtered view of the authoritative `TasksModel` via a new `TasksPanel::task_view_models_for(conversation)`.
- The pane is **client-agnostic**: interactions surface as `SidePaneAction`s; the window translates them into `set_scratchpad_note` / `delete_scratchpad_notes`, and the daemon's `ScratchpadChanged` round-trips back to refresh. Re-fetch happens on conversation load, turn complete, and live change events; a fetch that races a conversation switch is dropped.
- Layout: the chat moves into a `chat_column`; a right-side `Revealer` holds the pane, toggled from a new header button. The existing left-side global Tasks view is untouched.

## Tests

- Pure note grouping/ordering + `goal` extraction (`group_notes` / `goal_note`).
- New `apply` arms: active-conversation guards for `ConversationScratchpadLoaded` / `ScratchpadChanged`, and task events refreshing the pane.
- Updated the existing effect-vector assertions for the augmented `ConversationLoaded` / `StreamComplete` / `ConversationDeleted` arms.
- `just check` (fmt-check + lint + build + test) green — **143 tests**.

## Note for review

This is GTK UI; the logic is unit-tested but the **visual layout/interaction wants a manual QA pass** (reveal/hide, todo check-off round-trip, edit popover, dark + light themes) — not auto-merging for that reason.

Closes #60