### PR TITLE
feat(voice): dictate into the active conversation + barge-in mic button

### DIFF
--- a/src/voice_client.rs
+++ b/src/voice_client.rs
@@ -93,6 +93,35 @@ pub struct CurrentVoice {
     pub speaker: i32,
 }
 
+/// Where a mic-button push-to-talk turn should be routed.
+///
+/// This is the pure decision behind the mic button: when the user has a
+/// conversation open, the spoken prompt and reply must land in *that*
+/// conversation (`PushToTalkInConversation(<id>)`); with nothing open we fall
+/// back to the daemon's own session (`PushToTalk()`). Kept as a standalone
+/// value so the routing can be unit-tested without a live bus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PttRoute {
+    /// Dictate into this orchestrator conversation id.
+    InConversation(String),
+    /// No conversation open — use the daemon's own session.
+    DaemonSession,
+}
+
+impl PttRoute {
+    /// Decide the route from the active conversation id (the window's
+    /// `current_conversation_id`). A `Some` with a **non-empty** id routes into
+    /// that conversation; `None` *or* an empty/whitespace id falls back to the
+    /// daemon session (an empty id would otherwise mean "daemon session" to the
+    /// daemon anyway, so we normalise to the explicit `PushToTalk()`).
+    pub fn for_conversation(active_conversation: Option<&str>) -> Self {
+        match active_conversation {
+            Some(id) if !id.trim().is_empty() => Self::InConversation(id.to_string()),
+            _ => Self::DaemonSession,
+        }
+    }
+}
+
 /// Typed zbus proxy for the voice daemon.
 ///
 /// zbus derives each D-Bus method name by PascalCasing the Rust fn name, which
@@ -115,7 +144,17 @@ pub trait Voice {
     fn get_enabled(&self) -> zbus::Result<bool>;
 
     /// Start listening immediately (push-to-talk; works even with wake off).
+    /// The spoken turn lands in the daemon's own session.
     fn push_to_talk(&self) -> zbus::Result<()>;
+
+    /// Push-to-talk routed into a specific orchestrator conversation, so the
+    /// spoken prompt and reply appear in the conversation the user is viewing.
+    /// An empty `conversation_id` falls back to the daemon's own session,
+    /// matching [`VoiceProxy::push_to_talk`].
+    fn push_to_talk_in_conversation(&self, conversation_id: &str) -> zbus::Result<()>;
+
+    /// Stop any in-progress TTS playback (barge-in).
+    fn stop_speaking(&self) -> zbus::Result<()>;
 
     /// List installed voices as (id, display name, language, num_speakers).
     fn list_voices(&self) -> zbus::Result<Vec<(String, String, String, u32)>>;
@@ -195,6 +234,43 @@ impl VoiceController {
             return Err("voice service unavailable".to_string());
         };
         proxy.push_to_talk().await.map_err(|e| e.to_string())
+    }
+
+    /// Fire a push-to-talk request routed into a specific conversation, so the
+    /// spoken prompt and reply land in the conversation the user is viewing
+    /// (mirrors voice#24). An empty `conversation_id` is equivalent to
+    /// [`VoiceController::push_to_talk`] (the daemon's own session).
+    pub async fn push_to_talk_in_conversation(&self, conversation_id: &str) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy
+            .push_to_talk_in_conversation(conversation_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Dispatch a push-to-talk turn according to [`PttRoute::for_conversation`]:
+    /// into the active conversation when one is open, else the daemon session.
+    ///
+    /// This is the single entry point the mic button uses; the routing decision
+    /// itself is the pure [`PttRoute`] so it can be unit-tested without a bus.
+    pub async fn push_to_talk_routed(
+        &self,
+        active_conversation: Option<&str>,
+    ) -> Result<(), String> {
+        match PttRoute::for_conversation(active_conversation) {
+            PttRoute::InConversation(id) => self.push_to_talk_in_conversation(&id).await,
+            PttRoute::DaemonSession => self.push_to_talk().await,
+        }
+    }
+
+    /// Stop any in-progress TTS playback (barge-in before re-listening).
+    pub async fn stop_speaking(&self) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.stop_speaking().await.map_err(|e| e.to_string())
     }
 
     /// Read the wake-word enabled flag. `None` when the service is unavailable.
