### PR TITLE
Voice controls: mic button + 'Enable Hey Adele' toggle + voice picker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod oauth;
 mod profile;
 mod selected_models;
 mod theme;
+mod voice_client;
 #[cfg(feature = "linux")]
 mod webview;
 mod widgets;

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -78,6 +78,13 @@ window {
     background-color: #e6eaf3;
 }
 
+/* Push-to-talk button (issue #59): flat at rest, accent-tinted while the
+   voice pipeline is active. Mirrors the dark rule with the light accent. */
+.mic-button.mic-active {
+    background-color: #178a6e;
+    color: #ffffff;
+}
+
 .status-bar {
     color: #5b6473;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -55,6 +55,20 @@ window {
     padding-right: 16px;
 }
 
+/* Push-to-talk button in the chat input bar (issue #59). Flat at rest;
+   tinted with the accent while the voice pipeline is active
+   (listening/processing/speaking) so an in-progress turn reads at a glance. */
+.mic-button {
+    border-radius: 6px;
+    min-height: 36px;
+    min-width: 36px;
+}
+
+.mic-button.mic-active {
+    background-color: #84dac1;
+    color: #1b1e2e;
+}
+
 .status-bar {
     color: #8f99ae;
     font-size: 12px;

--- a/src/voice_client.rs
+++ b/src/voice_client.rs
@@ -1,0 +1,344 @@
+//! Client for the standalone voice daemon (`org.desktopAssistant.Voice`).
+//!
+//! The voice daemon (`adelie-ai/voice`) is a **separate** D-Bus service from
+//! the orchestrator the rest of this app talks to: it owns the bus name
+//! `org.desktopAssistant.Voice` (distinct from `org.desktopAssistant`) and
+//! speaks its own typed interface. Voice is just another client of it, so this
+//! module talks to it directly over zbus rather than through the
+//! `TransportClient` command channel.
+//!
+//! The wiring mirrors `theme.rs`: the zbus [`Connection`] and the
+//! `StateChanged` signal stream live on the shared Tokio runtime (where zbus
+//! has a reactor), and only plain values cross back to the GTK main thread via
+//! a `tokio::sync::mpsc` channel consumed by `glib::spawn_future_local`. The
+//! controls then mutate non-`Send` GTK widgets on the main thread.
+//!
+//! ## Graceful degradation
+//!
+//! When the daemon isn't running, the bus name has no owner. Each RPC then
+//! fails (zbus returns `ServiceUnknown`/`NameHasNoOwner`); callers treat that
+//! as "voice unavailable" and disable the controls rather than surfacing an
+//! error. [`VoiceController::connect`] probes ownership once up front so the UI
+//! can start out disabled, and the live `StateChanged` listener keeps it in
+//! sync if the daemon comes and goes (via `NameOwnerChanged`).
+
+use std::pin::pin;
+
+use tokio::sync::mpsc;
+use zbus::export::futures_core::Stream;
+
+use crate::async_bridge::spawn_on_runtime;
+
+/// The voice pipeline state, mirrored from the daemon's `StateChanged` signal
+/// and `GetState` reply.
+///
+/// The daemon sends the state as a string (`"Idle"`, `"Listening"`,
+/// `"Processing"`, `"Speaking"`); [`VoiceState::from_dbus`] parses it. An
+/// unrecognised value maps to [`VoiceState::Idle`] (the safe resting state)
+/// rather than failing the whole listener.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VoiceState {
+    /// Resting; always-on wake-word detection only (or fully disabled).
+    #[default]
+    Idle,
+    /// Actively recording the user's speech.
+    Listening,
+    /// Transcribing / awaiting the assistant's response.
+    Processing,
+    /// Playing back the assistant's spoken response.
+    Speaking,
+}
+
+impl VoiceState {
+    /// Parse the daemon's state string. Unknown values fall back to `Idle`.
+    pub fn from_dbus(s: &str) -> Self {
+        match s {
+            "Listening" => Self::Listening,
+            "Processing" => Self::Processing,
+            "Speaking" => Self::Speaking,
+            // "Idle" and anything unrecognised resolve to the resting state.
+            _ => Self::Idle,
+        }
+    }
+
+    /// Short human-readable label for the status line / tooltip.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "Idle",
+            Self::Listening => "Listening…",
+            Self::Processing => "Processing…",
+            Self::Speaking => "Speaking…",
+        }
+    }
+}
+
+/// A TTS voice enumerated by the daemon's `ListVoices`.
+///
+/// Mirrors the D-Bus `(sssu)` tuple: id, display name, language, speaker count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceInfo {
+    pub id: String,
+    pub display_name: String,
+    pub language: String,
+    /// Number of distinct speakers the voice model offers (1 for a
+    /// single-speaker voice; `>1` for a multi-speaker model).
+    pub num_speakers: u32,
+}
+
+/// The currently active voice as reported by `GetVoice`: voice id plus a
+/// speaker index (`-1` when unset / single-speaker).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentVoice {
+    pub id: String,
+    pub speaker: i32,
+}
+
+/// Typed zbus proxy for the voice daemon.
+///
+/// zbus derives each D-Bus method name by PascalCasing the Rust fn name, which
+/// matches the daemon's own interface (`get_state` → `GetState`,
+/// `push_to_talk` → `PushToTalk`, …), so no per-method `#[zbus(name = …)]`
+/// overrides are needed. Only the methods the GTK UI drives are declared.
+#[zbus::proxy(
+    interface = "org.desktopAssistant.Voice",
+    default_service = "org.desktopAssistant.Voice",
+    default_path = "/org/desktopAssistant/Voice"
+)]
+pub trait Voice {
+    /// Current pipeline state ("Idle" | "Listening" | "Processing" | "Speaking").
+    fn get_state(&self) -> zbus::Result<String>;
+
+    /// Enable/disable always-on "Hey Adele" wake-word detection.
+    fn set_enabled(&self, enabled: bool) -> zbus::Result<()>;
+
+    /// Whether always-on wake-word detection is enabled.
+    fn get_enabled(&self) -> zbus::Result<bool>;
+
+    /// Start listening immediately (push-to-talk; works even with wake off).
+    fn push_to_talk(&self) -> zbus::Result<()>;
+
+    /// List installed voices as (id, display name, language, num_speakers).
+    fn list_voices(&self) -> zbus::Result<Vec<(String, String, String, u32)>>;
+
+    /// Current voice as (id, speaker_id); speaker_id is -1 if unset.
+    fn get_voice(&self) -> zbus::Result<(String, i32)>;
+
+    /// Set the active voice (speaker -1 = default/single-speaker).
+    fn set_voice(&self, voice_id: &str, speaker: i32) -> zbus::Result<()>;
+
+    /// Emitted when the pipeline state changes.
+    #[zbus(signal)]
+    fn state_changed(&self, state: &str) -> zbus::Result<()>;
+}
+
+/// Handle to the voice daemon, usable from the GTK main thread.
+///
+/// Cheap to clone (just an `Arc`-backed zbus proxy). Each method spawns its
+/// own work on the Tokio runtime; results are delivered back to the caller's
+/// supplied channel so the GTK widgets are only ever touched on the main
+/// thread. A `None` proxy (connect failed entirely — e.g. no session bus) makes
+/// every call a graceful no-op / "unavailable".
+#[derive(Clone)]
+pub struct VoiceController {
+    /// `None` when even establishing the session-bus connection failed; the
+    /// controller is then inert and reports the service as unavailable.
+    proxy: Option<VoiceProxy<'static>>,
+}
+
+impl VoiceController {
+    /// Connect to the session bus and build the voice proxy. Returns a
+    /// controller whose proxy is `None` only when the bus connection itself
+    /// fails (rare — no session bus at all); a missing *daemon* still yields a
+    /// live proxy, with availability probed separately via
+    /// [`VoiceController::is_available`].
+    pub async fn connect() -> Self {
+        let proxy = match zbus::Connection::session().await {
+            Ok(conn) => match VoiceProxy::new(&conn).await {
+                Ok(proxy) => Some(proxy),
+                Err(error) => {
+                    tracing::warn!(%error, "failed to build voice proxy; voice controls disabled");
+                    None
+                }
+            },
+            Err(error) => {
+                tracing::warn!(%error, "no session bus for voice; voice controls disabled");
+                None
+            }
+        };
+        Self { proxy }
+    }
+
+    /// An inert controller with no proxy. Every call is a graceful no-op and
+    /// [`VoiceController::is_available`] reports `false`. Used as a stand-in
+    /// when a consumer needs a controller before the real one has connected.
+    pub fn unavailable() -> Self {
+        Self { proxy: None }
+    }
+
+    /// Whether the voice daemon currently owns its bus name.
+    ///
+    /// Used at startup to decide the controls' initial sensitivity. A `false`
+    /// here is normal (daemon not running / models unprovisioned) and must not
+    /// be treated as an error.
+    pub async fn is_available(&self) -> bool {
+        let Some(proxy) = &self.proxy else {
+            return false;
+        };
+        // A cheap round-trip that only succeeds when the name has an owner.
+        proxy.get_state().await.is_ok()
+    }
+
+    /// Fire a push-to-talk request. Errors (including "daemon absent") are
+    /// logged, not surfaced — the caller has already gated on availability.
+    pub async fn push_to_talk(&self) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.push_to_talk().await.map_err(|e| e.to_string())
+    }
+
+    /// Read the wake-word enabled flag. `None` when the service is unavailable.
+    pub async fn get_enabled(&self) -> Option<bool> {
+        let proxy = self.proxy.as_ref()?;
+        match proxy.get_enabled().await {
+            Ok(enabled) => Some(enabled),
+            Err(error) => {
+                tracing::debug!(%error, "voice get_enabled failed (service likely absent)");
+                None
+            }
+        }
+    }
+
+    /// Set the wake-word enabled flag.
+    pub async fn set_enabled(&self, enabled: bool) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.set_enabled(enabled).await.map_err(|e| e.to_string())
+    }
+
+    /// List installed voices. `None` when the service is unavailable.
+    pub async fn list_voices(&self) -> Option<Vec<VoiceInfo>> {
+        let proxy = self.proxy.as_ref()?;
+        match proxy.list_voices().await {
+            Ok(raw) => Some(
+                raw.into_iter()
+                    .map(|(id, display_name, language, num_speakers)| VoiceInfo {
+                        id,
+                        display_name,
+                        language,
+                        num_speakers,
+                    })
+                    .collect(),
+            ),
+            Err(error) => {
+                tracing::debug!(%error, "voice list_voices failed (service likely absent)");
+                None
+            }
+        }
+    }
+
+    /// Read the active voice. `None` when the service is unavailable.
+    pub async fn get_voice(&self) -> Option<CurrentVoice> {
+        let proxy = self.proxy.as_ref()?;
+        match proxy.get_voice().await {
+            Ok((id, speaker)) => Some(CurrentVoice { id, speaker }),
+            Err(error) => {
+                tracing::debug!(%error, "voice get_voice failed (service likely absent)");
+                None
+            }
+        }
+    }
+
+    /// Set the active voice (speaker `-1` = default/single-speaker).
+    pub async fn set_voice(&self, voice_id: String, speaker: i32) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy
+            .set_voice(&voice_id, speaker)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Subscribe to pipeline-state changes, forwarding each into `tx` as a
+    /// [`VoiceState`] on the GTK main thread.
+    ///
+    /// Spawns a Tokio task that pushes the current state once (so the UI starts
+    /// correct) and then every `StateChanged` signal. The task ends when `tx`
+    /// is dropped (window gone) or the proxy is absent. Cheap to call once at
+    /// window construction.
+    pub fn spawn_state_listener(&self, tx: mpsc::UnboundedSender<VoiceState>) {
+        let Some(proxy) = self.proxy.clone() else {
+            return;
+        };
+        spawn_on_runtime(async move {
+            run_state_listener(proxy, tx).await;
+        });
+    }
+}
+
+/// Push the initial state, then forward every `StateChanged` until `tx`
+/// closes. Errors (daemon absent / bus drop) end the loop quietly: the controls
+/// stay at their last state and the availability probe handles the rest.
+async fn run_state_listener(proxy: VoiceProxy<'static>, tx: mpsc::UnboundedSender<VoiceState>) {
+    // Seed with the current state if the daemon is up; ignore failure (absent).
+    if let Ok(state) = proxy.get_state().await
+        && tx.send(VoiceState::from_dbus(&state)).is_err()
+    {
+        return;
+    }
+
+    let changes = match proxy.receive_state_changed().await {
+        Ok(changes) => changes,
+        Err(error) => {
+            tracing::debug!(%error, "voice state_changed subscribe failed (service likely absent)");
+            return;
+        }
+    };
+    let mut changes = pin!(changes);
+    while let Some(change) =
+        std::future::poll_fn(|cx| Stream::poll_next(changes.as_mut(), cx)).await
+    {
+        let Ok(args) = change.args() else { continue };
+        if tx.send(VoiceState::from_dbus(args.state)).is_err() {
+            // Receiver gone (window closed) — stop listening.
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_states() {
+        assert_eq!(VoiceState::from_dbus("Idle"), VoiceState::Idle);
+        assert_eq!(VoiceState::from_dbus("Listening"), VoiceState::Listening);
+        assert_eq!(VoiceState::from_dbus("Processing"), VoiceState::Processing);
+        assert_eq!(VoiceState::from_dbus("Speaking"), VoiceState::Speaking);
+    }
+
+    #[test]
+    fn unknown_state_falls_back_to_idle() {
+        // A future/garbled state must not break the listener — rest at Idle.
+        assert_eq!(VoiceState::from_dbus("Dreaming"), VoiceState::Idle);
+        assert_eq!(VoiceState::from_dbus(""), VoiceState::Idle);
+    }
+
+    #[test]
+    fn default_state_is_idle() {
+        assert_eq!(VoiceState::default(), VoiceState::Idle);
+    }
+
+    #[test]
+    fn every_state_has_a_label() {
+        // Labels are user-facing; make sure none is empty and Listening/
+        // Processing/Speaking read as in-progress.
+        assert_eq!(VoiceState::Idle.label(), "Idle");
+        assert!(VoiceState::Listening.label().ends_with('…'));
+        assert!(VoiceState::Processing.label().ends_with('…'));
+        assert!(VoiceState::Speaking.label().ends_with('…'));
+    }
+}

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -1,12 +1,38 @@
 use gtk4::prelude::*;
-use gtk4::{Box as GtkBox, Button, Orientation, ScrolledWindow, TextView, WrapMode};
+use gtk4::{Box as GtkBox, Button, Image, Orientation, ScrolledWindow, TextView, WrapMode};
 
-/// Input bar widget with a text view and send button.
+use crate::voice_client::VoiceState;
+
+/// Input bar widget with a record/mic button, a text view, and a send button.
 pub struct InputBar {
     pub container: GtkBox,
     pub text_view: TextView,
     pub send_button: Button,
+    /// Push-to-talk button: starts a dictation turn on the voice daemon
+    /// (`PushToTalk`). Hidden until the voice service is found on the bus
+    /// (graceful degradation — see [`InputBar::set_voice_available`]).
+    pub mic_button: Button,
+    /// The mic icon, swapped between resting and active glyphs as the pipeline
+    /// state changes.
+    mic_image: Image,
 }
+
+/// Themed-icon fallback chain for the resting (idle) mic glyph. Breeze (KDE),
+/// Adwaita and most icon themes ship at least one of these; listing several
+/// avoids a broken glyph on a theme that lacks the first.
+const MIC_IDLE_ICONS: &[&str] = &[
+    "audio-input-microphone-symbolic",
+    "microphone-sensitivity-high-symbolic",
+    "audio-input-microphone",
+];
+
+/// Icon shown while the pipeline is actively listening/processing/speaking —
+/// a "recording" dot so the active turn reads at a glance.
+const MIC_ACTIVE_ICONS: &[&str] = &[
+    "media-record-symbolic",
+    "audio-input-microphone-high-symbolic",
+    "media-record",
+];
 
 impl InputBar {
     pub fn new() -> Self {
@@ -15,6 +41,18 @@ impl InputBar {
         container.set_margin_end(8);
         container.set_margin_top(4);
         container.set_margin_bottom(8);
+
+        // Push-to-talk button, left of the text entry. Starts hidden; the
+        // window reveals it once the voice daemon is found on the bus.
+        let mic_image = Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_IDLE_ICONS));
+        let mic_button = Button::new();
+        mic_button.set_child(Some(&mic_image));
+        mic_button.add_css_class("mic-button");
+        mic_button.set_valign(gtk4::Align::End);
+        mic_button.set_margin_bottom(4);
+        mic_button.set_tooltip_text(Some("Hold a conversation — click to start talking"));
+        mic_button.set_visible(false);
+        container.append(&mic_button);
 
         let scrolled = ScrolledWindow::new();
         scrolled.set_hexpand(true);
@@ -41,7 +79,37 @@ impl InputBar {
             container,
             text_view,
             send_button,
+            mic_button,
+            mic_image,
         }
+    }
+
+    /// Show or hide the mic button based on whether the voice daemon is
+    /// reachable. Hidden when absent so the user isn't offered a dead control
+    /// (graceful degradation per issue #59).
+    pub fn set_voice_available(&self, available: bool) {
+        self.mic_button.set_visible(available);
+    }
+
+    /// Reflect the voice pipeline state on the mic button: a CSS class drives
+    /// the accent while active, the icon swaps to a record glyph, and the
+    /// tooltip explains the current phase.
+    pub fn reflect_voice_state(&self, state: VoiceState) {
+        let active = !matches!(state, VoiceState::Idle);
+        if active {
+            self.mic_button.add_css_class("mic-active");
+            self.mic_image
+                .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_ACTIVE_ICONS));
+        } else {
+            self.mic_button.remove_css_class("mic-active");
+            self.mic_image
+                .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_IDLE_ICONS));
+        }
+        let tooltip = match state {
+            VoiceState::Idle => "Hold a conversation — click to start talking".to_string(),
+            other => format!("Voice: {}", other.label()),
+        };
+        self.mic_button.set_tooltip_text(Some(&tooltip));
     }
 
     /// Get the current text content and clear the input.

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -12,3 +12,4 @@ pub mod settings_dialog;
 pub mod setup_dialog;
 pub mod sidebar;
 pub mod tasks_panel;
