### PR TITLE
feat(voice): embed the voice module for in-app dictation + playback (#65)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,9 @@ version = 4
 name = "adele-gtk"
 version = "0.1.0"
 dependencies = [
+ "adele-voice-module",
+ "adele-voice-stt-whisper",
+ "adele-voice-vad-silero",
  "ammonia",
  "anyhow",
  "base64",
@@ -22,8 +25,9 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -34,6 +38,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "adele-voice-audio-cpal"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "anyhow",
+ "cpal",
+ "ringbuf",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "adele-voice-core"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "adele-voice-module"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-audio-cpal",
+ "adele-voice-core",
+ "adele-voice-stt-whisper",
+ "adele-voice-tts-kokoro",
+ "adele-voice-tts-piper",
+ "adele-voice-tts-polly",
+ "adele-voice-vad-silero",
+ "dirs",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "adele-voice-stt-whisper"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "anyhow",
+ "tracing",
+ "whisper-rs",
+]
+
+[[package]]
+name = "adele-voice-tts-kokoro"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "ort",
+ "rubato",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "adele-voice-tts-piper"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "anyhow",
+ "rubato",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "adele-voice-tts-polly"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "aws-config",
+ "aws-sdk-polly",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "adele-voice-vad-silero"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+ "anyhow",
+ "ndarray",
+ "ort",
+ "tracing",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +136,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -51,6 +146,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -130,6 +247,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -269,10 +395,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-config"
+version = "1.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.0",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -298,6 +499,325 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-polly"
+version = "1.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf75c9e58b42098de242441212aa184197e1b880037a40edda5c01701a9c2c88"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.106.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +835,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,12 +886,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -358,10 +932,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -408,6 +998,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,8 +1054,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -503,6 +1119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +1148,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -554,12 +1182,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
+dependencies = [
+ "bitflags",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -576,6 +1266,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -602,10 +1301,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -676,9 +1400,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -700,6 +1436,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -733,6 +1479,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -840,6 +1592,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1148,6 +1915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,7 +2060,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1334,7 +2107,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1343,8 +2116,23 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "html5ever"
@@ -1359,6 +2147,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1369,12 +2168,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1385,8 +2195,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1395,6 +2205,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1407,8 +2226,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1423,10 +2242,11 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1443,8 +2263,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -1645,6 +2465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +2504,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -1682,7 +2527,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -1701,6 +2546,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1790,6 +2644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,10 +2696,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "maplit"
@@ -1875,6 +2754,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,10 +2802,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1961,6 +2927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2978,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,15 +3008,104 @@ dependencies = [
  "base64",
  "chrono",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2044,10 +3132,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2064,6 +3189,36 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -2135,6 +3290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +3363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +3397,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2267,6 +3452,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -2442,6 +3636,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +3671,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +3692,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -2487,8 +3714,8 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2527,8 +3754,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2571,6 +3798,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "rubato"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce96ead1a91f7895704a9f08ea5947dfc8bd7c1f2936a22295b655ec67e5c6ef"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,6 +3837,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -2644,7 +3912,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -2726,7 +3994,7 @@ dependencies = [
  "num",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -2852,8 +4120,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2863,8 +4131,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2958,6 +4237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "soup3"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +4278,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -3369,8 +4665,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3452,6 +4748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,7 +4771,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -3523,6 +4829,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,10 +4872,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3572,6 +4920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +4936,23 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3808,12 +5179,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
 ]
 
 [[package]]
@@ -3827,6 +5272,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3856,6 +5312,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3888,6 +5354,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3911,6 +5386,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3947,6 +5437,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3960,6 +5465,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3969,6 +5480,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3996,6 +5513,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4005,6 +5528,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4020,6 +5549,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4029,6 +5564,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4150,6 +5691,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ open = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 clap = { version = "4", features = ["derive", "env"] }
@@ -49,3 +50,22 @@ path = "../desktop-assistant/crates/client-common"
 
 [dependencies.desktop-assistant-api-model]
 path = "../desktop-assistant/crates/api-model"
+
+# The embeddable voice module (adelie-ai/voice phase 1). Path-dep, mirroring the
+# desktop-assistant deps above: a `../voice` symlink under `.worktrees/adele-gtk/`
+# points at the voice checkout, and Cargo resolves the module's transitive
+# adapter crates (core/tts/…) via the voice workspace automatically. Powers the
+# in-app embedded dictation/playback path (issue #65) as an alternative to the
+# voice daemon's D-Bus surface.
+[dependencies.adele-voice-module]
+path = "../voice/crates/module"
+
+# The concrete VAD + STT adapters, only so the embedded engine can name the
+# `Dictation<SileroVad, WhisperStt>` returned by `build_dictation` for its
+# stored field. Same `../voice` symlink path-dep as the module above; no extra
+# crates enter the graph (they're already transitive deps of the module).
+[dependencies.adele-voice-vad-silero]
+path = "../voice/crates/vad-silero"
+
+[dependencies.adele-voice-stt-whisper]
+path = "../voice/crates/stt-whisper"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ mod profile;
 mod selected_models;
 mod theme;
 mod voice_client;
+mod voice_config;
+mod voice_embedded;
 #[cfg(feature = "linux")]
 mod webview;
 mod widgets;

--- a/src/voice_config.rs
+++ b/src/voice_config.rs
@@ -1,0 +1,190 @@
+//! Voice configuration for adele-gtk: pick between the standalone voice
+//! **daemon** (`org.desktopAssistant.Voice`, the existing D-Bus path) and an
+//! **embedded** in-process engine that does dictation + reply playback with the
+//! [`adele_voice_module`] crate — no daemon, no wake word (issue #65).
+//!
+//! Loaded from `~/.config/adele-gtk/voice.toml`. The file is optional and the
+//! whole struct is `#[serde(default)]`, so a missing or partial file yields the
+//! **daemon** mode — i.e. nothing changes for existing users who never write
+//! this file. To switch on the embedded engine a user sets:
+//!
+//! ```toml
+//! mode = "embedded"
+//!
+//! [tts]
+//! backend = "kokoro"   # or "piper" (both local); "polly" is cloud/opt-in
+//! ```
+//!
+//! The `[audio]` / `[vad]` / `[stt]` / `[tts]` sections are the voice module's
+//! own config types, so the embedded engine shares the exact knobs (and model
+//! defaults) the daemon uses; an embedding client just deserializes them here.
+
+use std::path::PathBuf;
+
+use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
+use serde::Deserialize;
+
+/// Which voice backend the mic button and reply playback use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VoiceMode {
+    /// The standalone voice daemon over D-Bus (`org.desktopAssistant.Voice`).
+    /// The default, so current behavior is unchanged when no config is present.
+    #[default]
+    Daemon,
+    /// The in-process [`adele_voice_module`] engine: dictation + playback run
+    /// inside adele-gtk, requiring no voice daemon. No wake word (daemon-only).
+    Embedded,
+}
+
+/// adele-gtk's voice settings. Deserialized from `voice.toml`; every field has
+/// a default so an absent/partial file is valid and resolves to the daemon path.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct VoiceConfig {
+    /// Daemon (default) vs. the embedded in-process engine.
+    pub mode: VoiceMode,
+    /// Audio input/output device names for the embedded engine.
+    pub audio: AudioConfig,
+    /// Voice-activity-detection (endpointing) tuning for embedded dictation.
+    pub vad: VadConfig,
+    /// Speech-to-text (Whisper) settings for embedded dictation.
+    pub stt: SttConfig,
+    /// Text-to-speech backend + voice for embedded reply playback. `backend`
+    /// selects "kokoro" (local, default) / "piper" (local) / "polly" (cloud).
+    pub tts: TtsConfig,
+}
+
+impl VoiceConfig {
+    /// Load the voice config from the default path
+    /// (`~/.config/adele-gtk/voice.toml`).
+    ///
+    /// A missing file is **not** an error — it returns the default (daemon)
+    /// config so the app behaves exactly as before for users who never opt in.
+    /// A present-but-unparseable file is logged and likewise degrades to the
+    /// default, mirroring `ProfileStore::load`'s corrupt-file tolerance, so a
+    /// typo in `voice.toml` can never stop the app from starting.
+    pub fn load() -> Self {
+        Self::load_from(&default_config_path())
+    }
+
+    /// Load from an explicit path (the seam the tests drive). Same tolerance as
+    /// [`VoiceConfig::load`]: absent → default; unparseable → default + warn.
+    pub fn load_from(path: &std::path::Path) -> Self {
+        let data = match std::fs::read_to_string(path) {
+            Ok(data) => data,
+            // Absent file is the common case (no opt-in) — stay quiet.
+            Err(_) => return Self::default(),
+        };
+        match toml::from_str::<VoiceConfig>(&data) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(
+                    "ignoring unparseable {} ({e}); using default (daemon) voice config",
+                    path.display()
+                );
+                Self::default()
+            }
+        }
+    }
+
+    /// Whether the embedded in-process engine is selected.
+    pub fn is_embedded(&self) -> bool {
+        self.mode == VoiceMode::Embedded
+    }
+}
+
+/// `~/.config/adele-gtk/voice.toml`. Mirrors `profile::default_config_dir` so
+/// all of adele-gtk's per-user files live in the same directory.
+fn default_config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("adele-gtk")
+        .join("voice.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_daemon_mode() {
+        // The critical no-regression guarantee: with no config, the existing
+        // daemon path is used.
+        let cfg = VoiceConfig::default();
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+        assert!(!cfg.is_embedded());
+    }
+
+    #[test]
+    fn missing_file_yields_daemon_default() {
+        let path = std::env::temp_dir().join(format!(
+            "adele-gtk-voice-missing-{}-{}.toml",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        // The file does not exist.
+        assert!(!path.exists());
+        let cfg = VoiceConfig::load_from(&path);
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+    }
+
+    #[test]
+    fn parses_embedded_mode_with_backend() {
+        let cfg: VoiceConfig = toml::from_str(
+            r#"
+                mode = "embedded"
+
+                [tts]
+                backend = "piper"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.mode, VoiceMode::Embedded);
+        assert!(cfg.is_embedded());
+        assert_eq!(cfg.tts.backend, "piper");
+        // Unspecified module fields fall back to the module's own defaults.
+        assert_eq!(cfg.stt.language, "en");
+    }
+
+    #[test]
+    fn parses_daemon_mode_explicitly() {
+        let cfg: VoiceConfig = toml::from_str(r#"mode = "daemon""#).unwrap();
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+    }
+
+    #[test]
+    fn empty_document_is_daemon_default() {
+        // A `voice.toml` that only has comments / is empty must still parse.
+        let cfg: VoiceConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+    }
+
+    #[test]
+    fn unparseable_file_degrades_to_default() {
+        let path = std::env::temp_dir().join(format!(
+            "adele-gtk-voice-bad-{}-{}.toml",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, "this is = = not valid toml").unwrap();
+        let cfg = VoiceConfig::load_from(&path);
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unknown_mode_value_is_rejected_then_degrades() {
+        // An invalid `mode` is a parse error; `load_from` swallows it to the
+        // default rather than failing startup.
+        let path = std::env::temp_dir().join(format!(
+            "adele-gtk-voice-unknownmode-{}-{}.toml",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, r#"mode = "telepathy""#).unwrap();
+        let cfg = VoiceConfig::load_from(&path);
+        assert_eq!(cfg.mode, VoiceMode::Daemon);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/voice_embedded.rs
+++ b/src/voice_embedded.rs
@@ -1,0 +1,178 @@
+//! In-process voice engine: dictation + reply playback with no daemon.
+//!
+//! The embedded alternative to `voice_client` (the D-Bus daemon path). It wraps
+//! the [`adele_voice_module`] primitives — [`Dictation`] (mic → Silero VAD
+//! endpoint → Whisper) and [`Speaker`] (configured TTS backend → audio sink) —
+//! so a machine with **no voice daemon** still gets a working mic button and
+//! spoken replies (issue #65). There is deliberately **no wake word** here; the
+//! always-on wake word stays daemon-only (epic voice#34).
+//!
+//! ## Threading
+//!
+//! The GTK main thread can't block, and the adapters (cpal mic/sink, the
+//! Whisper/ONNX models) are heavy, so:
+//!
+//! - Construction is **lazy**: the models load and the mic opens only on the
+//!   first [`EmbeddedVoice::dictate`] call (and the speaker on the first
+//!   [`EmbeddedVoice::say`]) — never at startup. A user who never clicks the
+//!   mic never pays the load cost and the **microphone is never opened**.
+//! - All work runs on the shared Tokio runtime (via [`spawn_on_runtime`]); the
+//!   GTK side hands in oneshot/mpsc channels and only plain values cross back.
+//! - A `tokio::sync::Mutex` serializes access, so a second mic click while a
+//!   turn is in flight waits its turn instead of opening a second mic stream.
+//!
+//! `EmbeddedVoice` is cheap to clone (just `Arc`s) and `Send + Sync`, so the
+//! window can share one handle between the mic-button handler and the
+//! reply-playback hook.
+
+use std::sync::Arc;
+
+use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
+use adele_voice_module::{Dictation, Speaker, TtsBackend, build_dictation, build_speaker};
+use adele_voice_stt_whisper::WhisperStt;
+use adele_voice_vad_silero::SileroVad;
+use tokio::sync::Mutex;
+
+/// The concrete dictation type the config builder wires (Silero VAD + Whisper).
+type EmbeddedDictation = Dictation<SileroVad, WhisperStt>;
+
+/// Shared, lazily-initialized in-process dictation + playback.
+///
+/// Clone to share the same underlying engine (the `Arc`s are shared, so the
+/// mic-button handler and the reply hook drive one `Dictation`/`Speaker`).
+#[derive(Clone)]
+pub struct EmbeddedVoice {
+    /// The voice-module config sections (audio/vad/stt/tts) used to build the
+    /// adapters on first use.
+    cfg: Arc<EmbeddedConfig>,
+    /// Built on the first `dictate()`; `None` until then so models/mic load
+    /// lazily. The `Mutex` also serializes dictation turns.
+    dictation: Arc<Mutex<Option<EmbeddedDictation>>>,
+    /// Built on the first `say()`; `None` until then. `Speaker` is itself cheap
+    /// to clone, but we hold one instance so the sink/backend are shared.
+    speaker: Arc<Mutex<Option<Speaker<TtsBackend>>>>,
+}
+
+/// The subset of [`crate::voice_config::VoiceConfig`] the engine needs — the
+/// module's own config types. Snapshotted into an `Arc` so the engine is
+/// self-contained (no borrow of the larger app config).
+pub struct EmbeddedConfig {
+    pub audio: AudioConfig,
+    pub vad: VadConfig,
+    pub stt: SttConfig,
+    pub tts: TtsConfig,
+}
+
+impl EmbeddedVoice {
+    /// Create an engine from the voice config. Builds **nothing** yet — the
+    /// adapters (and the mic) come up lazily on first use.
+    pub fn new(cfg: EmbeddedConfig) -> Self {
+        Self {
+            cfg: Arc::new(cfg),
+            dictation: Arc::new(Mutex::new(None)),
+            speaker: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Capture and transcribe one utterance.
+    ///
+    /// Opens the mic (building the engine on first call), waits for the user to
+    /// speak and stop (VAD endpointing), and returns the transcript — or `None`
+    /// when nothing was said / the capture was near-silent. Errors (model load
+    /// failure, audio device gone) surface as `Err(String)` for the caller to
+    /// report. Runs entirely on the Tokio runtime; never blocks the GTK thread.
+    pub async fn dictate(&self) -> Result<Option<String>, String> {
+        let mut guard = self.dictation.lock().await;
+        if guard.is_none() {
+            // First use: load Silero + Whisper and bind the mic.
+            let d = build_dictation(&self.cfg.audio, &self.cfg.vad, &self.cfg.stt)
+                .map_err(|e| format!("voice init failed: {e}"))?;
+            *guard = Some(d);
+        }
+        // Safe: just populated above.
+        let dictation = guard.as_mut().expect("dictation built");
+        dictation.dictate().await.map_err(|e| e.to_string())
+    }
+
+    /// Speak `text` through the configured TTS backend.
+    ///
+    /// Builds the speaker on first call (local-first Kokoro→Piper fallback).
+    /// A failure to synthesize/play surfaces as `Err(String)`. Independent of
+    /// the mic — speaking never listens.
+    pub async fn say(&self, text: &str) -> Result<(), String> {
+        let speaker = self.ensure_speaker().await;
+        speaker.say(text).await.map_err(|e| e.to_string())
+    }
+
+    /// Stop any in-progress playback (barge-in). A no-op if the speaker hasn't
+    /// been built yet (nothing has played, so nothing to stop).
+    pub async fn stop_speaking(&self) -> Result<(), String> {
+        let guard = self.speaker.lock().await;
+        match guard.as_ref() {
+            Some(speaker) => speaker.stop().map_err(|e| e.to_string()),
+            None => Ok(()),
+        }
+    }
+
+    /// Whether the speaker is currently playing audio. `false` before the
+    /// speaker is built (nothing has ever played).
+    pub async fn is_playing(&self) -> bool {
+        let guard = self.speaker.lock().await;
+        guard.as_ref().is_some_and(|s| s.is_playing())
+    }
+
+    /// Get (building on first call) a clone of the shared [`Speaker`]. Cloning
+    /// the speaker lets the lock be released before the (awaited) synthesis, so
+    /// `say` does not hold the mutex across playback.
+    async fn ensure_speaker(&self) -> Speaker<TtsBackend> {
+        let mut guard = self.speaker.lock().await;
+        if guard.is_none() {
+            let s = build_speaker(&self.cfg.tts, &self.cfg.audio).await;
+            *guard = Some(s);
+        }
+        guard.as_ref().expect("speaker built").clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn engine() -> EmbeddedVoice {
+        EmbeddedVoice::new(EmbeddedConfig {
+            audio: AudioConfig::default(),
+            vad: VadConfig::default(),
+            stt: SttConfig::default(),
+            tts: TtsConfig::default(),
+        })
+    }
+
+    /// Security/privacy property (issue #65): constructing the engine must not
+    /// open any audio device or load any model — that only happens on the first
+    /// explicit `dictate()`/`say()`. Before any use, the speaker is unbuilt, so
+    /// it reports not-playing and `stop_speaking()` is a harmless no-op. (This
+    /// deliberately never calls `dictate()`, which would open the mic.)
+    #[tokio::test]
+    async fn fresh_engine_has_not_touched_audio() {
+        let engine = engine();
+        assert!(
+            !engine.is_playing().await,
+            "a freshly built engine must report no playback (speaker not built)"
+        );
+        assert!(
+            engine.stop_speaking().await.is_ok(),
+            "stop on an unbuilt speaker is a no-op, not an error"
+        );
+    }
+
+    /// The engine is cheap to clone and shares state: clones must observe the
+    /// same (unbuilt) speaker, so cloning for the mic handler + reply hook is
+    /// sound and still hasn't opened audio.
+    #[tokio::test]
+    async fn clone_shares_state_without_building() {
+        let engine = engine();
+        let clone = engine.clone();
+        assert!(!clone.is_playing().await);
+        assert!(clone.stop_speaking().await.is_ok());
+    }
+}

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -166,6 +166,13 @@ impl InputBar {
         text
     }
 
+    /// Replace the input's text. Used by the embedded voice path (issue #65) to
+    /// drop a dictated transcript into the box before sending it like a typed
+    /// message.
+    pub fn set_text(&self, text: &str) {
+        self.text_view.buffer().set_text(text);
+    }
+
     /// Get the current text content without clearing.
     // Read-only counterpart to `take_text` (which is used). Part of the public
     // InputBar API; not yet called from `window.rs` but kept for the input-bar

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -715,6 +715,33 @@ impl AdelieWindow {
         let toast_revealer = Rc::new(toast_revealer);
         let toast_label = Rc::new(toast_label);
 
+        // Voice config (issue #65): pick between the standalone voice daemon
+        // (default; `org.desktopAssistant.Voice` over D-Bus) and an in-process
+        // embedded engine. Loaded once from `~/.config/adele-gtk/voice.toml`; an
+        // absent/partial file resolves to the daemon mode, so existing users see
+        // no change. When embedded, `embedded_voice` is the in-process engine
+        // (lazily initialized on first mic use — no models load, no mic opens,
+        // at startup); `None` on the daemon path.
+        let voice_config = crate::voice_config::VoiceConfig::load();
+        let embedded_voice: Rc<Option<crate::voice_embedded::EmbeddedVoice>> =
+            Rc::new(if voice_config.is_embedded() {
+                Some(crate::voice_embedded::EmbeddedVoice::new(
+                    crate::voice_embedded::EmbeddedConfig {
+                        audio: voice_config.audio.clone(),
+                        vad: voice_config.vad.clone(),
+                        stt: voice_config.stt.clone(),
+                        tts: voice_config.tts.clone(),
+                    },
+                ))
+            } else {
+                None
+            });
+        // Set when a turn was started by the embedded mic button, so only
+        // voice-initiated replies are spoken (a typed message stays silent).
+        // Lives outside `WindowState` to keep `apply()` pure; the reply-playback
+        // hook reads + clears it in the effect executor.
+        let voice_reply_pending: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+
         // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
         let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
 
@@ -742,6 +769,10 @@ impl AdelieWindow {
             toast_revealer,
             #[strong]
             toast_label,
+            #[strong]
+            embedded_voice,
+            #[strong]
+            voice_reply_pending,
             move |msg, ui_tx| {
                 handle_ui_message(
                     msg,
@@ -756,6 +787,8 @@ impl AdelieWindow {
                     &side_pane,
                     &toast_revealer,
                     &toast_label,
+                    &embedded_voice,
+                    &voice_reply_pending,
                     ui_tx,
                 );
             }
@@ -769,7 +802,15 @@ impl AdelieWindow {
         // gate the UI on the daemon actually owning its bus name (graceful
         // degradation when it isn't running / models aren't provisioned).
         let voice: Rc<RefCell<Option<VoiceController>>> = Rc::new(RefCell::new(None));
-        wire_voice_controls(&voice, &input_bar, &bridge, &state);
+        // The daemon controls are wired only on the daemon path. In embedded
+        // mode the mic button is driven in-process (wired in the send block
+        // below, where it can reuse the send action) and shown immediately,
+        // since there is no daemon to probe for.
+        if embedded_voice.is_some() {
+            input_bar.set_voice_available(true);
+        } else {
+            wire_voice_controls(&voice, &input_bar, &bridge, &state);
+        }
 
         // Wire the side pane's interactions to daemon commands. Edits/toggles/
         // deletes issue scratchpad commands; the daemon's `ScratchpadChanged`
@@ -1214,6 +1255,22 @@ impl AdelieWindow {
                 }
             ));
             input_bar.text_view.add_controller(key_controller);
+
+            // Embedded voice (issue #65): when the in-process engine is active,
+            // the mic button dictates locally and sends via the same
+            // `send_action` as a typed message. Wired here (inside the send
+            // block) so it can reuse `send_action`; the daemon path wires the
+            // mic separately in `wire_voice_controls`.
+            if let Some(engine) = (*embedded_voice).clone() {
+                wire_embedded_mic(
+                    engine,
+                    &input_bar,
+                    &send_action,
+                    &state,
+                    &bridge,
+                    &voice_reply_pending,
+                );
+            }
         }
 
         // Hamburger menu: Switch Connection → open the picker in a new
@@ -1561,6 +1618,144 @@ fn wire_voice_controls(
     ));
 }
 
+/// Wire the mic button to the **embedded** in-process voice engine (issue #65).
+///
+/// This is the no-daemon path: a click runs [`EmbeddedVoice::dictate`] locally
+/// (mic → Silero VAD endpoint → Whisper), drops the transcript into the input
+/// box, and fires the same `send_action` a typed message uses — so the spoken
+/// prompt lands in the active conversation through the app's normal assistant
+/// path. The reply is spoken by the `CompleteStreaming` hook (gated on
+/// `voice_reply_pending`, set here before the send).
+///
+/// A click **while a reply is playing barges in** (stops playback) instead of
+/// starting a new turn, mirroring the daemon mic button. The button reflects
+/// `Listening` for the duration of the capture, then returns to `Idle`.
+///
+/// All voice work runs on the Tokio runtime; only the transcript crosses back
+/// to the GTK thread (via a oneshot) to touch widgets and call `send_action`.
+fn wire_embedded_mic(
+    engine: crate::voice_embedded::EmbeddedVoice,
+    input_bar: &Rc<InputBar>,
+    send_action: &Rc<impl Fn() + 'static>,
+    state: &Rc<RefCell<WindowState>>,
+    bridge: &Rc<AsyncBridge>,
+    voice_reply_pending: &Rc<Cell<bool>>,
+) {
+    // Guards against a second click starting an overlapping dictation while one
+    // is already in flight (the mic stream + Whisper are single-shot per turn).
+    let dictating = Rc::new(Cell::new(false));
+
+    input_bar.mic_button.connect_clicked(glib::clone!(
+        #[strong]
+        engine,
+        #[strong]
+        input_bar,
+        #[strong]
+        send_action,
+        #[strong]
+        state,
+        #[strong]
+        bridge,
+        #[strong]
+        voice_reply_pending,
+        #[strong]
+        dictating,
+        move |_| {
+            if dictating.get() {
+                return; // a capture is already running
+            }
+
+            // Require an open conversation before dictating, so the spoken
+            // prompt has somewhere to go (matches the typed-send guard).
+            if state.borrow().current_conversation_id.is_none() {
+                return;
+            }
+
+            let ui_tx = bridge.ui_sender();
+
+            // Barge-in: if a reply is currently playing, the click stops it
+            // rather than starting a new turn. `is_playing` is async (the engine
+            // lives on the runtime), so probe there; if not playing, dictate.
+            let (decision_tx, decision_rx) = mpsc::unbounded_channel::<bool>();
+            crate::async_bridge::spawn_on_runtime(glib::clone!(
+                #[strong]
+                engine,
+                async move {
+                    if engine.is_playing().await {
+                        if let Err(e) = engine.stop_speaking().await {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                        }
+                        let _ = decision_tx.send(false); // barged in; don't dictate
+                    } else {
+                        let _ = decision_tx.send(true); // proceed to dictate
+                    }
+                }
+            ));
+
+            // Back on the GTK thread: if we should dictate, run the capture and
+            // feed the transcript into the send path.
+            glib::spawn_future_local(glib::clone!(
+                #[strong]
+                engine,
+                #[strong]
+                input_bar,
+                #[strong]
+                send_action,
+                #[strong]
+                voice_reply_pending,
+                #[strong]
+                dictating,
+                #[strong]
+                bridge,
+                async move {
+                    let mut decision_rx = decision_rx;
+                    let Some(true) = decision_rx.recv().await else {
+                        return; // barged in (or channel dropped) — no capture
+                    };
+
+                    dictating.set(true);
+                    input_bar.reflect_voice_state(VoiceState::Listening);
+
+                    // Run the (blocking-ish) capture on the runtime; the
+                    // transcript comes back over a oneshot.
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    let ui_tx = bridge.ui_sender();
+                    crate::async_bridge::spawn_on_runtime(glib::clone!(
+                        #[strong]
+                        engine,
+                        async move {
+                            let result = engine.dictate().await;
+                            let _ = tx.send(result);
+                        }
+                    ));
+
+                    let result = rx.await;
+                    dictating.set(false);
+                    input_bar.reflect_voice_state(VoiceState::Idle);
+
+                    match result {
+                        Ok(Ok(Some(text))) => {
+                            // Mark the turn as voice-initiated so its reply is
+                            // spoken, then drop the transcript into the input
+                            // box and send it like a typed message.
+                            voice_reply_pending.set(true);
+                            input_bar.set_text(&text);
+                            send_action();
+                        }
+                        // No speech / near-silent capture — nothing to send.
+                        Ok(Ok(None)) => {}
+                        Ok(Err(e)) => {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                        }
+                        // The capture task was dropped before replying.
+                        Err(_) => {}
+                    }
+                }
+            ));
+        }
+    ));
+}
+
 /// Current wall-clock time in epoch milliseconds. Centralized so the
 /// task-panel callers all use the same units as `TaskView.started_at`.
 fn now_epoch_ms() -> i64 {
@@ -1585,8 +1780,19 @@ fn handle_ui_message(
     side_pane: &Rc<ConversationSidePane>,
     toast_revealer: &Rc<Revealer>,
     toast_label: &Rc<Label>,
+    embedded_voice: &Rc<Option<crate::voice_embedded::EmbeddedVoice>>,
+    voice_reply_pending: &Rc<Cell<bool>>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
+    // Embedded voice (issue #65): a voice turn that ends in an error never
+    // reaches `CompleteStreaming`, so clear the "speak the reply" flag here on a
+    // stream error. Otherwise the flag would leak onto the next (possibly typed)
+    // turn and speak a reply the user didn't dictate. The successful path clears
+    // it in the `CompleteStreaming` effect below.
+    if matches!(msg, UiMessage::StreamError { .. }) {
+        voice_reply_pending.set(false);
+    }
+
     // Pure decision: mutate state + compute the effects to perform.
     let effects = state.borrow_mut().apply(msg);
 
@@ -1628,6 +1834,25 @@ fn handle_ui_message(
             }
             Effect::CompleteStreaming(full) => {
                 chat_view.borrow_mut().complete_streaming(&full);
+                // Embedded voice (issue #65): speak the reply only when this
+                // turn was started by the embedded mic button (so typed
+                // messages stay silent). The flag is consumed here; on the
+                // daemon path `embedded_voice` is `None` and the daemon speaks
+                // its own replies, so this is a no-op.
+                let engine = if voice_reply_pending.replace(false) {
+                    (**embedded_voice).clone()
+                } else {
+                    None
+                };
+                if let Some(engine) = engine {
+                    let ui_tx = ui_tx.clone();
+                    let reply = full.clone();
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        if let Err(e) = engine.say(&reply).await {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                        }
+                    });
+                }
             }
             Effect::SetModelSelection(selection) => {
                 model_picker.set_selection(selection.as_ref());


### PR DESCRIPTION
Closes #65 — Phase 2 of the voice **module + service** epic (voice#34).

Embeds the `adele-voice-module` crate (voice phase 1) so adele-gtk does **in-app dictation + reply playback with no voice daemon**, behind a config toggle. The existing daemon path (mic button + Settings → Voice tab driving `org.desktopAssistant.Voice` over D-Bus) is unchanged and remains the default.

## Config toggle

New `~/.config/adele-gtk/voice.toml` (all fields optional → daemon default, so nothing changes for current users):

```toml
mode = "embedded"      # "daemon" (default) | "embedded"

[tts]
backend = "kokoro"     # local default; "piper" (local) or "polly" (cloud, opt-in)
```

The `[audio]`/`[vad]`/`[stt]`/`[tts]` sections are the voice module's own config types, so the embedded engine shares the daemon's knobs + model defaults.

## Behavior (embedded mode)

- Mic button → `Dictation::dictate()` **in-process** (mic → Silero VAD endpoint → Whisper) → transcript dropped into the input box → sent via the app's **normal** assistant path (`send_action`), so the spoken prompt lands in the active conversation.
- Reply (`CompleteStreaming`) → `Speaker::say` (local-first Kokoro→Piper; never auto-falls-back to billable cloud). Gated on a "this turn was voice-initiated" flag so **typed messages stay silent**; cleared on stream error too.
- A mic click **while a reply is playing barges in** (stops playback).
- **No wake word** in the embed path — that stays daemon-only per the epic boundary.

## What changed

- `src/voice_config.rs` — `VoiceConfig` (mode toggle + module config). Absent/partial/unparseable file degrades to the daemon default (mirrors `ProfileStore::load`). 7 parse tests.
- `src/voice_embedded.rs` — `EmbeddedVoice`: wraps the module's `Dictation`+`Speaker`, **lazily built on first use** — no models load and the **mic never opens** at startup (2 tests assert the fresh engine has not touched audio). All work runs on the Tokio runtime; only the transcript crosses back to the GTK thread.
- `src/window.rs` — branch the mic wiring on the mode (`wire_embedded_mic` for embedded; `wire_voice_controls` for daemon — mutually exclusive, no double-connect); speak the reply in the `CompleteStreaming` effect hook.
- `src/widgets/input_bar.rs` — `set_text` to inject the dictated transcript.

## Path-dep wrinkle (reviewer note)

`adele-voice-module` (plus the `vad-silero`/`stt-whisper` adapters, used **only** to name the `Dictation<SileroVad, WhisperStt>` type for the stored field) are path-deps via a **new `voice` symlink** at `~/Projects/adelie-ai/.worktrees/adele-gtk/voice → <voice checkout>`, exactly mirroring the existing `desktop-assistant` symlink + `path = "../desktop-assistant/..."` mechanism. The symlink is a local, untracked dev artifact (same as desktop-assistant's); a fresh clone / CI needs the sibling `voice` checkout symlinked next to it. **No new third-party crates** beyond the voice workspace's existing transitive graph; `cargo audit` is clean across all 565 crates and `toml` 1.1.2 has no CVEs.

## Out of scope (flagged)

The Settings → **Voice tab** still targets the daemon `VoiceController`; in embedded mode it shows its existing "Voice service not available" message (the tab's wake-word toggle + daemon voice picker are inherently daemon-only per the epic). The embedded voice/backend is configured via `voice.toml`, not that tab. Surfacing embedded state in the tab is a possible follow-up but isn't part of this issue's acceptance.

## Verification

`just check` green: `cargo fmt -p adele-gtk --check`, `cargo clippy -p adele-gtk --all-targets -- -D warnings` (zero warnings), `cargo build`, `cargo test` (**164 passed**, 1 pre-existing ignored; +9 new). `--no-default-features` (non-WebKit fallback) still builds. The module + all adapters compile against this checkout via the path-dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)