@@ -340,5 +416,35 @@ mod tests {
         assert!(VoiceState::Listening.label().ends_with('…'));
         assert!(VoiceState::Processing.label().ends_with('…'));
         assert!(VoiceState::Speaking.label().ends_with('…'));
+    }
+
+    #[test]
+    fn ptt_routes_into_the_active_conversation() {
+        // A live conversation id → PushToTalkInConversation(id).
+        assert_eq!(
+            PttRoute::for_conversation(Some("conv-123")),
+            PttRoute::InConversation("conv-123".to_string())
+        );
+    }
+
+    #[test]
+    fn ptt_falls_back_to_daemon_session_with_no_conversation() {
+        // Nothing open → plain PushToTalk (daemon's own session).
+        assert_eq!(PttRoute::for_conversation(None), PttRoute::DaemonSession);
+    }
+
+    #[test]
+    fn ptt_treats_empty_conversation_id_as_no_conversation() {
+        // An empty/whitespace id must not be sent as a "real" conversation; it
+        // normalises to the daemon session (which is also how the daemon reads
+        // an empty id), so the mic button issues the explicit PushToTalk().
+        assert_eq!(
+            PttRoute::for_conversation(Some("")),
+            PttRoute::DaemonSession
+        );
+        assert_eq!(
+            PttRoute::for_conversation(Some("   ")),
+            PttRoute::DaemonSession
+        );
     }
 }

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
 use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, Button, Image, Orientation, ScrolledWindow, TextView, WrapMode};
 
@@ -8,31 +11,64 @@ pub struct InputBar {
     pub container: GtkBox,
     pub text_view: TextView,
     pub send_button: Button,
-    /// Push-to-talk button: starts a dictation turn on the voice daemon
-    /// (`PushToTalk`). Hidden until the voice service is found on the bus
-    /// (graceful degradation — see [`InputBar::set_voice_available`]).
+    /// Push-to-talk button: starts a dictation turn on the voice daemon,
+    /// routed into the active conversation (`PushToTalkInConversation`) or the
+    /// daemon's own session (`PushToTalk`) when none is open. Hidden until the
+    /// voice service is found on the bus (graceful degradation — see
+    /// [`InputBar::set_voice_available`]).
     pub mic_button: Button,
-    /// The mic icon, swapped between resting and active glyphs as the pipeline
-    /// state changes.
+    /// The mic icon, swapped per pipeline state to mirror the plasmoid's glyphs.
     mic_image: Image,
+    /// The last pipeline state reflected on the button. The window's click
+    /// handler reads it to decide barge-in (click while `Speaking` →
+    /// `StopSpeaking`, otherwise start a push-to-talk turn).
+    state: Rc<Cell<VoiceState>>,
 }
 
-/// Themed-icon fallback chain for the resting (idle) mic glyph. Breeze (KDE),
-/// Adwaita and most icon themes ship at least one of these; listing several
-/// avoids a broken glyph on a theme that lacks the first.
+/// Themed-icon fallback chain for the **resting (Idle)** mic glyph. The first
+/// entry mirrors the plasmoid (`audio-input-microphone-muted`); the rest are
+/// fallbacks so a theme missing the muted glyph still renders a mic.
 const MIC_IDLE_ICONS: &[&str] = &[
+    "audio-input-microphone-muted-symbolic",
+    "audio-input-microphone-muted",
+    "microphone-sensitivity-muted-symbolic",
     "audio-input-microphone-symbolic",
-    "microphone-sensitivity-high-symbolic",
-    "audio-input-microphone",
 ];
 