+pub mod voice_tab;

--- a/src/widgets/settings_dialog.rs
+++ b/src/widgets/settings_dialog.rs
@@ -27,10 +27,12 @@ use tokio::sync::mpsc;
 
 use crate::async_bridge::{AsyncBridge, UiMessage};
 use crate::management_client;
+use crate::voice_client::VoiceController;
 
 use super::connection_config_dialog::{ConnectorType, show_configure_dialog};
 use super::connections_tab::ConnectionsTab;
 use super::purposes_tab::PurposesTab;
+use super::voice_tab::VoiceTab;
 
 /// Minimal yes/no confirmation dialog. We avoid GTK4's `AlertDialog`
 /// (gated behind the `v4_10` feature) to keep the feature floor low.
@@ -100,10 +102,16 @@ fn confirm<F>(
 /// Present the Settings dialog modally against `parent`, using `transport`
 /// for all RPC traffic. `bridge` provides the tokio runtime + the shared
 /// ui-message channel so errors propagate back to the window status bar.
+///
+/// `voice` is the handle to the standalone voice daemon (a *separate* D-Bus
+/// service from `transport`'s orchestrator); it backs the Voice tab's wake-word
+/// toggle and voice picker. The tab degrades gracefully when the daemon is
+/// absent.
 pub fn show_settings_dialog(
     parent: &impl IsA<Window>,
     transport: Arc<TransportClient>,
     bridge: Rc<AsyncBridge>,
+    voice: VoiceController,
 ) {
     let dialog = Window::builder()
         .title("Settings")
@@ -121,12 +129,14 @@ pub fn show_settings_dialog(
 
     let connections_tab = Rc::new(ConnectionsTab::new());
     let purposes_tab = Rc::new(PurposesTab::new());
+    let voice_tab = Rc::new(VoiceTab::new());
 
     notebook.append_page(
         &connections_tab.container,
         Some(&Label::new(Some("Connections"))),
     );
     notebook.append_page(&purposes_tab.container, Some(&Label::new(Some("Purposes"))));
+    notebook.append_page(&voice_tab.container, Some(&Label::new(Some("Voice"))));
 
     vbox.append(&notebook);
 
@@ -494,10 +504,106 @@ pub fn show_settings_dialog(
         }
     ));
 
+    // ---------------------------------------------------------------
+    // Voice tab wiring (separate D-Bus service — see `voice_client`).
+    // ---------------------------------------------------------------
+    wire_voice_tab(&voice_tab, &voice, &bridge);
+
     // First refresh.
     refresh();
 
     dialog.present();
+}
+
+/// Snapshot of the voice daemon's state used to hydrate the Voice tab in one
+/// hop back to the GTK main thread. `available == false` means the daemon has
+/// no owner on the bus; the tab then shows its "unavailable" message.
+struct VoiceSnapshot {
+    available: bool,
+    enabled: bool,
+    voices: Vec<crate::voice_client::VoiceInfo>,
+    current_voice: Option<String>,
+}
+
+/// Wire the Voice tab's toggle/dropdown to the [`VoiceController`] and hydrate
+/// it from the daemon's current state.
+///
+/// Writes (`SetEnabled` / `SetVoice`) are dispatched on the Tokio runtime;
+/// failures go to the window status bar via the bridge's ui-sender. Hydration
+/// fetches availability + enabled + voices in one task and applies the result
+/// on the GTK main thread. Graceful: when the daemon is absent the tab is
+/// disabled with an explanatory message instead of erroring.
+fn wire_voice_tab(voice_tab: &Rc<VoiceTab>, voice: &VoiceController, bridge: &Rc<AsyncBridge>) {
+    // Toggle "Hey Adele" → SetEnabled.
+    voice_tab.connect_set_enabled(glib::clone!(
+        #[strong]
+        voice,
+        #[strong]
+        bridge,
+        move |enabled| {
+            let voice = voice.clone();
+            let ui_tx = bridge.ui_sender();
+            crate::async_bridge::spawn_on_runtime(async move {
+                if let Err(e) = voice.set_enabled(enabled).await {
+                    let _ = ui_tx.send(UiMessage::Error(format!("Set wake word: {e}")));
+                }
+            });
+        }
+    ));
+
+    // Pick a voice → SetVoice (default speaker -1).
+    voice_tab.connect_set_voice(glib::clone!(
+        #[strong]
+        voice,
+        #[strong]
+        bridge,
+        move |voice_id| {
+            let voice = voice.clone();
+            let ui_tx = bridge.ui_sender();
+            crate::async_bridge::spawn_on_runtime(async move {
+                if let Err(e) = voice.set_voice(voice_id, -1).await {
+                    let _ = ui_tx.send(UiMessage::Error(format!("Set voice: {e}")));
+                }
+            });
+        }
+    ));
+
+    // Hydrate from the daemon. One task fetches the snapshot; the result is
+    // applied on the GTK main thread via a short-lived channel.
+    let (tx, mut rx) = mpsc::unbounded_channel::<VoiceSnapshot>();
+    let voice_for_fetch = voice.clone();
+    bridge.spawn(async move {
+        let available = voice_for_fetch.is_available().await;
+        let snapshot = if available {
+            VoiceSnapshot {
+                available: true,
+                enabled: voice_for_fetch.get_enabled().await.unwrap_or(false),
+                voices: voice_for_fetch.list_voices().await.unwrap_or_default(),
+                current_voice: voice_for_fetch.get_voice().await.map(|v| v.id),
+            }
+        } else {
+            VoiceSnapshot {
+                available: false,
+                enabled: false,
+                voices: Vec::new(),
+                current_voice: None,
+            }
+        };
+        let _ = tx.send(snapshot);
+    });
+
+    let voice_tab = Rc::clone(voice_tab);
+    glib::spawn_future_local(async move {
+        if let Some(snapshot) = rx.recv().await {
+            if !snapshot.available {
+                voice_tab.set_unavailable();
+                return;
+            }
+            voice_tab.set_available();
+            voice_tab.set_enabled_state(snapshot.enabled);
+            voice_tab.set_voices(&snapshot.voices, snapshot.current_voice.as_deref());
+        }
+    });
 }
 
 /// Issue a `DeleteConnection` call. On refusal (purposes still reference

