### PR TITLE
feat: per-conversation personality picker (#70)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-core",
  "anyhow",
+ "tokio",
  "tracing",
  "whisper-rs",
 ]

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -562,6 +562,14 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
         SignalEvent::ScratchpadChanged { conversation_id } => {
             UiMessage::ScratchpadChanged { conversation_id }
         }
+        // Client-local MCP tool execution (#107/#231) is not implemented in the
+        // GTK client — it has no local tool runtime to satisfy the call. Surface
+        // it as a status string so the parked turn is at least visible; the
+        // daemon eventually times the suspended call out. Wiring real
+        // client-side tool execution here is a separate feature.
+        SignalEvent::ClientToolCall { tool_name, .. } => UiMessage::StatusUpdate(format!(
+            "Assistant requested a client-side tool ({tool_name}) this client can't run."
+        )),
         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
     }
 }

--- a/src/management_client.rs
+++ b/src/management_client.rs
@@ -118,6 +118,22 @@ pub async fn set_purpose(
     expect_ack("SetPurpose", result)
 }
 
+/// Set (or clear) a conversation's personality override (#70 / daemon #227).
+/// `personality` is a *partial* override: each `Some` trait pins that trait for
+/// the conversation, each `None` inherits the global config. An all-`None`
+/// override clears it. Returns the stored value after the write. Routes through
+/// the `set_conversation_personality` default method on the command channel, so
+/// the result-envelope handling stays in `client-common`.
+pub async fn set_conversation_personality(
+    transport: &TransportClient,
+    conversation_id: &str,
+    personality: api::ConversationPersonalityView,
+) -> Result<api::ConversationPersonalityView> {
+    commands(transport)?
+        .set_conversation_personality(conversation_id, personality)
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod input_bar;
 pub mod knowledge_browser;
 pub mod login_screen;
 pub mod model_picker;
+pub mod personality_dialog;
 pub mod purposes_tab;
 pub mod select_models_dialog;
 pub mod settings_dialog;

--- a/src/widgets/personality_dialog.rs
+++ b/src/widgets/personality_dialog.rs
@@ -1,0 +1,301 @@
+//! Per-conversation personality picker (#70). A modal dialog with one row per
+//! "Expressive 7" trait. Each row is a `DropDown` offering **Global** (inherit
+//! the daemon's global disposition) plus the five concrete levels
+//! (Never/Rarely/Sometimes/Often/Always).
+//!
+//! Unlike the header model picker (a live per-send override), the personality
+//! override is persisted on the daemon: Save calls
+//! `set_conversation_personality` through the async bridge; the daemon stores
+//! the partial override and resolves each `None` trait against the global config
+//! on every send. An all-**Global** selection clears the override.
+//!
+//! The dropdown index ↔ override mapping is pure and unit-tested below so the
+//! "Global = None" / "level = Some" contract can't drift without a failing test.
+
+use std::rc::Rc;
+
+use desktop_assistant_api_model as api;
+use gtk4::prelude::*;
+use gtk4::{Align, Box as GtkBox, Button, DropDown, Label, Orientation, StringList, Window, glib};
+
+/// The "Expressive 7" traits, in the order the wire contract (#236) lists
+/// them: professionalism, warmth, directness, enthusiasm, humor, sarcasm,
+/// pretentiousness. The label is the user-facing row title.
+const TRAITS: [&str; 7] = [
+    "Professionalism",
+    "Warmth",
+    "Directness",
+    "Enthusiasm",
+    "Humor",
+    "Sarcasm",
+    "Pretentiousness",
+];
+
+/// The per-row dropdown entries. Index 0 is the "inherit global" sentinel; the
+/// remaining five are the concrete [`api::PersonalityLevel`] variants in
+/// ascending order.
+const ROW_OPTIONS: [&str; 6] = ["Global", "Never", "Rarely", "Sometimes", "Often", "Always"];
+
+/// Map a dropdown row index to a trait override value. Index 0 ("Global") is
+/// `None` (inherit); 1..=5 map to `Never`..=`Always`. Out-of-range indices fall
+/// back to `None` (inherit) rather than panicking, so a malformed selection
+/// degrades to the safe "inherit global" behaviour.
+fn level_from_index(index: u32) -> Option<api::PersonalityLevel> {
+    match index {
+        1 => Some(api::PersonalityLevel::Never),
+        2 => Some(api::PersonalityLevel::Rarely),
+        3 => Some(api::PersonalityLevel::Sometimes),
+        4 => Some(api::PersonalityLevel::Often),
+        5 => Some(api::PersonalityLevel::Always),
+        // 0 ("Global") and anything out of range → inherit.
+        _ => None,
+    }
+}
+
+/// Inverse of [`level_from_index`]: map a trait override value to its dropdown
+/// row index. `None` ("inherit global") is index 0.
+fn index_from_level(level: Option<api::PersonalityLevel>) -> u32 {
+    match level {
+        None => 0,
+        Some(api::PersonalityLevel::Never) => 1,
+        Some(api::PersonalityLevel::Rarely) => 2,
+        Some(api::PersonalityLevel::Sometimes) => 3,
+        Some(api::PersonalityLevel::Often) => 4,
+        Some(api::PersonalityLevel::Always) => 5,
+    }
+}
+
+/// Build a [`api::ConversationPersonalityView`] from the 7 dropdown indices, in
+/// the canonical trait order. All-`Global` (every index 0) yields the all-`None`
+/// override, which the daemon treats as "cleared".
+fn override_from_indices(indices: [u32; 7]) -> api::ConversationPersonalityView {
+    api::ConversationPersonalityView {
+        professionalism: level_from_index(indices[0]),
+        warmth: level_from_index(indices[1]),
+        directness: level_from_index(indices[2]),
+        enthusiasm: level_from_index(indices[3]),
+        humor: level_from_index(indices[4]),
+        sarcasm: level_from_index(indices[5]),
+        pretentiousness: level_from_index(indices[6]),
+    }
+}
+
+/// Inverse of [`override_from_indices`]: derive the 7 dropdown indices from a
+/// stored override so the dialog pre-fills. A missing override (`None`) pre-fills
+/// every row to "Global" (index 0).
+fn indices_from_override(over: Option<&api::ConversationPersonalityView>) -> [u32; 7] {
+    let over = match over {
+        Some(o) => o,
+        None => return [0; 7],
+    };
+    [
+        index_from_level(over.professionalism),
+        index_from_level(over.warmth),
+        index_from_level(over.directness),
+        index_from_level(over.enthusiasm),
+        index_from_level(over.humor),
+        index_from_level(over.sarcasm),
+        index_from_level(over.pretentiousness),
+    ]
+}
+
+/// Show the per-conversation personality picker as a modal dialog.
+///
+/// `prefill` is the conversation's stored override (from
+/// `ConversationDetail::conversation_personality`); each trait pre-selects
+/// "Global" when its value is `None`. On Save, `on_save` is invoked with the
+/// assembled [`api::ConversationPersonalityView`] (all-`None` = clear); Cancel
+/// discards without calling it.
+pub fn show_personality_dialog<F>(
+    parent: &impl IsA<Window>,
+    prefill: Option<&api::ConversationPersonalityView>,
+    on_save: F,
+) where
+    F: Fn(api::ConversationPersonalityView) + 'static,
+{
+    let dialog = Window::builder()
+        .title("Conversation Personality")
+        .transient_for(parent)
+        .modal(true)
+        .default_width(420)
+        .build();
+
+    let outer = GtkBox::new(Orientation::Vertical, 0);
+
+    let intro = Label::new(Some(
+        "Tune this conversation's personality. Each trait set to \
+         \"Global\" inherits your global setting; pin a level to override it \
+         for this conversation only.",
+    ));
+    intro.set_wrap(true);
+    intro.set_xalign(0.0);
+    intro.set_margin_start(16);
+    intro.set_margin_end(16);
+    intro.set_margin_top(16);
+    intro.set_margin_bottom(12);
+    outer.append(&intro);
+
+    let prefill_indices = indices_from_override(prefill);
+
+    // One row per trait: a label on the left, a dropdown on the right. The
+    // dropdowns are collected so Save can read every selection at once.
+    let dropdowns: Rc<Vec<DropDown>> = Rc::new(
+        TRAITS
+            .iter()
+            .enumerate()
+            .map(|(i, trait_name)| {
+                let row = GtkBox::new(Orientation::Horizontal, 8);
+                row.set_margin_start(16);
+                row.set_margin_end(16);
+                row.set_margin_top(4);
+                row.set_margin_bottom(4);
+
+                let label = Label::new(Some(trait_name));
+                label.set_halign(Align::Start);
+                label.set_hexpand(true);
+                row.append(&label);
+
+                let options = StringList::new(&ROW_OPTIONS);
+                let dd = DropDown::new(Some(options), gtk4::Expression::NONE);
+                dd.set_selected(prefill_indices[i]);
+                row.append(&dd);
+
+                outer.append(&row);
+                dd
+            })
+            .collect(),
+    );
+
+    let btn_row = GtkBox::new(Orientation::Horizontal, 8);
+    btn_row.set_halign(Align::End);
+    btn_row.set_margin_top(12);
+    btn_row.set_margin_bottom(16);
+    btn_row.set_margin_start(16);
+    btn_row.set_margin_end(16);
+
+    let cancel = Button::with_label("Cancel");
+    cancel.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
+    btn_row.append(&cancel);
+
+    let save = Button::with_label("Save");
+    save.add_css_class("suggested-action");
+    save.connect_clicked(glib::clone!(
+        #[weak(rename_to = dialog_ref)]
+        dialog,
+        #[strong]
+        dropdowns,
+        move |_| {
+            let mut indices = [0u32; 7];
+            for (i, dd) in dropdowns.iter().enumerate() {
+                indices[i] = dd.selected();
+            }
+            let personality = override_from_indices(indices);
+            dialog_ref.close();
+            on_save(personality);
+        }
+    ));
+    btn_row.append(&save);
+
+    outer.append(&btn_row);
+
+    dialog.set_child(Some(&outer));
+    dialog.present();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_index_maps_to_none_and_back() {
+        assert_eq!(level_from_index(0), None);
+        assert_eq!(index_from_level(None), 0);
+    }
+
+    #[test]
+    fn every_level_round_trips_through_its_index() {
+        let levels = [
+            api::PersonalityLevel::Never,
+            api::PersonalityLevel::Rarely,
+            api::PersonalityLevel::Sometimes,
+            api::PersonalityLevel::Often,
+            api::PersonalityLevel::Always,
+        ];
+        for level in levels {
+            let idx = index_from_level(Some(level));
+            assert_eq!(level_from_index(idx), Some(level), "round-trip {level:?}");
+        }
+        // The five concrete levels occupy indices 1..=5.
+        assert_eq!(index_from_level(Some(api::PersonalityLevel::Never)), 1);
+        assert_eq!(index_from_level(Some(api::PersonalityLevel::Always)), 5);
+    }
+
+    #[test]
+    fn out_of_range_index_falls_back_to_inherit() {
+        // A malformed selection must degrade to "inherit global", never panic.
+        assert_eq!(level_from_index(6), None);
+        assert_eq!(level_from_index(u32::MAX), None);
+    }
+
+    #[test]
+    fn all_global_indices_produce_cleared_override() {
+        let over = override_from_indices([0; 7]);
+        assert_eq!(over, api::ConversationPersonalityView::default());
+        // Default is all-`None`, which the daemon treats as "cleared".
+        assert!(over.professionalism.is_none());
+        assert!(over.pretentiousness.is_none());
+    }
+
+    #[test]
+    fn indices_map_to_the_canonical_trait_order() {
+        // Distinct level per slot proves no two traits are swapped: assign
+        // index = position+1 so each trait gets a different level.
+        let over = override_from_indices([1, 2, 3, 4, 5, 1, 2]);
+        assert_eq!(over.professionalism, Some(api::PersonalityLevel::Never));
+        assert_eq!(over.warmth, Some(api::PersonalityLevel::Rarely));
+        assert_eq!(over.directness, Some(api::PersonalityLevel::Sometimes));
+        assert_eq!(over.enthusiasm, Some(api::PersonalityLevel::Often));
+        assert_eq!(over.humor, Some(api::PersonalityLevel::Always));
+        assert_eq!(over.sarcasm, Some(api::PersonalityLevel::Never));
+        assert_eq!(over.pretentiousness, Some(api::PersonalityLevel::Rarely));
+    }
+
+    #[test]
+    fn prefill_none_selects_global_for_every_row() {
+        assert_eq!(indices_from_override(None), [0; 7]);
+    }
+
+    #[test]
+    fn prefill_round_trips_a_partial_override() {
+        // Humor=Never, directness=Always, rest inherited — the issue's
+        // acceptance example.
+        let stored = api::ConversationPersonalityView {
+            humor: Some(api::PersonalityLevel::Never),
+            directness: Some(api::PersonalityLevel::Always),
+            ..api::ConversationPersonalityView::default()
+        };
+        let indices = indices_from_override(Some(&stored));
+        // Re-assembling from the pre-filled indices yields the same override.
+        assert_eq!(override_from_indices(indices), stored);
+        // Spot-check the two pinned slots land on the right rows.
+        assert_eq!(indices[2], 5, "directness → Always");
+        assert_eq!(indices[4], 1, "humor → Never");
+    }
+
+    #[test]
+    fn row_options_have_global_plus_five_levels() {
+        // The dropdown must offer exactly Global + the 5 levels, Global first.
+        assert_eq!(ROW_OPTIONS.len(), 6);
+        assert_eq!(ROW_OPTIONS[0], "Global");
+        // Each non-Global option maps to a distinct concrete level.
+        for idx in 1..ROW_OPTIONS.len() as u32 {
+            assert!(level_from_index(idx).is_some(), "option {idx} is a level");
+        }
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -584,6 +584,13 @@ impl AdelieWindow {
         knowledge_btn.set_halign(Align::Fill);
         menu_box.append(&knowledge_btn);
 
+        // Per-conversation personality override (#70). Opens a modal picker
+        // pre-filled from the active conversation's stored override.
+        let personality_btn = Button::with_label("Personality…");
+        personality_btn.add_css_class("context-button");
+        personality_btn.set_halign(Align::Fill);
+        menu_box.append(&personality_btn);
+
         let disconnect_btn = Button::with_label("Disconnect");
         disconnect_btn.add_css_class("context-button");
         disconnect_btn.set_halign(Align::Fill);
@@ -1402,6 +1409,99 @@ impl AdelieWindow {
             }
         ));
 
+        // Hamburger menu: Personality… → open the per-conversation personality
+        // picker (#70). Mirrors the model picker's gating: the override travels
+        // on the command channel (UDS/WS), which D-Bus doesn't expose. Pre-fills
+        // from the active conversation's stored override and, on Save, dispatches
+        // `set_conversation_personality` through the async bridge, then reloads
+        // the conversation so `current_conversation.conversation_personality`
+        // (the next pre-fill source) stays in sync with the daemon.
+        personality_btn.connect_clicked(glib::clone!(
+            #[weak]
+            menu_popover,
+            #[weak]
+            window,
+            #[strong]
+            client,
+            #[strong]
+            bridge,
+            #[strong]
+            status_label,
+            #[strong]
+            state,
+            move |_| {
+                menu_popover.popdown();
+                let Some(connector) = client.borrow().clone() else {
+                    status_label.set_text("Not connected — personality unavailable");
+                    return;
+                };
+                if connector.client().as_commands().is_none() {
+                    status_label.set_text(
+                        "Personality settings require a local-socket or WebSocket connection (not available over D-Bus)",
+                    );
+                    return;
+                }
+                let (conv_id, prefill) = {
+                    let s = state.borrow();
+                    let id = s.current_conversation_id.clone();
+                    let prefill = s
+                        .current_conversation
+                        .as_ref()
+                        .and_then(|c| c.conversation_personality);
+                    (id, prefill)
+                };
+                let Some(conv_id) = conv_id else {
+                    status_label.set_text("Open a conversation first to set its personality");
+                    return;
+                };
+
+                let bridge_for_save = Rc::clone(&bridge);
+                let connector_for_save = Arc::clone(&connector);
+                let status_for_save = status_label.clone();
+                crate::widgets::personality_dialog::show_personality_dialog(
+                    &window,
+                    prefill.as_ref(),
+                    move |personality| {
+                        let tx = bridge_for_save.ui_sender();
+                        let connector = Arc::clone(&connector_for_save);
+                        let conv_id = conv_id.clone();
+                        let status = status_for_save.clone();
+                        status.set_text("Saving personality…");
+                        bridge_for_save.spawn(async move {
+                            let transport = connector.client();
+                            match management_client::set_conversation_personality(
+                                transport,
+                                &conv_id,
+                                personality,
+                            )
+                            .await
+                            {
+                                Ok(_stored) => {
+                                    // Reload so the next pre-fill reflects the
+                                    // stored override (and any all-None clear).
+                                    match transport.get_conversation(&conv_id).await {
+                                        Ok(detail) => {
+                                            let _ = tx.send(UiMessage::ConversationLoaded(detail));
+                                        }
+                                        Err(e) => {
+                                            let _ = tx.send(UiMessage::Error(format!(
+                                                "Reload after personality save: {e}"
+                                            )));
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    let _ = tx.send(UiMessage::Error(format!(
+                                        "Save personality: {e}"
+                                    )));
+                                }
+                            }
+                        });
+                    },
+                );
+            }
+        ));
+
         // Hamburger menu: Disconnect → close this window, show login screen
         disconnect_btn.connect_clicked(glib::clone!(
             #[weak]
@@ -2056,6 +2156,7 @@ fn filter_messages(detail: &ConversationDetail, debug: bool) -> ConversationDeta
             .cloned()
             .collect(),
         model_selection: detail.model_selection.clone(),
+        conversation_personality: detail.conversation_personality,
     }
 }
 
@@ -2087,6 +2188,7 @@ mod tests {
             title: format!("conv {id}"),
             messages,
             model_selection: None,
+            conversation_personality: None,
         }
     }
 


### PR DESCRIPTION
Closes #70

## Summary
Adds a per-conversation **personality picker**, mirroring the existing per-conversation **model** picker. The user pins some/all of the "Expressive 7" traits for the active conversation; unpinned traits inherit the global personality. Backed by the client contract merged in desktop-assistant #236 (`set_conversation_personality`, surfaced via `as_commands()`).

## What changed
- **`src/widgets/personality_dialog.rs`** (new): a modal dialog with one `DropDown` per trait (order: professionalism, warmth, directness, enthusiasm, humor, sarcasm, pretentiousness). Each offers **Global** + Never/Rarely/Sometimes/Often/Always. The index↔override mapping is pure (`Global` = `None` inherit, a level = `Some`; all-`Global` = the all-`None` clear) and **unit-tested first**. Save invokes an `on_save` callback with the assembled `api::ConversationPersonalityView`; Cancel discards.
- **`src/management_client.rs`**: `set_conversation_personality` wrapper that resolves the command channel (UDS/WS) and delegates to the client-common default method, keeping the result-envelope handling in client-common.
- **`src/window.rs`**: a **"Personality…"** hamburger-menu entry. Mirrors the Settings handler's command-channel gating (D-Bus can't carry it), pre-fills from the active conversation's `ConversationDetail::conversation_personality`, and on Save dispatches the write through the async bridge (`bridge.spawn`), then reloads the conversation so the next pre-fill stays in sync with the daemon (including all-`None` clears).

## How it's launched + dispatched
Launch: hamburger menu → "Personality…" → `show_personality_dialog(&window, prefill, on_save)`, gated on a present command channel and an open conversation. Save dispatch: the `on_save` closure calls `management_client::set_conversation_personality(...)` inside `bridge.spawn(async ...)`, then `get_conversation` → `UiMessage::ConversationLoaded` to refresh state — the same async-bridge shape the model picker / knowledge browser use.

## Incidental path-dep drift fixes
The gtk worktree path-deps the live desktop-assistant checkout, which is ahead of gtk's `main`. Two unrelated fixes were required to compile:
- Handle the new `conversation_personality` field on `ConversationDetail` in `filter_messages` (preserve it) + a test helper.
- A graceful status-string arm for the new `SignalEvent::ClientToolCall` variant (#231) — gtk has no client-side tool runtime, so it surfaces a notice rather than running the tool. Real client-side tool execution is a separate feature.

## Verification
`just check` green: `cargo fmt -p adele-gtk --check`, `cargo clippy -p adele-gtk --all-targets -- -D warnings`, `cargo build`, `cargo test` — 172 passed (incl. 8 new `personality_dialog` mapping tests), 1 ignored. `--no-default-features` (Label fallback) also builds.

## Acceptance
Open the picker on a conversation, set Humor=Never (rest Global), Save → the daemon stores the partial override and resolves the rest against global on every send; a fresh conversation keeps the global disposition. All-Global Save clears the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)