-/// Icon shown while the pipeline is actively listening/processing/speaking —
-/// a "recording" dot so the active turn reads at a glance.
-const MIC_ACTIVE_ICONS: &[&str] = &[
-    "media-record-symbolic",
-    "audio-input-microphone-high-symbolic",
-    "media-record",
+/// Icon shown while **Listening** — an open mic (plasmoid: `audio-input-microphone`).
+const MIC_LISTENING_ICONS: &[&str] = &[
+    "audio-input-microphone-symbolic",
+    "audio-input-microphone",
+    "microphone-sensitivity-high-symbolic",
 ];
+
+/// Icon shown while **Processing** ("Thinking…") — a refresh/spinner glyph
+/// (plasmoid: `view-refresh-symbolic`).
+const MIC_PROCESSING_ICONS: &[&str] = &["view-refresh-symbolic", "content-loading-symbolic"];
+
+/// Icon shown while **Speaking** — a speaker (plasmoid: `audio-volume-high`).
+const MIC_SPEAKING_ICONS: &[&str] = &["audio-volume-high-symbolic", "audio-volume-high"];
+
+/// The themed-icon fallback chain for a given pipeline state.
+fn mic_icons_for(state: VoiceState) -> &'static [&'static str] {
+    match state {
+        VoiceState::Idle => MIC_IDLE_ICONS,
+        VoiceState::Listening => MIC_LISTENING_ICONS,
+        VoiceState::Processing => MIC_PROCESSING_ICONS,
+        VoiceState::Speaking => MIC_SPEAKING_ICONS,
+    }
+}
+
+/// The mic button's tooltip for a given state, mirroring the plasmoid: "Stop
+/// speaking" while Speaking (the click barges in), otherwise "Push to talk"
+/// with the in-progress phase appended.
+fn mic_tooltip_for(state: VoiceState) -> String {
+    match state {
+        VoiceState::Speaking => "Stop speaking".to_string(),
+        VoiceState::Idle => "Push to talk".to_string(),
+        other => format!("Push to talk — {}", other.label()),
+    }
+}
 
 impl InputBar {
     pub fn new() -> Self {
@@ -50,7 +86,7 @@ impl InputBar {
         mic_button.add_css_class("mic-button");
         mic_button.set_valign(gtk4::Align::End);
         mic_button.set_margin_bottom(4);
-        mic_button.set_tooltip_text(Some("Hold a conversation — click to start talking"));
+        mic_button.set_tooltip_text(Some(&mic_tooltip_for(VoiceState::Idle)));
         mic_button.set_visible(false);
         container.append(&mic_button);
 
@@ -81,6 +117,7 @@ impl InputBar {
             send_button,
             mic_button,
             mic_image,
+            state: Rc::new(Cell::new(VoiceState::Idle)),
         }
     }
 
@@ -91,25 +128,32 @@ impl InputBar {
         self.mic_button.set_visible(available);
     }
 
-    /// Reflect the voice pipeline state on the mic button: a CSS class drives
-    /// the accent while active, the icon swaps to a record glyph, and the
-    /// tooltip explains the current phase.
+    /// Reflect the voice pipeline state on the mic button: the icon swaps to
+    /// the per-state glyph (mirroring the plasmoid), a CSS class drives the
+    /// accent while a turn is active, and the tooltip explains the current
+    /// phase. The state is also cached for the click handler's barge-in check
+    /// (see [`InputBar::current_state`]).
     pub fn reflect_voice_state(&self, state: VoiceState) {
-        let active = !matches!(state, VoiceState::Idle);
-        if active {
-            self.mic_button.add_css_class("mic-active");
-            self.mic_image
-                .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_ACTIVE_ICONS));
-        } else {
+        self.state.set(state);
+
+        // Highlight while a turn is in flight (anything but resting Idle).
+        if matches!(state, VoiceState::Idle) {
             self.mic_button.remove_css_class("mic-active");
-            self.mic_image
-                .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_IDLE_ICONS));
+        } else {
+            self.mic_button.add_css_class("mic-active");
         }
-        let tooltip = match state {
-            VoiceState::Idle => "Hold a conversation — click to start talking".to_string(),
-            other => format!("Voice: {}", other.label()),
-        };
-        self.mic_button.set_tooltip_text(Some(&tooltip));
+
+        self.mic_image
+            .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(mic_icons_for(state)));
+        self.mic_button
+            .set_tooltip_text(Some(&mic_tooltip_for(state)));
+    }
+
+    /// The last pipeline state reflected on the button. The window's click
+    /// handler uses this to choose barge-in (`Speaking` → `StopSpeaking`) vs.
+    /// starting a push-to-talk turn.
+    pub fn current_state(&self) -> VoiceState {
+        self.state.get()
     }
 
     /// Get the current text content and clear the input.