--- a/src/widgets/voice_tab.rs
+++ b/src/widgets/voice_tab.rs
@@ -1,0 +1,308 @@
+//! Voice tab of the Settings dialog.
+//!
+//! Two controls backed by the standalone voice daemon
+//! (`org.desktopAssistant.Voice`, see `crate::voice_client`):
+//!
+//! - an **Enable "Hey Adele"** toggle → `SetEnabled` / `GetEnabled` (the
+//!   always-on wake word). There is no tray in adele-gtk, so this lives here
+//!   rather than a tray menu (issue #59).
+//! - a **TTS voice** dropdown → `ListVoices` / `SetVoice`.
+//!
+//! The tab owns the widgets and emits callbacks; the parent (Settings dialog)
+//! wires those to the `VoiceController` and re-hydrates the tab from daemon
+//! state. When the daemon is absent the parent calls
+//! [`VoiceTab::set_unavailable`], which disables the controls and shows a hint
+//! rather than presenting dead toggles (graceful degradation).
+//!
+//! Re-hydration uses a `suppress` flag (mirroring `purposes_tab.rs`) so that
+//! programmatically applying daemon state doesn't echo back as a write.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use gtk4::prelude::*;
+use gtk4::{
+    Align, Box as GtkBox, CheckButton, DropDown, Label, Orientation, Separator, StringList, glib,
+};
+
+use crate::voice_client::VoiceInfo;
+
+type SetEnabledCb = Box<dyn Fn(bool)>;
+type SetVoiceCb = Box<dyn Fn(String)>;
+
+pub struct VoiceTab {
+    pub container: GtkBox,
+    enable_check: CheckButton,
+    voice_dd: DropDown,
+    voice_list: StringList,
+    /// Voice ids in the same index order as `voice_dd`'s string list, so a
+    /// dropdown index maps back to the id to send in `SetVoice`.
+    voice_ids: Rc<RefCell<Vec<String>>>,
+    /// Shown when the daemon is unreachable; replaces the live hint.
+    status: Label,
+    on_set_enabled: Rc<RefCell<Option<SetEnabledCb>>>,
+    on_set_voice: Rc<RefCell<Option<SetVoiceCb>>>,
+    /// While true, we're reconciling the UI to daemon state — suppress the
+    /// `toggled` / `selected` write callbacks so re-hydration isn't echoed back.
+    suppress: Rc<RefCell<bool>>,
+}
+
+impl VoiceTab {
+    pub fn new() -> Self {
+        let container = GtkBox::new(Orientation::Vertical, 8);
+        container.set_margin_start(12);
+        container.set_margin_end(12);
+        container.set_margin_top(12);
+        container.set_margin_bottom(12);
+
+        let header = Label::new(Some("Voice"));
+        header.add_css_class("heading");
+        header.set_halign(Align::Start);
+        container.append(&header);
+
+        let blurb = Label::new(Some(
+            "Talk to Adele hands-free. The voice daemon runs on-device; speech \
+             never leaves this machine.",
+        ));
+        blurb.set_wrap(true);
+        blurb.set_halign(Align::Start);
+        blurb.add_css_class("dim-label");
+        container.append(&blurb);
+
+        container.append(&Separator::new(Orientation::Horizontal));
+
+        // --- Wake word toggle ---------------------------------------------
+        let enable_check = CheckButton::with_label("Enable \u{201c}Hey Adele\u{201d}");
+        enable_check.set_halign(Align::Start);
+        enable_check.set_tooltip_text(Some(
+            "Listen continuously for the \u{201c}Hey Adele\u{201d} wake word. \
+             With this off, use the record button in the chat bar to talk.",
+        ));
+        enable_check.set_margin_top(6);
+        container.append(&enable_check);
+
+        // --- Voice selection ----------------------------------------------
+        let voice_row = GtkBox::new(Orientation::Horizontal, 8);
+        voice_row.set_margin_top(6);
+        let voice_label = Label::new(Some("Spoken voice"));
+        voice_label.set_halign(Align::Start);
+        voice_label.set_width_chars(14);
+        voice_row.append(&voice_label);
+
+        let voice_list = StringList::new(&[]);
+        let voice_dd = DropDown::new(Some(voice_list.clone()), gtk4::Expression::NONE);
+        voice_dd.set_hexpand(true);
+        voice_row.append(&voice_dd);
+        container.append(&voice_row);
+
+        // Live hint / unavailable message, sharing the dim style with the blurb.
+        let status = Label::new(None);
+        status.set_halign(Align::Start);
+        status.set_wrap(true);
+        status.add_css_class("dim-label");
+        status.set_margin_top(6);
+        container.append(&status);
+
+        let voice_ids: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let on_set_enabled: Rc<RefCell<Option<SetEnabledCb>>> = Rc::new(RefCell::new(None));
+        let on_set_voice: Rc<RefCell<Option<SetVoiceCb>>> = Rc::new(RefCell::new(None));
+        let suppress = Rc::new(RefCell::new(false));
+
+        enable_check.connect_toggled(glib::clone!(
+            #[strong]
+            on_set_enabled,
+            #[strong]
+            suppress,
+            move |btn| {
+                if *suppress.borrow() {
+                    return;
+                }
+                if let Some(cb) = on_set_enabled.borrow().as_ref() {
+                    cb(btn.is_active());
+                }
+            }
+        ));
+
+        voice_dd.connect_selected_notify(glib::clone!(
+            #[strong]
+            on_set_voice,
+            #[strong]
+            voice_ids,
+            #[strong]
+            suppress,
+            move |dd| {
+                if *suppress.borrow() {
+                    return;
+                }
+                let idx = dd.selected() as usize;
+                if let Some(id) = voice_ids.borrow().get(idx).cloned()
+                    && let Some(cb) = on_set_voice.borrow().as_ref()
+                {
+                    cb(id);
+                }
+            }
+        ));
+
+        Self {
+            container,
+            enable_check,
+            voice_dd,
+            voice_list,
+            voice_ids,
+            status,
+            on_set_enabled,
+            on_set_voice,
+            suppress,
+        }
+    }
+
+    /// Register the callback fired when the user toggles the wake word.
+    pub fn connect_set_enabled<F: Fn(bool) + 'static>(&self, f: F) {
+        *self.on_set_enabled.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Register the callback fired when the user picks a different voice. The
+    /// argument is the chosen voice id.
+    pub fn connect_set_voice<F: Fn(String) + 'static>(&self, f: F) {
+        *self.on_set_voice.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Apply the daemon's current wake-word enabled flag without echoing a
+    /// write back.
+    pub fn set_enabled_state(&self, enabled: bool) {
+        let _guard = SuppressGuard::new(&self.suppress);
+        self.enable_check.set_active(enabled);
+    }
+
+    /// Populate the voice dropdown from `ListVoices` and select `current` (the
+    /// active voice id from `GetVoice`, if any). Setting the model + selection
+    /// is suppressed so it doesn't fire a spurious `SetVoice`.
+    ///
+    /// `SetVoice` is always issued with the default speaker (`-1`); a
+    /// per-speaker sub-picker is out of scope for the single voice dropdown the
+    /// issue calls for, and `-1` selects each model's default speaker.
+    pub fn set_voices(&self, voices: &[VoiceInfo], current: Option<&str>) {
+        let _guard = SuppressGuard::new(&self.suppress);
+
+        // Reset the GTK string list in place.
+        while self.voice_list.n_items() > 0 {
+            self.voice_list.remove(0);
+        }
+        let mut ids = Vec::with_capacity(voices.len());
+        for v in voices {
+            self.voice_list.append(&display_label(v));
+            ids.push(v.id.clone());
+        }
+
+        let selected = current
+            .and_then(|cur| ids.iter().position(|id| id == cur))
+            .unwrap_or(0);
+        *self.voice_ids.borrow_mut() = ids;
+
+        let has_voices = self.voice_list.n_items() > 0;
+        self.voice_dd.set_sensitive(has_voices);
+        if has_voices {
+            self.voice_dd.set_selected(selected as u32);
+        }
+
+        self.status.set_text(if has_voices {
+            ""
+        } else {
+            "No voices installed. Run the voice daemon's setup to provision a voice model."
+        });
+    }
+
+    /// Disable the controls and explain why — used when the voice daemon has
+    /// no owner on the bus (not running / models unprovisioned).
+    pub fn set_unavailable(&self) {
+        let _guard = SuppressGuard::new(&self.suppress);
+        self.enable_check.set_active(false);
+        self.enable_check.set_sensitive(false);
+        self.voice_dd.set_sensitive(false);
+        self.status.set_text(
+            "Voice service not available. Start the voice daemon \
+             (org.desktopAssistant.Voice) to enable these controls.",
+        );
+    }
+
+    /// Re-enable the controls after a transition back to available (e.g. the
+    /// dialog is re-presented while the daemon is now up). Selection state is
+    /// applied separately via [`VoiceTab::set_enabled_state`] /
+    /// [`VoiceTab::set_voices`].
+    pub fn set_available(&self) {
+        self.enable_check.set_sensitive(true);
+        self.voice_dd.set_sensitive(true);
+        self.status.set_text("");
+    }
+}
+
+/// RAII guard that sets the `suppress` flag for the duration of a
+/// state-reconciliation, so programmatic widget updates don't fire the user
+/// `toggled` / `selected` callbacks. Mirrors the suppression pattern in
+/// `purposes_tab.rs` but bundled into a guard so early returns can't leak it.
+struct SuppressGuard<'a> {
+    flag: &'a Rc<RefCell<bool>>,
+}
+
+impl<'a> SuppressGuard<'a> {
+    fn new(flag: &'a Rc<RefCell<bool>>) -> Self {
+        *flag.borrow_mut() = true;
+        Self { flag }
+    }
+}
+
+impl Drop for SuppressGuard<'_> {
+    fn drop(&mut self) {
+        *self.flag.borrow_mut() = false;
+    }
+}
+
+/// Render a voice's dropdown label. Prefers the display name, appends the
+/// language when present, and falls back to the raw id if the name is empty.
+fn display_label(v: &VoiceInfo) -> String {
+    let name = if v.display_name.trim().is_empty() {
+        v.id.as_str()
+    } else {
+        v.display_name.as_str()
+    };
+    if v.language.trim().is_empty() {
+        name.to_string()
+    } else {
+        format!("{name} ({})", v.language)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn voice(id: &str, name: &str, lang: &str, speakers: u32) -> VoiceInfo {
+        VoiceInfo {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            language: lang.to_string(),
+            num_speakers: speakers,
+        }
+    }
+
+    #[test]
+    fn label_combines_name_and_language() {
+        assert_eq!(
+            display_label(&voice("en_US-amy", "Amy", "en_US", 1)),
+            "Amy (en_US)"
+        );
+    }
+
+    #[test]
+    fn label_falls_back_to_id_when_name_empty() {
+        assert_eq!(
+            display_label(&voice("en_US-amy", "", "en_US", 1)),
+            "en_US-amy (en_US)"
+        );
+    }
+
+    #[test]
+    fn label_omits_empty_language() {
+        assert_eq!(display_label(&voice("custom", "Custom", "", 2)), "Custom");
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc;
 
 use crate::async_bridge::{AsyncBridge, UiMessage, connection_manager};
 use crate::management_client;
+use crate::voice_client::{VoiceController, VoiceState};
 use crate::widgets::chat_view::ChatView;
 use crate::widgets::conversation_side_pane::{ConversationSidePane, SidePaneAction};
 use crate::widgets::input_bar::InputBar;
@@ -761,6 +762,15 @@ impl AdelieWindow {
         ));
         let bridge = Rc::new(bridge);
 
+        // Voice controls (issue #59). The voice daemon is a *separate* D-Bus
+        // service (`org.desktopAssistant.Voice`); it has no relationship to the
+        // orchestrator transport above. We connect once, share the handle so
+        // both the mic button and the Settings → Voice tab can drive it, and
+        // gate the UI on the daemon actually owning its bus name (graceful
+        // degradation when it isn't running / models aren't provisioned).
+        let voice: Rc<RefCell<Option<VoiceController>>> = Rc::new(RefCell::new(None));
+        wire_voice_controls(&voice, &input_bar, &bridge);
+
         // Wire the side pane's interactions to daemon commands. Edits/toggles/
         // deletes issue scratchpad commands; the daemon's `ScratchpadChanged`
         // event then refreshes the pane (issue #60).
@@ -1236,6 +1246,8 @@ impl AdelieWindow {
             bridge,
             #[strong]
             status_label,
+            #[strong]
+            voice,
             move |_| {
                 menu_popover.popdown();
                 let Some(transport) = client.borrow().clone() else {
@@ -1248,10 +1260,20 @@ impl AdelieWindow {
                     );
                     return;
                 }
+                // The Voice tab talks to its own daemon, so hand the dialog a
+                // controller regardless of which orchestrator transport we're
+                // on. When voice hasn't connected yet (or has no session bus),
+                // fall back to an inert controller — the tab then shows its
+                // "unavailable" state.
+                let voice_handle = match voice.borrow().clone() {
+                    Some(v) => v,
+                    None => VoiceController::unavailable(),
+                };
                 crate::widgets::settings_dialog::show_settings_dialog(
                     &window,
                     Arc::clone(&transport),
                     Rc::clone(&bridge),
+                    voice_handle,
                 );
                 // The user may have added/removed connections; re-query the
                 // aggregated model list so the header picker reflects the new
@@ -1430,6 +1452,88 @@ impl AdelieWindow {
     pub fn present(&self) {
         self.window.present();
     }
+}
+
+/// Connect to the voice daemon and wire the input bar's mic button + state
+/// reflection (issue #59).
+///
+/// Connecting is async (session bus + proxy build), so it runs on the Tokio
+/// runtime; the resulting [`VoiceController`] is delivered back to the GTK main
+/// thread, stored in `voice` (shared with the Settings → Voice tab), and used
+/// to:
+/// - show the mic button only when the daemon owns its bus name
+///   (graceful degradation when it's absent), and
+/// - keep the button's state in sync with the daemon's `StateChanged` signal.
+///
+/// The mic button fires `PushToTalk`, which starts a dictation turn even when
+/// the always-on wake word is off.
+fn wire_voice_controls(
+    voice: &Rc<RefCell<Option<VoiceController>>>,
+    input_bar: &Rc<InputBar>,
+    bridge: &Rc<AsyncBridge>,
+) {
+    // Mic button → PushToTalk. The controller may not be connected yet; a
+    // click before then is a harmless no-op (the button is hidden until the
+    // daemon is confirmed present anyway).
+    input_bar.mic_button.connect_clicked(glib::clone!(
+        #[strong]
+        voice,
+        #[strong]
+        bridge,
+        move |_| {
+            let Some(controller) = voice.borrow().clone() else {
+                return;
+            };
+            let ui_tx = bridge.ui_sender();
+            crate::async_bridge::spawn_on_runtime(async move {
+                if let Err(e) = controller.push_to_talk().await {
+                    let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                }
+            });
+        }
+    ));
+
+    // Connect + probe + subscribe. The controller and the initial availability
+    // are delivered to the main thread; the state listener then streams
+    // `VoiceState` updates over its own channel.
+    let (ready_tx, mut ready_rx) = mpsc::unbounded_channel::<(VoiceController, bool)>();
+    let (state_tx, mut state_rx) = mpsc::unbounded_channel::<VoiceState>();
+    crate::async_bridge::spawn_on_runtime(async move {
+        let controller = VoiceController::connect().await;
+        let available = controller.is_available().await;
+        // Subscribe to state changes regardless of the initial probe: the
+        // daemon may be activated on demand after we connect.
+        controller.spawn_state_listener(state_tx);
+        let _ = ready_tx.send((controller, available));
+    });
+
+    // Apply the connected controller + initial availability on the main thread.
+    glib::spawn_future_local(glib::clone!(
+        #[strong]
+        voice,
+        #[strong]
+        input_bar,
+        async move {
+            if let Some((controller, available)) = ready_rx.recv().await {
+                *voice.borrow_mut() = Some(controller);
+                input_bar.set_voice_available(available);
+            }
+        }
+    ));
+
+    // Reflect every pipeline-state change on the mic button. A non-Idle state
+    // also implies the daemon is present, so reveal the button if a state
+    // arrives before (or instead of) the initial availability probe.
+    glib::spawn_future_local(glib::clone!(
+        #[strong]
+        input_bar,
+        async move {
+            while let Some(state) = state_rx.recv().await {
+                input_bar.set_voice_available(true);
+                input_bar.reflect_voice_state(state);
+            }
+        }
+    ));
 }
 
 /// Current wall-clock time in epoch milliseconds. Centralized so the


### PR DESCRIPTION
Closes #59

Wires adele-gtk to the standalone voice daemon (`org.desktopAssistant.Voice`). The voice daemon is a **separate** D-Bus service from the orchestrator the rest of the app talks to, so voice is just another client: a new `src/voice_client.rs` adds a typed `#[zbus::proxy]` plus a cheap, cloneable `VoiceController` handle, following the existing `theme.rs` pattern (proxy + signal stream owned on the Tokio runtime; only plain values cross back to the GTK main thread).

## What's implemented (all four parts of #59)

- **(a) Record/mic button** in `src/widgets/input_bar.rs` → `PushToTalk`. Starts a dictation turn even when the wake word is off. Sits left of the text entry; its icon + accent track the pipeline state.
- **(b) "Enable 'Hey Adele'" toggle** in Settings → new **Voice** tab (`src/widgets/voice_tab.rs`) → `SetEnabled` / `GetEnabled`. There's no tray in adele-gtk, so the toggle lives in settings.
- **(c) TTS voice dropdown** in the Voice tab → `ListVoices` / `SetVoice` (sends the default speaker `-1`; a per-speaker sub-picker is out of scope for the single dropdown the issue calls for).
- **(d) `StateChanged` reflected live** — Idle/Listening/Processing/Speaking drives the mic button's glyph, accent, and tooltip.

## Graceful degradation

When the voice daemon has no owner on the bus (not running / models unprovisioned), the mic button stays hidden and the Voice tab disables its controls with an explanatory message — no crash, no error toast. Availability is probed via a cheap `GetState` round-trip; the `StateChanged` listener is subscribed regardless so on-demand activation is picked up.

## Contract fidelity

zbus PascalCases the proxy method names to match the daemon's interface (`get_state`→`GetState`, `push_to_talk`→`PushToTalk`, `list_voices`→`ListVoices`, …). Tuple signatures match the D-Bus contract: voices `a(sssu)` → `(id, name, language, num_speakers)`; current voice `(si)` → `(id, speaker)`; `SetVoice(s, i)`. Source of truth confirmed against `adelie-ai/voice` `crates/dbus-interface/src/lib.rs` on its `origin/main`.

## Tests / gate

`just check` is green (fmt-check + clippy `-D warnings` + build + test; 150 passed, 1 pre-existing ignored keyring integration test). Added unit tests for pure logic: voice-state string parsing (incl. unknown-value fallback) and voice-label rendering. The `--no-default-features` (Label-fallback) build also still compiles.

## Not verified

Couldn't exercise the live GTK app end-to-end — the voice daemon isn't running locally (models unprovisioned), so the implementation relies on the D-Bus contract + the `voice` repo source rather than a live round-trip. The unavailable-daemon path (graceful degradation) is the code path that *did* run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)