### PR TITLE
refactor: adopt the shared client-common Connector

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -4,10 +4,7 @@ use std::sync::OnceLock;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::SignalEvent;
-use desktop_assistant_client_common::{
-    AssistantClient, ConnectionConfig, TransportClient, connect_transport,
-    transport::transport_label,
-};
+use desktop_assistant_client_common::{AssistantClient, ConnectionConfig, Connector};
 use gtk4::glib;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
@@ -25,13 +22,16 @@ fn runtime() -> &'static Runtime {
 
 /// Messages sent from async tasks back to the GTK main thread.
 pub enum UiMessage {
-    /// A freshly connected transport handed off to the GTK main thread.
-    /// `Arc<TransportClient>` is `Send`, so this rides the same channel as
+    /// A freshly connected [`Connector`] handed off to the GTK main thread.
+    /// `Arc<Connector>` is `Send`, so this rides the same channel as
     /// every other UI message (replacing the former dedicated `InternalMsg`
     /// channel). Sent by `connection_manager` immediately after `Connected`
     /// and before `ConversationsLoaded`, so the window's client cell is
-    /// populated before any handler that needs it runs.
-    ClientReady(Arc<TransportClient>),
+    /// populated before any handler that needs it runs. The `Connector` owns
+    /// the transport (`connector.client()`) and the signal stream; the window
+    /// shares this same handle wherever it previously held an
+    /// `Arc<TransportClient>`.
+    ClientReady(Arc<Connector>),
     ConversationsLoaded(Vec<desktop_assistant_client_common::ConversationSummary>),
     ConversationLoaded(desktop_assistant_client_common::ConversationDetail),
     ConversationCreated {
@@ -146,15 +146,15 @@ pub enum UiMessage {
     },
 }
 
-// Manual `Debug` (can't derive: `TransportClient` is not `Debug`). Only
+// Manual `Debug` (can't derive: `Connector` is not `Debug`). Only
 // `ClientReady` needs special handling — it prints a marker instead of the
-// opaque transport; every other variant forwards its fields as before so
+// opaque connector; every other variant forwards its fields as before so
 // the test panic messages stay informative.
 impl std::fmt::Debug for UiMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             UiMessage::ClientReady(_) => {
-                f.debug_tuple("ClientReady").field(&"<transport>").finish()
+                f.debug_tuple("ClientReady").field(&"<connector>").finish()
             }
             UiMessage::ConversationsLoaded(v) => {
                 f.debug_tuple("ConversationsLoaded").field(v).finish()
@@ -328,21 +328,29 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
     let mut backoff_secs = INITIAL_BACKOFF_SECS;
 
     loop {
-        match connect_transport(&config).await {
-            Ok((transport, mut signal_rx)) => {
+        match Connector::connect(&config).await {
+            Ok(connector) => {
                 backoff_secs = INITIAL_BACKOFF_SECS;
-                let transport = Arc::new(transport);
+                // Subscribe before issuing any prompt so no early chunk is
+                // lost; the fanout pump inside the `Connector` keeps running as
+                // long as the `Arc<Connector>` is alive (held by the window).
+                let mut signal_rx = connector.subscribe();
+                let connector = Arc::new(connector);
+                // `client()` borrows the transport owned by the `Connector`;
+                // the connector outlives every use below (and the shared
+                // `Arc` clone handed to the GTK thread keeps the pump alive).
+                let transport = connector.client();
 
-                let label = transport_label(&config);
+                let label = connector.label().to_string();
                 if ui_tx.send(UiMessage::Connected { label }).is_err() {
                     return;
                 }
 
-                // Hand the transport to the GTK main thread before the
+                // Hand the connector to the GTK main thread before the
                 // conversation list (which needs it). Same channel, so
                 // delivery stays ordered.
                 if ui_tx
-                    .send(UiMessage::ClientReady(Arc::clone(&transport)))
+                    .send(UiMessage::ClientReady(Arc::clone(&connector)))
                     .is_err()
                 {
                     return;
@@ -387,7 +395,7 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
                 // selection (issue #53). Graceful: on failure (or a D-Bus
                 // transport that doesn't carry GetPurposes) we send `None` and
                 // the picker degrades to its last-resort "Model" label.
-                let default_model = match crate::management_client::get_purposes(&transport).await {
+                let default_model = match crate::management_client::get_purposes(transport).await {
                     Ok(purposes) => interactive_default_from_purposes(&purposes),
                     Err(e) => {
                         tracing::warn!("get_purposes failed; default model unresolved: {e}");
@@ -441,7 +449,10 @@ pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::Unbounded
                 // `ListBackgroundTasks` snapshot above seeds the panel; the
                 // streaming arms in `match signal` keep it live.
 
-                // Forward signals until disconnect
+                // Forward signals until disconnect. The `Connector`'s fanout
+                // emits a terminal `SignalEvent::Disconnected` and then closes
+                // this receiver when the underlying stream ends, so the normal
+                // path already delivers a `UiMessage::Disconnected` here.
                 while let Some(signal) = signal_rx.recv().await {
                     if ui_tx.send(signal_to_ui_message(signal)).is_err() {
                         return;

--- a/src/widgets/knowledge_browser.rs
+++ b/src/widgets/knowledge_browser.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
-use desktop_assistant_client_common::{AssistantClient, TransportClient};
+use desktop_assistant_client_common::{AssistantClient, Connector};
 use gtk4::prelude::*;
 use gtk4::{
     Align, ApplicationWindow, Box as GtkBox, Button, Entry, HeaderBar, Label, ListBox, ListBoxRow,
@@ -61,7 +61,7 @@ impl KnowledgeBrowser {
     /// Build the popup. Caller is responsible for `.present()`-ing it.
     pub fn new(
         parent: &ApplicationWindow,
-        transport: Arc<TransportClient>,
+        transport: Arc<Connector>,
         bridge: Rc<AsyncBridge>,
     ) -> Self {
         let window = Window::builder()
@@ -243,10 +243,11 @@ impl KnowledgeBrowser {
                 let transport = Arc::clone(&transport);
                 let msg_tx = msg_tx.clone();
                 bridge.spawn(async move {
+                    let client = transport.client();
                     let result = if query.trim().is_empty() {
-                        transport.list_knowledge_entries(LIST_LIMIT, 0, None).await
+                        client.list_knowledge_entries(LIST_LIMIT, 0, None).await
                     } else {
-                        transport
+                        client
                             .search_knowledge_entries(&query, None, SEARCH_LIMIT)
                             .await
                     };
@@ -511,14 +512,15 @@ impl KnowledgeBrowser {
                 let msg_tx = msg_tx.clone();
                 let content_owned = content.clone();
                 bridge.spawn(async move {
+                    let client = transport.client();
                     let result = match selected_id {
                         Some(id) => {
-                            transport
+                            client
                                 .update_knowledge_entry(&id, &content_owned, tags, metadata)
                                 .await
                         }
                         None => {
-                            transport
+                            client
                                 .create_knowledge_entry(&content_owned, tags, metadata)
                                 .await
                         }
@@ -601,7 +603,10 @@ impl KnowledgeBrowser {
                         let transport = Arc::clone(&transport);
                         let msg_tx = msg_tx.clone();
                         bridge.spawn(async move {
-                            let result = transport.delete_knowledge_entry(&id_for_async).await;
+                            let result = transport
+                                .client()
+                                .delete_knowledge_entry(&id_for_async)
+                                .await;
                             let _ = match result {
                                 Ok(()) => {
                                     msg_tx.send(BrowserMsg::EntryDeleted { id: id_for_async })

--- a/src/widgets/settings_dialog.rs
+++ b/src/widgets/settings_dialog.rs
@@ -6,8 +6,9 @@
 //! of RPCs).
 //!
 //! Async wiring mirrors `widgets/knowledge_browser.rs`: the dialog is
-//! handed an `Arc<TransportClient>` (resolved once by the caller) and an
-//! `Rc<AsyncBridge>`. Each RPC is dispatched on the tokio runtime via
+//! handed an `Arc<Connector>` (resolved once by the caller) and an
+//! `Rc<AsyncBridge>`. Management RPCs go through the connector's transport
+//! (`connector.client()`). Each RPC is dispatched on the tokio runtime via
 //! `bridge.spawn`, with results routed back to the GTK main thread through
 //! a short-lived `tokio::sync::mpsc` channel consumed by
 //! `glib::spawn_future_local`. Surface-level errors go to the window status
@@ -20,7 +21,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
-use desktop_assistant_client_common::TransportClient;
+use desktop_assistant_client_common::Connector;
 use gtk4::prelude::*;
 use gtk4::{Align, Box as GtkBox, Button, Label, Notebook, Orientation, Window, glib};
 use tokio::sync::mpsc;
@@ -99,17 +100,18 @@ fn confirm<F>(
     dialog.present();
 }
 
-/// Present the Settings dialog modally against `parent`, using `transport`
-/// for all RPC traffic. `bridge` provides the tokio runtime + the shared
-/// ui-message channel so errors propagate back to the window status bar.
+/// Present the Settings dialog modally against `parent`, using `connector`
+/// for all RPC traffic (management commands go through `connector.client()`).
+/// `bridge` provides the tokio runtime + the shared ui-message channel so
+/// errors propagate back to the window status bar.
 ///
 /// `voice` is the handle to the standalone voice daemon (a *separate* D-Bus
-/// service from `transport`'s orchestrator); it backs the Voice tab's wake-word
-/// toggle and voice picker. The tab degrades gracefully when the daemon is
-/// absent.
+/// service from the connector's orchestrator); it backs the Voice tab's
+/// wake-word toggle and voice picker. The tab degrades gracefully when the
+/// daemon is absent.
 pub fn show_settings_dialog(
     parent: &impl IsA<Window>,
-    transport: Arc<TransportClient>,
+    transport: Arc<Connector>,
     bridge: Rc<AsyncBridge>,
     voice: VoiceController,
 ) {
@@ -195,22 +197,22 @@ pub fn show_settings_dialog(
 
             let transport_for_task = Arc::clone(&transport);
             bridge.spawn(async move {
-                let conns = management_client::list_connections(&transport_for_task)
+                let client = transport_for_task.client();
+                let conns = management_client::list_connections(client)
                     .await
                     .map_err(|e| e.to_string());
                 let _ = tx_conn.send(conns);
 
-                let purposes = management_client::get_purposes(&transport_for_task)
+                let purposes = management_client::get_purposes(client)
                     .await
                     .map_err(|e| e.to_string());
                 let _ = tx_purposes.send(purposes);
 
                 // Aggregated list (None connection_id) populates model
                 // caches for every healthy connection at once.
-                let models =
-                    management_client::list_available_models(&transport_for_task, None, false)
-                        .await
-                        .map_err(|e| e.to_string());
+                let models = management_client::list_available_models(client, None, false)
+                    .await
+                    .map_err(|e| e.to_string());
                 let _ = tx_models.send(models);
             });
 
@@ -286,9 +288,10 @@ pub fn show_settings_dialog(
                     let ui_tx = bridge.ui_sender();
                     let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
                     bridge.spawn(async move {
-                        let r = management_client::create_connection(&transport, id, config)
-                            .await
-                            .map_err(|e| e.to_string());
+                        let r =
+                            management_client::create_connection(transport.client(), id, config)
+                                .await
+                                .map_err(|e| e.to_string());
                         let _ = tx.send(r);
                     });
                     glib::spawn_future_local(async move {
@@ -362,9 +365,10 @@ pub fn show_settings_dialog(
                     let ui_tx = bridge_save.ui_sender();
                     let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
                     bridge_save.spawn(async move {
-                        let r = management_client::update_connection(&transport, id, config)
-                            .await
-                            .map_err(|e| e.to_string());
+                        let r =
+                            management_client::update_connection(transport.client(), id, config)
+                                .await
+                                .map_err(|e| e.to_string());
                         let _ = tx.send(r);
                     });
                     glib::spawn_future_local(async move {
@@ -385,7 +389,7 @@ pub fn show_settings_dialog(
                     let ui_tx = bridge_refresh.ui_sender();
                     bridge_refresh.spawn(async move {
                         let r = management_client::list_available_models(
-                            &transport,
+                            transport.client(),
                             Some(id_for_refresh),
                             true,
                         )
@@ -450,7 +454,7 @@ pub fn show_settings_dialog(
             let ui_tx = bridge.ui_sender();
             let (tx, mut rx) = mpsc::unbounded_channel::<Result<(), String>>();
             bridge.spawn(async move {
-                let r = management_client::set_purpose(&transport, purpose, config).await;
+                let r = management_client::set_purpose(transport.client(), purpose, config).await;
                 let _ = tx.send(r.map_err(|e| e.to_string()));
             });
             glib::spawn_future_local(async move {
@@ -481,7 +485,7 @@ pub fn show_settings_dialog(
             let connection_id_for_task = connection_id.clone();
             bridge.spawn(async move {
                 let r = management_client::list_available_models(
-                    &transport,
+                    transport.client(),
                     Some(connection_id_for_task),
                     false,
                 )
@@ -611,7 +615,7 @@ fn wire_voice_tab(voice_tab: &Rc<VoiceTab>, voice: &VoiceController, bridge: &Rc
 /// the daemon rewires referencing purposes to fall back to interactive.
 fn do_remove_connection(
     parent: &impl IsA<Window>,
-    transport: Arc<TransportClient>,
+    transport: Arc<Connector>,
     bridge: Rc<AsyncBridge>,
     refresh: Rc<dyn Fn()>,
     id: String,
@@ -622,7 +626,9 @@ fn do_remove_connection(
     let transport_for_task = Arc::clone(&transport);
     let id_for_task = id.clone();
     bridge.spawn(async move {
-        let r = management_client::delete_connection(&transport_for_task, id_for_task, force).await;
+        let r =
+            management_client::delete_connection(transport_for_task.client(), id_for_task, force)
+                .await;
         let _ = tx.send(r.map_err(|e| e.to_string()));
     });
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{
-    AssistantClient, ChatMessage, ConnectionConfig, ConversationDetail, ConversationSummary,
-    TransportClient,
+    AssistantClient, ChatMessage, ConnectionConfig, Connector, ConversationDetail,
+    ConversationSummary,
 };
 use gtk4::prelude::*;
 use gtk4::{
@@ -49,8 +49,8 @@ struct WindowState {
 /// Effects are emitted in the exact order the legacy `handle_ui_message`
 /// performed them, so the observable behavior is identical.
 enum Effect {
-    /// Stash the freshly connected transport in the window's client cell.
-    SetClient(Arc<TransportClient>),
+    /// Stash the freshly connected connector in the window's client cell.
+    SetClient(Arc<Connector>),
     /// Clear the client cell (on disconnect).
     ClearClient,
     /// Set the bottom status-bar text verbatim.
@@ -116,14 +116,14 @@ enum Effect {
     RefreshSidePaneTasks,
 }
 
-// Manual `Debug` (can't derive: `TransportClient` is not `Debug`, mirroring
+// Manual `Debug` (can't derive: `Connector` is not `Debug`, mirroring
 // `UiMessage`). Only `SetClient` needs special handling — it prints a marker
-// instead of the opaque transport; every other variant forwards its fields so
+// instead of the opaque connector; every other variant forwards its fields so
 // test panic messages stay informative.
 impl std::fmt::Debug for Effect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Effect::SetClient(_) => f.debug_tuple("SetClient").field(&"<transport>").finish(),
+            Effect::SetClient(_) => f.debug_tuple("SetClient").field(&"<connector>").finish(),
             Effect::ClearClient => f.write_str("ClearClient"),
             Effect::SetStatusText(t) => f.debug_tuple("SetStatusText").field(t).finish(),
             Effect::SetSendSensitive(b) => f.debug_tuple("SetSendSensitive").field(b).finish(),
@@ -178,12 +178,12 @@ impl WindowState {
     /// effects into widget calls.
     fn apply(&mut self, msg: UiMessage) -> Vec<Effect> {
         match msg {
-            UiMessage::ClientReady(transport) => {
+            UiMessage::ClientReady(connector) => {
                 // The connection_manager handed us a freshly connected
-                // transport. Stash it so the rest of the UI can issue RPCs;
+                // connector. Stash it so the rest of the UI can issue RPCs;
                 // this arrives before `ConversationsLoaded`, which relies on
                 // the client cell.
-                vec![Effect::SetClient(transport)]
+                vec![Effect::SetClient(connector)]
             }
             UiMessage::ConversationsLoaded(convs) => {
                 self.conversations = convs.clone();
@@ -742,8 +742,10 @@ impl AdelieWindow {
         // hook reads + clears it in the effect executor.
         let voice_reply_pending: Rc<Cell<bool>> = Rc::new(Cell::new(false));
 
-        // Client wrapped in Arc for async tasks, Rc<RefCell<>> for GTK thread
-        let client: Rc<RefCell<Option<Arc<TransportClient>>>> = Rc::new(RefCell::new(None));
+        // Connector wrapped in Arc for async tasks, Rc<RefCell<>> for GTK
+        // thread. The `Connector` owns the transport; call `.client()` for the
+        // `&TransportClient` surface (`as_commands()`, `AssistantClient` RPCs).
+        let client: Rc<RefCell<Option<Arc<Connector>>>> = Rc::new(RefCell::new(None));
 
         // Set up async bridge with UI message handler
         let bridge = AsyncBridge::new(glib::clone!(
@@ -824,11 +826,11 @@ impl AdelieWindow {
                 let Some(conv) = state.borrow().current_conversation_id.clone() else {
                     return;
                 };
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     return;
                 };
                 crate::async_bridge::spawn_on_runtime(async move {
-                    let Some(cmds) = transport.as_commands() else {
+                    let Some(cmds) = connector.client().as_commands() else {
                         return;
                     };
                     let result = match action {
@@ -856,11 +858,11 @@ impl AdelieWindow {
             #[strong]
             client,
             move |id: String| {
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     return;
                 };
                 crate::async_bridge::spawn_on_runtime(async move {
-                    if let Some(cmds) = transport.as_commands() {
+                    if let Some(cmds) = connector.client().as_commands() {
                         let _ = cmds
                             .send_command(api::Command::CancelBackgroundTask { id })
                             .await;
@@ -870,7 +872,7 @@ impl AdelieWindow {
         ));
 
         // Spawn persistent connection manager (connect → forward → reconnect).
-        // It now delivers the freshly connected transport to the main thread
+        // It now delivers the freshly connected `Connector` to the main thread
         // via `UiMessage::ClientReady` on the same channel as every other UI
         // message (handled in `handle_ui_message`).
         {
@@ -893,10 +895,10 @@ impl AdelieWindow {
                     let conv_id = conv.id.clone();
                     drop(state_borrow);
 
-                    if let Some(client) = client.borrow().clone() {
+                    if let Some(connector) = client.borrow().clone() {
                         let tx = bridge.ui_sender();
                         bridge.spawn(async move {
-                            match client.get_conversation(&conv_id).await {
+                            match connector.client().get_conversation(&conv_id).await {
                                 Ok(detail) => {
                                     let _ = tx.send(UiMessage::ConversationLoaded(detail));
                                 }
@@ -918,9 +920,10 @@ impl AdelieWindow {
             #[strong]
             bridge,
             move |_| {
-                if let Some(client) = client.borrow().clone() {
+                if let Some(connector) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     bridge.spawn(async move {
+                        let client = connector.client();
                         match client.create_conversation("New Conversation").await {
                             Ok(id) => {
                                 let _ = tx.send(UiMessage::ConversationCreated { id: id.clone() });
@@ -959,11 +962,11 @@ impl AdelieWindow {
                         None => return,
                     }
                 };
-                if let Some(client) = client.borrow().clone() {
+                if let Some(connector) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     let id = id.clone();
                     bridge.spawn(async move {
-                        match client.delete_conversation(&id).await {
+                        match connector.client().delete_conversation(&id).await {
                             Ok(()) => {
                                 let _ = tx.send(UiMessage::ConversationDeleted { id });
                             }
@@ -1046,12 +1049,12 @@ impl AdelieWindow {
                             return;
                         }
                         dialog.close();
-                        if let Some(client) = client.borrow().clone() {
+                        if let Some(connector) = client.borrow().clone() {
                             let tx = bridge.ui_sender();
                             let id = id.clone();
                             let title = new_title.clone();
                             bridge.spawn(async move {
-                                match client.rename_conversation(&id, &title).await {
+                                match connector.client().rename_conversation(&id, &title).await {
                                     Ok(()) => {
                                         let _ =
                                             tx.send(UiMessage::ConversationRenamed { id, title });
@@ -1099,10 +1102,11 @@ impl AdelieWindow {
                         None => return,
                     }
                 };
-                if let Some(client) = client.borrow().clone() {
+                if let Some(connector) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     let id = id.clone();
                     bridge.spawn(async move {
+                        let client = connector.client();
                         let result = if archived {
                             client.unarchive_conversation(&id).await
                         } else {
@@ -1132,9 +1136,10 @@ impl AdelieWindow {
             #[strong]
             bridge,
             move |include_archived| {
-                if let Some(client) = client.borrow().clone() {
+                if let Some(connector) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
                     bridge.spawn(async move {
+                        let client = connector.client();
                         let result = if include_archived {
                             client.list_conversations_with_archived().await
                         } else {
@@ -1198,10 +1203,11 @@ impl AdelieWindow {
 
                     let override_selection = model_picker.current_override();
 
-                    if let Some(client) = client.borrow().clone() {
+                    if let Some(connector) = client.borrow().clone() {
                         let tx = bridge_ref.ui_sender();
                         let text = text.clone();
                         bridge_ref.spawn(async move {
+                            let client = connector.client();
                             // Use the command-channel override path when
                             // available so the picker's selection is honoured.
                             // The shared AssistantClient trait can't carry the
@@ -1307,11 +1313,11 @@ impl AdelieWindow {
             voice,
             move |_| {
                 menu_popover.popdown();
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     status_label.set_text("Not connected — settings unavailable");
                     return;
                 };
-                if transport.as_commands().is_none() {
+                if connector.client().as_commands().is_none() {
                     status_label.set_text(
                         "Settings require a local-socket or WebSocket connection (not available over D-Bus)",
                     );
@@ -1328,7 +1334,7 @@ impl AdelieWindow {
                 };
                 crate::widgets::settings_dialog::show_settings_dialog(
                     &window,
-                    Arc::clone(&transport),
+                    Arc::clone(&connector),
                     Rc::clone(&bridge),
                     voice_handle,
                 );
@@ -1339,7 +1345,8 @@ impl AdelieWindow {
                 // changes); the dialog itself keeps its own tabs in sync.
                 let tx = bridge.ui_sender();
                 bridge.spawn(async move {
-                    match management_client::list_available_models(&transport, None, false).await {
+                    let transport = connector.client();
+                    match management_client::list_available_models(transport, None, false).await {
                         Ok(listings) => {
                             let _ = tx.send(UiMessage::ModelsLoaded(listings));
                         }
@@ -1352,7 +1359,7 @@ impl AdelieWindow {
                     // still on the default (issue #53). Graceful: on failure we
                     // emit `None` (picker degrades to "Model").
                     let default_model =
-                        match management_client::get_purposes(&transport).await {
+                        match management_client::get_purposes(transport).await {
                             Ok(purposes) => {
                                 crate::async_bridge::interactive_default_from_purposes(&purposes)
                             }
@@ -1382,13 +1389,13 @@ impl AdelieWindow {
             status_label,
             move |_| {
                 menu_popover.popdown();
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     status_label.set_text("Not connected — knowledge base unavailable");
                     return;
                 };
                 let browser = crate::widgets::knowledge_browser::KnowledgeBrowser::new(
                     &window,
-                    transport,
+                    connector,
                     Rc::clone(&bridge),
                 );
                 browser.present();
@@ -1423,11 +1430,11 @@ impl AdelieWindow {
                 state.borrow_mut().debug_enabled = btn.is_active();
                 let conv_id = state.borrow().current_conversation_id.clone();
                 if let Some(conv_id) = conv_id
-                    && let Some(client) = client.borrow().clone()
+                    && let Some(connector) = client.borrow().clone()
                 {
                     let tx = bridge.ui_sender();
                     bridge.spawn(async move {
-                        match client.get_conversation(&conv_id).await {
+                        match connector.client().get_conversation(&conv_id).await {
                             Ok(detail) => {
                                 let _ = tx.send(UiMessage::ConversationLoaded(detail));
                             }
@@ -1454,12 +1461,12 @@ impl AdelieWindow {
             #[strong]
             bridge,
             move |task_id| {
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     return;
                 };
                 let tx = bridge.ui_sender();
                 bridge.spawn(async move {
-                    let Some(cmds) = transport.as_commands() else {
+                    let Some(cmds) = connector.client().as_commands() else {
                         let _ = tx.send(UiMessage::Error(
                             "Background tasks require a local-socket or WebSocket connection \
                              (not available over D-Bus)"
@@ -1486,12 +1493,12 @@ impl AdelieWindow {
             stack,
             move |conv_id| {
                 stack.set_visible_child_name("conversations");
-                let Some(transport) = client.borrow().clone() else {
+                let Some(connector) = client.borrow().clone() else {
                     return;
                 };
                 let tx = bridge.ui_sender();
                 bridge.spawn(async move {
-                    match transport.get_conversation(&conv_id).await {
+                    match connector.client().get_conversation(&conv_id).await {
                         Ok(detail) => {
                             let _ = tx.send(UiMessage::ConversationLoaded(detail));
                         }
@@ -1773,7 +1780,7 @@ fn handle_ui_message(
     sidebar: &Rc<Sidebar>,
     chat_view: &Rc<RefCell<ChatView>>,
     status_label: &Rc<Label>,
-    client: &Rc<RefCell<Option<Arc<TransportClient>>>>,
+    client: &Rc<RefCell<Option<Arc<Connector>>>>,
     input_bar: &Rc<InputBar>,
     model_picker: &Rc<ModelPicker>,
     tasks_panel: &Rc<TasksPanel>,
@@ -1799,8 +1806,8 @@ fn handle_ui_message(
     // Thin executor: perform each effect against the real widgets, in order.
     for effect in effects {
         match effect {
-            Effect::SetClient(transport) => {
-                *client.borrow_mut() = Some(transport);
+            Effect::SetClient(connector) => {
+                *client.borrow_mut() = Some(connector);
             }
             Effect::ClearClient => {
                 *client.borrow_mut() = None;
@@ -1886,10 +1893,10 @@ fn handle_ui_message(
                 tasks_panel.handle_task_completed(id, now_epoch_ms());
             }
             Effect::FetchScratchpad(conversation_id) => {
-                if let Some(transport) = client.borrow().clone() {
+                if let Some(connector) = client.borrow().clone() {
                     let tx = ui_tx.clone();
                     crate::async_bridge::spawn_on_runtime(async move {
-                        let Some(cmds) = transport.as_commands() else {
+                        let Some(cmds) = connector.client().as_commands() else {
                             return;
                         };
                         match cmds
@@ -1932,7 +1939,7 @@ fn handle_ui_message(
 fn ensure_active_conversation(
     state: &Rc<RefCell<WindowState>>,
     sidebar: &Rc<Sidebar>,
-    client: &Rc<RefCell<Option<Arc<TransportClient>>>>,
+    client: &Rc<RefCell<Option<Arc<Connector>>>>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
     let (target_id, target_index) = {
@@ -1953,7 +1960,7 @@ fn ensure_active_conversation(
         }
     };
 
-    let Some(transport) = client.borrow().clone() else {
+    let Some(connector) = client.borrow().clone() else {
         // Not connected yet — connection_manager will resend
         // ConversationsLoaded once the transport is up, and we'll re-run.
         return;
@@ -1964,7 +1971,7 @@ fn ensure_active_conversation(
         (Some(id), Some(idx)) => {
             sidebar.select_index(idx);
             crate::async_bridge::spawn_on_runtime(async move {
-                match transport.get_conversation(&id).await {
+                match connector.client().get_conversation(&id).await {
                     Ok(detail) => {
                         let _ = tx.send(UiMessage::ConversationLoaded(detail));
                     }
@@ -1976,13 +1983,14 @@ fn ensure_active_conversation(
         }
         _ => {
             crate::async_bridge::spawn_on_runtime(async move {
-                match transport.create_conversation("New Conversation").await {
+                let client = connector.client();
+                match client.create_conversation("New Conversation").await {
                     Ok(id) => {
                         let _ = tx.send(UiMessage::ConversationCreated { id: id.clone() });
-                        if let Ok(convs) = transport.list_conversations().await {
+                        if let Ok(convs) = client.list_conversations().await {
                             let _ = tx.send(UiMessage::ConversationsLoaded(convs));
                         }
-                        if let Ok(detail) = transport.get_conversation(&id).await {
+                        if let Ok(detail) = client.get_conversation(&id).await {
                             let _ = tx.send(UiMessage::ConversationLoaded(detail));
                         }
                     }


### PR DESCRIPTION
Closes #67

## What

Adopt the high-level **`Connector`** from `client-common` (desktop-assistant#203) for connect + signal subscription, replacing the bespoke `connect_transport` + `Arc<TransportClient>` + manual signal-loop wiring. The `Connector` owns the transport **and** the daemon's signal stream, fanning every `SignalEvent` to any number of `subscribe()`rs — same wrapper voice migrated onto (voice#37).

This is a **wrapper adoption only**. GTK was already transport-generic via `transport.as_commands()` (adele-gtk#49), so there is no `as_ws()` cleanup here. All behavior is identical across UDS / WS / D-Bus.

## Mapping

`Arc<Connector>` is the new shared, `Send`, cheaply-cloneable handle, mirroring the old `Arc<TransportClient>` exactly (the `Connector` owns the `TransportClient` and only hands out `&TransportClient` via `client()`, so the window/widgets hold the connector and call `.client()` at each RPC site).

## Per-file

- **src/async_bridge.rs** — `connection_manager` connects via `Connector::connect`, subscribes with `connector.subscribe()` (before the first prompt, as the docs require), reads `connector.label()`, and uses `connector.client()` for the on-connect command work. `UiMessage::ClientReady` now carries `Arc<Connector>`; Debug marker + docs updated. The fanout's terminal `SignalEvent::Disconnected` already drives `UiMessage::Disconnected` on the normal path; the post-loop defensive Disconnected is retained.
- **src/window.rs** — the shared client cell (`Rc<RefCell<Option<Arc<Connector>>>>`), `Effect::SetClient`, and the two helper signatures (`handle_ui_message`, `ensure_active_conversation`) hold `Arc<Connector>`. Every RPC site (sidebar load/new/delete/rename/archive, send, scratchpad, tasks-cancel, settings/KB gates, debug reload, ensure-active) calls `connector.client()` for the `&TransportClient` surface. All `as_commands()` transport-generic logic is unchanged.
- **src/widgets/settings_dialog.rs** — `show_settings_dialog` + `do_remove_connection` take `Arc<Connector>`; management RPCs route through `connector.client()`.
- **src/widgets/knowledge_browser.rs** — `KnowledgeBrowser::new` takes `Arc<Connector>`; KB RPCs route through `connector.client()`.
- **src/management_client.rs** — unchanged. Its `&TransportClient` wrappers are kept (per the issue); callers now pass `connector.client()`.
- **src/voice_client.rs** — unchanged. It talks to the **separate** voice daemon (`org.desktopAssistant.Voice`) directly over zbus and never used the orchestrator `TransportClient`.

## Verification

`just check` (fmt + clippy `-D warnings` + build + tests) is green: **164 passed; 0 failed; 1 ignored**. The pre-push hook re-ran it on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)