@@ -132,5 +176,54 @@ impl InputBar {
         buffer
             .text(&buffer.start_iter(), &buffer.end_iter(), false)
             .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tooltip_offers_barge_in_only_while_speaking() {
+        // Mirrors the plasmoid: clicking while Speaking stops playback, so the
+        // tooltip reads "Stop speaking"; every other state invites talking.
+        assert_eq!(mic_tooltip_for(VoiceState::Speaking), "Stop speaking");
+        assert_eq!(mic_tooltip_for(VoiceState::Idle), "Push to talk");
+        assert_eq!(
+            mic_tooltip_for(VoiceState::Listening),
+            "Push to talk — Listening…"
+        );
+        assert_eq!(
+            mic_tooltip_for(VoiceState::Processing),
+            "Push to talk — Processing…"
+        );
+    }
+
+    #[test]
+    fn each_state_maps_to_a_distinct_primary_icon() {
+        // The first entry in each chain is the plasmoid glyph; they must differ
+        // per state so the button visibly tracks the pipeline.
+        assert_eq!(mic_icons_for(VoiceState::Idle)[0], MIC_IDLE_ICONS[0]);
+        assert_eq!(
+            mic_icons_for(VoiceState::Listening)[0],
+            MIC_LISTENING_ICONS[0]
+        );
+        assert_eq!(
+            mic_icons_for(VoiceState::Processing)[0],
+            MIC_PROCESSING_ICONS[0]
+        );
+        assert_eq!(
+            mic_icons_for(VoiceState::Speaking)[0],
+            MIC_SPEAKING_ICONS[0]
+        );
+        // No chain is empty (an empty `from_names` would render nothing).
+        for state in [
+            VoiceState::Idle,
+            VoiceState::Listening,
+            VoiceState::Processing,
+            VoiceState::Speaking,
+        ] {
+            assert!(!mic_icons_for(state).is_empty());
+        }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -769,7 +769,7 @@ impl AdelieWindow {
         // gate the UI on the daemon actually owning its bus name (graceful
         // degradation when it isn't running / models aren't provisioned).
         let voice: Rc<RefCell<Option<VoiceController>>> = Rc::new(RefCell::new(None));
-        wire_voice_controls(&voice, &input_bar, &bridge);
+        wire_voice_controls(&voice, &input_bar, &bridge, &state);
 
         // Wire the side pane's interactions to daemon commands. Edits/toggles/
         // deletes issue scratchpad commands; the daemon's `ScratchpadChanged`
@@ -1455,7 +1455,7 @@ impl AdelieWindow {
 }
 
 /// Connect to the voice daemon and wire the input bar's mic button + state
-/// reflection (issue #59).
+/// reflection (issues #59, #63).
 ///
 /// Connecting is async (session bus + proxy build), so it runs on the Tokio
 /// runtime; the resulting [`VoiceController`] is delivered back to the GTK main
@@ -1465,28 +1465,53 @@ impl AdelieWindow {
 ///   (graceful degradation when it's absent), and
 /// - keep the button's state in sync with the daemon's `StateChanged` signal.
 ///
-/// The mic button fires `PushToTalk`, which starts a dictation turn even when
-/// the always-on wake word is off.
+/// Clicking the mic button dictates **into the active conversation**: it reads
+/// the window's `current_conversation_id` and calls
+/// `PushToTalkInConversation(<id>)` so the spoken prompt and reply land in the
+/// conversation the user is viewing (mirrors voice#24); with no conversation
+/// open it falls back to plain `PushToTalk()` (the daemon's own session). If a
+/// reply is currently playing (`Speaking`), the click barges in with
+/// `StopSpeaking()` instead — matching the plasmoid.
 fn wire_voice_controls(
     voice: &Rc<RefCell<Option<VoiceController>>>,
     input_bar: &Rc<InputBar>,
     bridge: &Rc<AsyncBridge>,
+    state: &Rc<RefCell<WindowState>>,
 ) {
-    // Mic button → PushToTalk. The controller may not be connected yet; a
-    // click before then is a harmless no-op (the button is hidden until the
-    // daemon is confirmed present anyway).
+    // Mic button click. The controller may not be connected yet; a click
+    // before then is a harmless no-op (the button is hidden until the daemon is
+    // confirmed present anyway).
     input_bar.mic_button.connect_clicked(glib::clone!(
         #[strong]
         voice,
         #[strong]
         bridge,
+        #[strong]
+        state,
+        #[strong]
+        input_bar,
         move |_| {
             let Some(controller) = voice.borrow().clone() else {
                 return;
             };
             let ui_tx = bridge.ui_sender();
+
+            // Barge-in: while a reply is playing, the click stops it rather than
+            // starting a new turn (mirrors the plasmoid's mic button).
+            if matches!(input_bar.current_state(), VoiceState::Speaking) {
+                crate::async_bridge::spawn_on_runtime(async move {
+                    if let Err(e) = controller.stop_speaking().await {
+                        let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                    }
+                });
+                return;
+            }
+
+            // Otherwise start a dictation turn routed into the conversation the
+            // user is viewing (or the daemon's own session when none is open).
+            let active = state.borrow().current_conversation_id.clone();
             crate::async_bridge::spawn_on_runtime(async move {
-                if let Err(e) = controller.push_to_talk().await {
+                if let Err(e) = controller.push_to_talk_routed(active.as_deref()).await {
                     let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
                 }
             });


### PR DESCRIPTION
Closes #63

## Summary

The voice controls landed by #59/#62 (zbus `voice_client`, wake-word toggle, voice picker, mic button, state display) always fired the daemon's context-free `PushToTalk()` — so a spoken prompt and its reply went to the **daemon's own session**, not the conversation the user was viewing. This routes the mic button into the **active conversation** and mirrors the plasmoid's pipeline-state display and barge-in, completing the core of #63.

The voice daemon owns the full audio pipeline (mic → STT → assistant → TTS → playback); this client only sends D-Bus control and reflects state — no audio code.

## What changed

**`src/voice_client.rs`**
- Added `PushToTalkInConversation(s)` and `StopSpeaking()` to the zbus proxy and `VoiceController` (the daemon exposes both as of voice **#27**).
- Added `PttRoute`, the **pure** routing decision: a non-empty active conversation id → `InConversation(id)`; `None` / empty / whitespace → `DaemonSession` (which is also how the daemon reads an empty id, so we normalise to the explicit `PushToTalk()`). `push_to_talk_routed()` dispatches on it.

**`src/widgets/input_bar.rs`**
- Reflect the pipeline state on the mic button using the plasmoid's glyphs — Listening=`audio-input-microphone`, Processing=`view-refresh-symbolic` ("Thinking…"), Speaking=`audio-volume-high`, Idle=`audio-input-microphone-muted` (each a small fallback chain so themes missing a glyph still render).
- Tooltip mirrors the plasmoid: **"Stop speaking"** while Speaking, otherwise **"Push to talk — <phase>"**.
- Cache the last `VoiceState` so the window's click handler can decide barge-in.

**`src/window.rs`**
- `wire_voice_controls` now takes the window `state`. On click it reads `current_conversation_id` (the *same* source the Send button uses) and calls `push_to_talk_routed(active)`. If a reply is currently **Speaking**, the click instead `StopSpeaking()`s (barge-in) rather than starting a new turn — matching the plasmoid's mic button.

## How the active conversation id is obtained

`WindowState.current_conversation_id: Option<String>`, read via `state.borrow().current_conversation_id.clone()` at click time — identical to the existing Send-button path (`window.rs` ~L1138). No new tracking introduced.

## State display

Signal-driven (unchanged from #62): `VoiceController::spawn_state_listener` seeds from `GetState`, then forwards every `StateChanged` over an mpsc channel consumed on the GTK main thread, which calls `InputBar::reflect_voice_state`.

## Tests

Pure logic only (GTK widgets can't render headless):
- routing decision — active id → `InConversation`, none → `DaemonSession`, empty/whitespace → `DaemonSession`;
- mic-button tooltip (barge-in only while Speaking) and per-state primary-icon mapping.

`just check` (fmt + clippy `-D warnings` + build + 155 tests, 1 ignored) is green; the pre-push hook re-ran it.

## Deferred / notes

- Voice selection and the wake-word toggle were **already delivered** by #62 (Settings → Voice tab); unchanged here.
- Graceful degradation (mic hidden when the daemon doesn't own the bus name) is inherited from #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)