### PR TITLE
Per-conversation speech toggle + session-scoped say_this (#76)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -150,6 +150,32 @@ pub enum UiMessage {
     ScratchpadChanged {
         conversation_id: String,
     },
+
+    // --- Speech toggle (issue #76) ----------------------------------------
+    /// The user flipped the per-conversation hard "speech enabled" toggle in
+    /// the input bar. Carries the conversation the toggle belongs to (so a
+    /// stale toggle from a since-switched conversation can't bleed) and the new
+    /// state. Default is OFF; while OFF no path produces audio. See issue #76.
+    SetSpeechEnabled {
+        conversation_id: String,
+        enabled: bool,
+    },
+
+    // --- Client-local tool calls (issue #76) ------------------------------
+    /// The daemon suspended a turn on a client-local tool call and is waiting
+    /// for this client to post the outcome (#107/#231). Carried verbatim from
+    /// [`SignalEvent::ClientToolCall`]; the window must ALWAYS resolve it via
+    /// `submit_client_tool_result` (even when it can't honour the tool) so the
+    /// suspended turn never wedges. `say_this` is handled specially: spoken
+    /// when the conversation's speech toggle is on, otherwise shown inline as
+    /// `(speech mode disabled) …`. See issue #76.
+    ClientToolCall {
+        task_id: String,
+        conversation_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
 }
 
 // Manual `Debug` (can't derive: `Connector` is not `Debug`). Only
@@ -269,6 +295,28 @@ impl std::fmt::Debug for UiMessage {
             UiMessage::ScratchpadChanged { conversation_id } => f
                 .debug_struct("ScratchpadChanged")
                 .field("conversation_id", conversation_id)
+                .finish(),
+            UiMessage::SetSpeechEnabled {
+                conversation_id,
+                enabled,
+            } => f
+                .debug_struct("SetSpeechEnabled")
+                .field("conversation_id", conversation_id)
+                .field("enabled", enabled)
+                .finish(),
+            UiMessage::ClientToolCall {
+                task_id,
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => f
+                .debug_struct("ClientToolCall")
+                .field("task_id", task_id)
+                .field("conversation_id", conversation_id)
+                .field("tool_call_id", tool_call_id)
+                .field("tool_name", tool_name)
+                .field("arguments", arguments)
                 .finish(),
         }
     }
@@ -571,14 +619,25 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
         SignalEvent::ScratchpadChanged { conversation_id } => {
             UiMessage::ScratchpadChanged { conversation_id }
         }
-        // Client-local MCP tool execution (#107/#231) is not implemented in the
-        // GTK client — it has no local tool runtime to satisfy the call. Surface
-        // it as a status string so the parked turn is at least visible; the
-        // daemon eventually times the suspended call out. Wiring real
-        // client-side tool execution here is a separate feature.
-        SignalEvent::ClientToolCall { tool_name, .. } => UiMessage::StatusUpdate(format!(
-            "Assistant requested a client-side tool ({tool_name}) this client can't run."
-        )),
+        // Client-local tool execution (#107/#231/#76). The window must ALWAYS
+        // resolve this (via `submit_client_tool_result`) or the suspended turn
+        // wedges — the previous status-string mapping silently dropped it.
+        // `say_this` is honoured (spoken or shown inline) per the conversation's
+        // speech toggle; any other tool name is resolved with an error result so
+        // the turn still completes. See issue #76.
+        SignalEvent::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => UiMessage::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        },
         SignalEvent::Disconnected { reason } => UiMessage::Disconnected { reason },
     }
 }
@@ -772,6 +831,37 @@ mod tests {
         match msg {
             UiMessage::Disconnected { reason } => assert_eq!(reason, "lost"),
             other => panic!("expected Disconnected, got {other:?}"),
+        }
+    }
+
+    /// Issue #76: a `ClientToolCall` signal must map to the typed
+    /// `UiMessage::ClientToolCall` carrying every field verbatim — not the old
+    /// lossy `StatusUpdate` string, which dropped the ids and wedged the turn
+    /// (the window could never post a result without them).
+    #[test]
+    fn signal_client_tool_call_routes_to_typed_ui_message_with_all_fields() {
+        let msg = signal_to_ui_message(SignalEvent::ClientToolCall {
+            task_id: "task-9".to_string(),
+            conversation_id: "conv-7".to_string(),
+            tool_call_id: "call-3".to_string(),
+            tool_name: "say_this".to_string(),
+            arguments: serde_json::json!({ "text": "hi there" }),
+        });
+        match msg {
+            UiMessage::ClientToolCall {
+                task_id,
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                assert_eq!(task_id, "task-9");
+                assert_eq!(conversation_id, "conv-7");
+                assert_eq!(tool_call_id, "call-3");
+                assert_eq!(tool_name, "say_this");
+                assert_eq!(arguments, serde_json::json!({ "text": "hi there" }));
+            }
+            other => panic!("expected ClientToolCall, got {other:?}"),
         }
     }
 }

--- a/src/widgets/chat_view.rs
+++ b/src/widgets/chat_view.rs
@@ -132,6 +132,17 @@ impl ChatView {
         self.render();
     }
 
+    /// Render an inline note in the transcript (issue #76). Used for the
+    /// `(speech mode disabled) …` downgrade when a `say_this` aside arrives with
+    /// speech off: the text is shown rather than dropped. Rendered with the
+    /// `assistant` role so it sits in the reply column; the caller pre-formats
+    /// the `(speech mode disabled)` prefix.
+    pub fn add_inline_note(&mut self, content: &str) {
+        self.messages
+            .push(("assistant".to_string(), content.to_string()));
+        self.render();
+    }
+
     /// Clear the view.
     pub fn clear(&mut self) {
         self.messages.clear();

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -1,10 +1,17 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use gtk4::prelude::*;
-use gtk4::{Box as GtkBox, Button, Image, Orientation, ScrolledWindow, TextView, WrapMode};
+use gtk4::{
+    Box as GtkBox, Button, Image, Orientation, ScrolledWindow, TextView, ToggleButton, WrapMode,
+    glib,
+};
 
 use crate::voice_client::VoiceState;
+
+/// Callback fired when the user flips the speech toggle (issue #76). The bool
+/// is the new "speech enabled" state for the active conversation.
+type SpeechToggledCb = Box<dyn Fn(bool)>;
 
 /// Input bar widget with a record/mic button, a text view, and a send button.
 pub struct InputBar {
@@ -19,10 +26,44 @@ pub struct InputBar {
     pub mic_button: Button,
     /// The mic icon, swapped per pipeline state to mirror the plasmoid's glyphs.
     mic_image: Image,
+    /// Per-conversation hard "speech enabled" toggle (issue #76). Default OFF.
+    /// When OFF, no path produces audio; when ON, the assistant may narrate
+    /// replies and `say_this` is spoken. The window owns the authoritative
+    /// per-conversation state and drives `set_speech_active` on conversation
+    /// switch; this button is the affordance + write source.
+    pub speech_button: ToggleButton,
+    /// The speaker glyph on the toggle, swapped on/off.
+    speech_image: Image,
+    /// User callback for toggle flips. Guarded by `suppress` so a programmatic
+    /// `set_speech_active` (on conversation switch) does not echo a write back.
+    on_speech_toggled: Rc<RefCell<Option<SpeechToggledCb>>>,
+    /// Re-entrancy guard for `set_speech_active`, mirroring `voice_tab`.
+    suppress: Rc<Cell<bool>>,
     /// The last pipeline state reflected on the button. The window's click
     /// handler reads it to decide barge-in (click while `Speaking` →
     /// `StopSpeaking`, otherwise start a push-to-talk turn).
     state: Rc<Cell<VoiceState>>,
+}
+
+/// Themed-icon fallback chain for the speech toggle, by enabled state (#76).
+/// ON shows a speaker with sound; OFF shows a muted speaker, mirroring the
+/// "audio never plays while off" master cut-off.
+fn speech_icons_for(enabled: bool) -> &'static [&'static str] {
+    if enabled {
+        &["audio-volume-high-symbolic", "audio-volume-high"]
+    } else {
+        &["audio-volume-muted-symbolic", "audio-volume-muted"]
+    }
+}
+
+/// Tooltip for the speech toggle by state (#76). The toggle is the hard
+/// master cut-off, so the copy makes the consequence explicit.
+fn speech_tooltip_for(enabled: bool) -> &'static str {
+    if enabled {
+        "Speech enabled — Adele may speak replies in this conversation. Click to mute."
+    } else {
+        "Speech disabled — no audio plays in this conversation. Click to enable."
+    }
 }
 
 /// Themed-icon fallback chain for the **resting (Idle)** mic glyph. The first
@@ -105,11 +146,51 @@ impl InputBar {
         scrolled.set_child(Some(&text_view));
         container.append(&scrolled);
 
+        // Per-conversation speech toggle (issue #76), between the entry and
+        // Send. Default OFF (the master audio cut-off); the window sets the
+        // active conversation's state on switch via `set_speech_active`.
+        let speech_image =
+            Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(false)));
+        let speech_button = ToggleButton::new();
+        speech_button.set_child(Some(&speech_image));
+        speech_button.add_css_class("speech-button");
+        speech_button.set_valign(gtk4::Align::End);
+        speech_button.set_margin_bottom(4);
+        speech_button.set_tooltip_text(Some(speech_tooltip_for(false)));
+        container.append(&speech_button);
+
         let send_button = Button::with_label("Send");
         send_button.add_css_class("send-button");
         send_button.set_valign(gtk4::Align::End);
         send_button.set_margin_bottom(4);
         container.append(&send_button);
+
+        let on_speech_toggled: Rc<RefCell<Option<SpeechToggledCb>>> = Rc::new(RefCell::new(None));
+        let suppress = Rc::new(Cell::new(false));
+
+        speech_button.connect_toggled(glib::clone!(
+            #[strong]
+            on_speech_toggled,
+            #[strong]
+            suppress,
+            #[weak]
+            speech_image,
+            move |btn| {
+                let enabled = btn.is_active();
+                // Always reflect the glyph/tooltip, even on a suppressed
+                // (programmatic) flip, so the button never lies about state.
+                speech_image.set_from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(
+                    enabled,
+                )));
+                btn.set_tooltip_text(Some(speech_tooltip_for(enabled)));
+                if suppress.get() {
+                    return;
+                }
+                if let Some(cb) = on_speech_toggled.borrow().as_ref() {
+                    cb(enabled);
+                }
+            }
+        ));
 
         Self {
             container,
@@ -117,8 +198,37 @@ impl InputBar {
             send_button,
             mic_button,
             mic_image,
+            speech_button,
+            speech_image,
+            on_speech_toggled,
+            suppress,
             state: Rc::new(Cell::new(VoiceState::Idle)),
         }
+    }
+
+    /// Register the callback fired when the user flips the speech toggle
+    /// (issue #76). The argument is the new per-conversation "speech enabled"
+    /// state.
+    pub fn connect_speech_toggled<F: Fn(bool) + 'static>(&self, f: F) {
+        *self.on_speech_toggled.borrow_mut() = Some(Box::new(f));
+    }
+
+    /// Reflect the active conversation's speech state on the toggle WITHOUT
+    /// echoing a write back (issue #76). Called by the window on conversation
+    /// switch so the button always shows the conversation it belongs to —
+    /// per-conversation state, no cross-conversation bleed.
+    pub fn set_speech_active(&self, enabled: bool) {
+        self.suppress.set(true);
+        self.speech_button.set_active(enabled);
+        // `connect_toggled` only fires on a *change*; ensure the glyph/tooltip
+        // are correct even when the value didn't change.
+        self.speech_image
+            .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(
+                enabled,
+            )));
+        self.speech_button
+            .set_tooltip_text(Some(speech_tooltip_for(enabled)));
+        self.suppress.set(false);
     }
 
     /// Show or hide the mic button based on whether the voice daemon is
@@ -204,6 +314,22 @@ mod tests {
             mic_tooltip_for(VoiceState::Processing),
             "Push to talk — Processing…"
         );
+    }
+
+    #[test]
+    fn speech_toggle_icon_and_tooltip_reflect_enabled_state() {
+        // Issue #76: the glyph and tooltip must distinguish ON (a speaker that
+        // plays) from OFF (a muted speaker — the master cut-off).
+        assert_ne!(speech_icons_for(true)[0], speech_icons_for(false)[0]);
+        assert_eq!(speech_icons_for(true)[0], "audio-volume-high-symbolic");
+        assert_eq!(speech_icons_for(false)[0], "audio-volume-muted-symbolic");
+        assert!(!speech_icons_for(true).is_empty());
+        assert!(!speech_icons_for(false).is_empty());
+
+        // The OFF tooltip must make the cut-off explicit ("no audio").
+        assert!(speech_tooltip_for(false).contains("no audio"));
+        assert!(speech_tooltip_for(true).contains("may speak"));
+        assert_ne!(speech_tooltip_for(true), speech_tooltip_for(false));
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -34,6 +35,25 @@ struct WindowState {
     pending_request_id: Option<String>,
     streaming_buffer: String,
     debug_enabled: bool,
+    /// Per-conversation hard "speech enabled" toggle (issue #76), keyed by
+    /// conversation id. Default (absent key) is **OFF** — the master cut-off,
+    /// so no path produces audio for a conversation until the user explicitly
+    /// enables speech for it. State is per-conversation, so enabling speech in
+    /// one conversation never leaks audio into another.
+    conversation_speech_enabled: HashMap<String, bool>,
+}
+
+impl WindowState {
+    /// Whether speech is hard-enabled for the *currently active* conversation.
+    /// `false` when there is no active conversation or the toggle was never set
+    /// (default OFF). The single gate every audio-producing path consults.
+    fn speech_enabled_for_current(&self) -> bool {
+        self.current_conversation_id
+            .as_deref()
+            .and_then(|id| self.conversation_speech_enabled.get(id))
+            .copied()
+            .unwrap_or(false)
+    }
 }
 
 /// A single observable side-effect produced by [`WindowState::apply`].
@@ -121,6 +141,27 @@ enum Effect {
     /// Recompute the side pane's task list from the authoritative `TasksModel`,
     /// filtered to the active conversation.
     RefreshSidePaneTasks,
+
+    // --- Speech toggle + client tools (issue #76) -------------------------
+    /// Speak `text` through the embedded `Speaker`. Emitted only when the
+    /// active conversation's speech toggle is ON (the executor still no-ops if
+    /// there is no embedded engine, e.g. the daemon path). The master audio
+    /// cut-off lives in `apply`: when speech is OFF this effect is never
+    /// produced, so no path plays audio while the toggle is off.
+    Speak(String),
+    /// Render an inline note in the chat transcript (issue #76). Used for the
+    /// `(speech mode disabled) …` downgrade when `say_this` arrives with speech
+    /// OFF, so the text is shown rather than dropped.
+    AddInlineNote(String),
+    /// Resolve a suspended client-tool call back to the daemon via
+    /// `submit_client_tool_result` so the parked turn resumes (issue #76). Every
+    /// `ClientToolCall` yields exactly one of these — `Ok` on success, `Err`
+    /// with a reason otherwise — which is what kills the silent-drop wedge.
+    SubmitClientToolResult {
+        task_id: String,
+        tool_call_id: String,
+        result: Result<String, String>,
+    },
 }
 
 // Manual `Debug` (can't derive: `Connector` is not `Debug`, mirroring
@@ -174,6 +215,18 @@ impl std::fmt::Debug for Effect {
                 f.debug_tuple("SidePaneSetScratchpad").field(n).finish()
             }
             Effect::RefreshSidePaneTasks => f.write_str("RefreshSidePaneTasks"),
+            Effect::Speak(t) => f.debug_tuple("Speak").field(t).finish(),
+            Effect::AddInlineNote(t) => f.debug_tuple("AddInlineNote").field(t).finish(),
+            Effect::SubmitClientToolResult {
+                task_id,
+                tool_call_id,
+                result,
+            } => f
+                .debug_struct("SubmitClientToolResult")
+                .field("task_id", task_id)
+                .field("tool_call_id", tool_call_id)
+                .field("result", result)
+                .finish(),
         }
     }
 }
@@ -491,6 +544,11 @@ impl WindowState {
                     vec![]
                 }
             }
+            // STUB (failing-tests commit): real handling lands in the
+            // implementation commit. Returning no effects makes the #76 tests
+            // fail on their assertions rather than fail to compile.
+            UiMessage::SetSpeechEnabled { .. } => vec![],
+            UiMessage::ClientToolCall { .. } => vec![],
             UiMessage::Disconnected { reason } => {
                 let mut effects = vec![
                     Effect::ClearClient,
@@ -790,6 +848,7 @@ impl AdelieWindow {
             pending_request_id: None,
             streaming_buffer: String::new(),
             debug_enabled: false,
+            conversation_speech_enabled: HashMap::new(),
         }));
 
         // Wrap widgets in Rc for closures
@@ -2143,6 +2202,10 @@ fn handle_ui_message(
                 let rows = tasks_panel.task_view_models_for(conv.as_deref(), now_epoch_ms());
                 side_pane.set_tasks(&rows);
             }
+            // STUBS (failing-tests commit): wired in the implementation commit.
+            Effect::Speak(_) => {}
+            Effect::AddInlineNote(_) => {}
+            Effect::SubmitClientToolResult { .. } => {}
         }
     }
 }
@@ -3084,5 +3147,264 @@ mod tests {
         });
         assert_eq!(state.current_conversation_id.as_deref(), Some("new-c"));
         assert!(effects.is_empty());
+    }
+
+    // --- Speech toggle + client tools (issue #76) ------------------------
+
+    /// A `say_this` client-tool call (#76). Convenience constructor for the
+    /// tests below.
+    fn say_this_call(conversation_id: &str, text: &str) -> UiMessage {
+        UiMessage::ClientToolCall {
+            task_id: "task-1".to_string(),
+            conversation_id: conversation_id.to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "say_this".to_string(),
+            arguments: serde_json::json!({ "text": text }),
+        }
+    }
+
+    /// Acceptance: the hard toggle defaults OFF for a conversation that was
+    /// never touched, so `speech_enabled_for_current` reports `false` and no
+    /// audio path can fire.
+    #[test]
+    fn speech_toggle_defaults_off_per_conversation() {
+        let state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            !state.speech_enabled_for_current(),
+            "speech must default OFF for an untouched conversation"
+        );
+    }
+
+    /// `SetSpeechEnabled` records the flag per conversation and only affects
+    /// the named conversation — enabling speech in c1 must not enable it in c2
+    /// (no cross-conversation bleed).
+    #[test]
+    fn set_speech_enabled_is_scoped_to_its_conversation() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::SetSpeechEnabled {
+            conversation_id: "c1".to_string(),
+            enabled: true,
+        });
+        assert!(effects.is_empty(), "toggling state emits no effects");
+        assert!(state.speech_enabled_for_current());
+        // Switch the active conversation to c2: it inherits the default OFF.
+        state.current_conversation_id = Some("c2".to_string());
+        assert!(
+            !state.speech_enabled_for_current(),
+            "enabling speech in c1 must not leak into c2"
+        );
+        // And back to c1: still ON (sticks per conversation).
+        state.current_conversation_id = Some("c1".to_string());
+        assert!(state.speech_enabled_for_current());
+    }
+
+    /// Acceptance: with speech OFF, a `say_this` call produces the inline
+    /// `(speech mode disabled) …` downgrade and ALWAYS a `SubmitClientToolResult`
+    /// — and crucially NO `Speak` effect (the master audio cut-off). The turn
+    /// completes (a result is posted), so it can't hang.
+    #[test]
+    fn say_this_while_speech_off_renders_inline_and_resolves_without_audio() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(say_this_call("c1", "the aside"));
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "speech OFF must never produce a Speak effect: {effects:?}"
+        );
+        let inline = effects.iter().any(
+            |e| matches!(e, Effect::AddInlineNote(t) if t == "(speech mode disabled) the aside"),
+        );
+        assert!(inline, "expected the inline downgrade note: {effects:?}");
+        let resolved = effects.iter().any(|e| {
+            matches!(
+                e,
+                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Ok(_) }
+                    if task_id == "task-1" && tool_call_id == "call-1"
+            )
+        });
+        assert!(
+            resolved,
+            "say_this must always resolve a result: {effects:?}"
+        );
+    }
+
+    /// Acceptance: with speech ON, a `say_this` call speaks the text and
+    /// resolves the result `"spoken"`. No inline downgrade note.
+    #[test]
+    fn say_this_while_speech_on_speaks_and_resolves_spoken() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        state
+            .conversation_speech_enabled
+            .insert("c1".to_string(), true);
+        let effects = state.apply(say_this_call("c1", "hello aloud"));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::Speak(t) if t == "hello aloud")),
+            "speech ON must speak the aside: {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::AddInlineNote(_))),
+            "no inline downgrade when spoken: {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::SubmitClientToolResult { result: Ok(r), .. } if r == "spoken"
+            )),
+            "result must be \"spoken\": {effects:?}"
+        );
+    }
+
+    /// Master cut-off: even a `say_this` for the *active* conversation does not
+    /// speak while that conversation's toggle is OFF — and a `say_this` whose
+    /// conversation_id differs from the active one (stale / concurrent session)
+    /// is judged against the *active* conversation's toggle, never another's.
+    #[test]
+    fn say_this_for_other_conversation_uses_active_toggle_no_bleed() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        // c2 has speech ON, but the active conversation is c1 (OFF). A call
+        // tagged c2 must NOT borrow c2's ON state to play audio on this client.
+        state
+            .conversation_speech_enabled
+            .insert("c2".to_string(), true);
+        let effects = state.apply(say_this_call("c2", "should not play"));
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "a call for a non-active conversation must not borrow its toggle: {effects:?}"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SubmitClientToolResult { .. })),
+            "still always resolves: {effects:?}"
+        );
+    }
+
+    /// Acceptance: a non-`say_this` client tool the GTK client can't run still
+    /// ALWAYS gets a result (an `Err`), so the suspended turn resumes rather
+    /// than wedging on a `PendingClientTool`.
+    #[test]
+    fn unknown_client_tool_always_resolves_with_error_result() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::ClientToolCall {
+            task_id: "task-2".to_string(),
+            conversation_id: "c1".to_string(),
+            tool_call_id: "call-2".to_string(),
+            tool_name: "frobnicate".to_string(),
+            arguments: serde_json::json!({}),
+        });
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "an unknown tool must not produce audio: {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Err(_) }
+                    if task_id == "task-2" && tool_call_id == "call-2"
+            )),
+            "an unrunnable tool must resolve with an Err result: {effects:?}"
+        );
+    }
+
+    /// Malformed `say_this` arguments (missing/invalid `text`) must not panic
+    /// and must resolve with an `Err` result (never unwrap), so a hostile or
+    /// buggy payload can't wedge or crash the turn.
+    #[test]
+    fn say_this_with_malformed_arguments_resolves_error_not_panic() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        state
+            .conversation_speech_enabled
+            .insert("c1".to_string(), true);
+        let effects = state.apply(UiMessage::ClientToolCall {
+            task_id: "task-3".to_string(),
+            conversation_id: "c1".to_string(),
+            tool_call_id: "call-3".to_string(),
+            tool_name: "say_this".to_string(),
+            // `text` missing entirely.
+            arguments: serde_json::json!({ "wrong": 5 }),
+        });
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "malformed say_this must not speak: {effects:?}"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SubmitClientToolResult { result: Err(_), .. })),
+            "malformed say_this must resolve an Err result: {effects:?}"
+        );
+    }
+
+    /// Acceptance: reply narration is gated on the per-conversation toggle. With
+    /// speech ON, `StreamComplete` additionally emits a `Speak` of the reply;
+    /// with speech OFF it does not (only the normal text effects).
+    #[test]
+    fn reply_narration_is_gated_on_speech_toggle() {
+        // OFF → no Speak.
+        let mut off = WindowState {
+            pending_request_id: Some("req".to_string()),
+            current_conversation: Some(detail("c1", vec![])),
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = off.apply(UiMessage::StreamComplete {
+            request_id: "req".to_string(),
+            full_response: "an answer".to_string(),
+        });
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "speech OFF must not narrate the reply: {effects:?}"
+        );
+
+        // ON → Speak the reply (in addition to the usual text effects).
+        let mut on = WindowState {
+            pending_request_id: Some("req".to_string()),
+            current_conversation: Some(detail("c1", vec![])),
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        on.conversation_speech_enabled
+            .insert("c1".to_string(), true);
+        let effects = on.apply(UiMessage::StreamComplete {
+            request_id: "req".to_string(),
+            full_response: "an answer".to_string(),
+        });
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::Speak(t) if t == "an answer")),
+            "speech ON must narrate the reply: {effects:?}"
+        );
+        // The normal text finalize must still happen.
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::CompleteStreaming(t) if t == "an answer")),
+            "the reply text must still be finalized: {effects:?}"
+        );
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -56,6 +56,19 @@ impl WindowState {
     }
 }
 
+/// Extract the `text` argument from a `say_this` client-tool call (issue #76).
+///
+/// Returns `None` (rather than panicking) when `arguments` is not an object,
+/// the `text` field is absent, or it isn't a string — a hostile or buggy
+/// payload must resolve to an `Err` result, never crash the turn. An empty
+/// string is accepted (the LLM asked to say nothing; the result still resolves).
+fn say_this_text(arguments: &serde_json::Value) -> Option<String> {
+    arguments
+        .get("text")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
 /// A single observable side-effect produced by [`WindowState::apply`].
 ///
 /// `apply` is a pure decision function: it mutates `WindowState` and returns
@@ -395,10 +408,19 @@ impl WindowState {
                             content: full_response.clone(),
                         });
                     }
-                    let mut effects = vec![
-                        Effect::ClearChatStatus,
-                        Effect::CompleteStreaming(full_response),
-                    ];
+                    // Reply narration (issue #76): when the active conversation
+                    // has speech hard-enabled, narrate the finalized reply via
+                    // the embedded `Speaker`. Gated entirely here so the master
+                    // cut-off holds — with speech OFF no `Speak` effect exists,
+                    // so no path plays audio. (The executor additionally no-ops
+                    // when there is no embedded engine, e.g. the daemon path,
+                    // which narrates its own replies.)
+                    let narrate = self.speech_enabled_for_current();
+                    let mut effects = vec![Effect::ClearChatStatus];
+                    if narrate {
+                        effects.push(Effect::Speak(full_response.clone()));
+                    }
+                    effects.push(Effect::CompleteStreaming(full_response));
                     // The turn may have changed the scratchpad (Adele's todos);
                     // refresh the pane. (The live `ScratchpadChanged` event also
                     // covers this, but a turn-boundary refetch is a cheap
@@ -544,11 +566,85 @@ impl WindowState {
                     vec![]
                 }
             }
-            // STUB (failing-tests commit): real handling lands in the
-            // implementation commit. Returning no effects makes the #76 tests
-            // fail on their assertions rather than fail to compile.
-            UiMessage::SetSpeechEnabled { .. } => vec![],
-            UiMessage::ClientToolCall { .. } => vec![],
+            UiMessage::SetSpeechEnabled {
+                conversation_id,
+                enabled,
+            } => {
+                // Record the per-conversation hard toggle. Pure state change;
+                // the button already reflects itself (it is the write source).
+                // Keyed by conversation so it never bleeds across conversations.
+                self.conversation_speech_enabled
+                    .insert(conversation_id, enabled);
+                vec![]
+            }
+            UiMessage::ClientToolCall {
+                task_id,
+                conversation_id: _,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                // ALWAYS resolve the call (issue #76) so the suspended turn
+                // resumes — the previous code dropped it and wedged the turn.
+                //
+                // `say_this` is the only tool this client honours. Note we gate
+                // on the *active* conversation's toggle, not the call's
+                // `conversation_id`: a say_this for some other (e.g. a
+                // concurrent voice session's) conversation must never borrow a
+                // different conversation's ON state to play audio on this
+                // client. With #261's session-scoped registration the daemon
+                // already scopes tools per session; this is the belt-and-braces
+                // local guard.
+                if tool_name == "say_this" {
+                    match say_this_text(&arguments) {
+                        Some(text) if self.speech_enabled_for_current() => {
+                            // Hard toggle ON → speak it.
+                            vec![
+                                Effect::Speak(text),
+                                Effect::SubmitClientToolResult {
+                                    task_id,
+                                    tool_call_id,
+                                    result: Ok("spoken".to_string()),
+                                },
+                            ]
+                        }
+                        Some(text) => {
+                            // Hard toggle OFF → show, don't speak. The turn
+                            // still completes; no audio on any path.
+                            let note = format!("(speech mode disabled) {text}");
+                            vec![
+                                Effect::AddInlineNote(note),
+                                Effect::SubmitClientToolResult {
+                                    task_id,
+                                    tool_call_id,
+                                    result: Ok("speech mode disabled; shown to the user as text \
+                                         instead of spoken"
+                                        .to_string()),
+                                },
+                            ]
+                        }
+                        None => {
+                            // Malformed arguments (missing/!string `text`):
+                            // never panic, resolve an Err so the turn completes.
+                            vec![Effect::SubmitClientToolResult {
+                                task_id,
+                                tool_call_id,
+                                result: Err(
+                                    "say_this requires a string `text` argument".to_string()
+                                ),
+                            }]
+                        }
+                    }
+                } else {
+                    // Any other client tool: this client has no runtime for it,
+                    // but it must still be resolved or the turn wedges.
+                    vec![Effect::SubmitClientToolResult {
+                        task_id,
+                        tool_call_id,
+                        result: Err(format!("this client cannot run the tool \"{tool_name}\"")),
+                    }]
+                }
+            }
             UiMessage::Disconnected { reason } => {
                 let mut effects = vec![
                     Effect::ClearClient,
@@ -1426,6 +1522,29 @@ impl AdelieWindow {
             }
         }
 
+        // Per-conversation speech toggle (issue #76). A user flip routes a
+        // `SetSpeechEnabled` for the *current* conversation through the same
+        // handler as everything else, so the pure `apply` records it. The
+        // `set_speech_active` reflection on conversation switch (below, in the
+        // `LoadConversationIntoChat` effect) is suppressed, so it never echoes
+        // back here. With no active conversation the flip is dropped (the
+        // button is only meaningful against a conversation).
+        input_bar.connect_speech_toggled(glib::clone!(
+            #[strong]
+            state,
+            #[strong]
+            bridge,
+            move |enabled| {
+                let Some(conv_id) = state.borrow().current_conversation_id.clone() else {
+                    return;
+                };
+                let _ = bridge.ui_sender().send(UiMessage::SetSpeechEnabled {
+                    conversation_id: conv_id,
+                    enabled,
+                });
+            }
+        ));
+
         // Hamburger menu: Switch Connection → open the picker in a new
         // window. The current connection's window is intentionally left open;
         // selecting a profile spawns a fresh AdelieWindow alongside it.
@@ -2085,6 +2204,13 @@ fn handle_ui_message(
             }
             Effect::LoadConversationIntoChat(filtered) => {
                 chat_view.borrow_mut().load_conversation(&filtered);
+                // Reflect the newly-active conversation's speech toggle on the
+                // input bar (issue #76). `apply` has already pointed
+                // `current_conversation_id` at this conversation, so this reads
+                // the right per-conversation state. Suppressed inside
+                // `set_speech_active`, so it doesn't echo a write back.
+                let enabled = state.borrow().speech_enabled_for_current();
+                input_bar.set_speech_active(enabled);
             }
             Effect::ReloadConversation(id) => {
                 // Re-fetch an already-open conversation (reconnect / debug /
@@ -2202,10 +2328,47 @@ fn handle_ui_message(
                 let rows = tasks_panel.task_view_models_for(conv.as_deref(), now_epoch_ms());
                 side_pane.set_tasks(&rows);
             }
-            // STUBS (failing-tests commit): wired in the implementation commit.
-            Effect::Speak(_) => {}
-            Effect::AddInlineNote(_) => {}
-            Effect::SubmitClientToolResult { .. } => {}
+            Effect::Speak(text) => {
+                // Speak via the embedded engine. `apply` only emits this when
+                // the active conversation has speech ON, so this is the spoken
+                // path of both reply narration and a `say_this` aside. No-op on
+                // the daemon path (`embedded_voice` is `None` there — the daemon
+                // narrates its own replies), which keeps the master cut-off:
+                // audio is produced by exactly one engine.
+                if let Some(engine) = (**embedded_voice).clone() {
+                    let ui_tx = ui_tx.clone();
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        if let Err(e) = engine.say(&text).await {
+                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+                        }
+                    });
+                }
+            }
+            Effect::AddInlineNote(note) => {
+                chat_view.borrow_mut().add_inline_note(&note);
+            }
+            Effect::SubmitClientToolResult {
+                task_id,
+                tool_call_id,
+                result,
+            } => {
+                // Post the outcome back to the daemon so the suspended turn
+                // resumes (issue #76). Spawned off the GTK thread; failures to
+                // deliver are logged (the daemon's suspension timeout, #262, is
+                // the backstop if delivery never lands).
+                if let Some(connector) = client.borrow().clone() {
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        if let Err(e) = connector
+                            .submit_client_tool_result(&task_id, &tool_call_id, result)
+                            .await
+                        {
+                            tracing::warn!("submit_client_tool_result failed: {e}");
+                        }
+                    });
+                } else {
+                    tracing::warn!("no connector to submit client-tool result for task {task_id}");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #76

Phase-1 of the gtk voice-mode work. Scoped (with the user) to the four items below; the fuller soft-sticky/`request_voice` layer is a deferred follow-up.

## What this does (4 items)

1. **Per-conversation hard "speech enabled" toggle, default OFF.** A speaker `ToggleButton` in the input bar, backed by `WindowState::conversation_speech_enabled: HashMap<String,bool>` keyed by conversation id. `WindowState::speech_enabled_for_current()` is the single audio gate. The window reflects the toggle on conversation switch (`set_speech_active`, suppressed so it never echoes a write back) — per-conversation, no cross-conversation bleed.
2. **Reply narration gated on the toggle.** `StreamComplete` emits a `Speak(reply)` effect *only* when the active conversation has speech ON. With speech OFF, no `Speak` effect is ever produced on any path (master cut-off). The executor additionally no-ops `Speak` when there is no embedded engine (daemon path narrates its own replies).
3. **A `ClientToolCall` ALWAYS resolves a `ClientToolResult`.** `signal_to_ui_message` now maps `SignalEvent::ClientToolCall` to a typed `UiMessage::ClientToolCall` (it was a lossy status string that silently dropped the ids and wedged the turn). A new window handler resolves every call via the Connector's `submit_client_tool_result(task_id, tool_call_id, …)`.
4. **`say_this` with downgrade.** Speech ON → speak it, result `"spoken"`. Speech OFF → render `(speech mode disabled) <text>` inline in the transcript + a result noting it was shown-not-spoken. The turn always completes.

## say_this: defensive-only (no registration)

I chose to handle `say_this` **defensively** — branching on `tool_name` in `apply`, **not** registering a client tool. The daemon forwards any client-tool call regardless, so item 4 is real end-to-end without registration, and registration (when speech is enabled, dynamic re-registration on toggle, etc.) properly belongs to the deferred soft-sticky layer. The toggle is evaluated against the **active** conversation, never the call's `conversation_id`, so a concurrent voice session's `say_this` can never borrow another conversation's ON state to play audio here.

## Deferred to a follow-up (not in this PR)

- Model-driven `request_voice` / `stop_voice` tools.
- Passing the voice `system_refinement` on send.

## Tests (TDD: failing tests committed first, then implementation)

`apply`-path unit tests (no GTK/audio needed) + signal-mapping + input_bar pure helpers:

- `speech_toggle_defaults_off_per_conversation`
- `set_speech_enabled_is_scoped_to_its_conversation` (no cross-conversation bleed)
- `say_this_while_speech_off_renders_inline_and_resolves_without_audio`
- `say_this_while_speech_on_speaks_and_resolves_spoken`
- `say_this_for_other_conversation_uses_active_toggle_no_bleed`
- `unknown_client_tool_always_resolves_with_error_result`
- `say_this_with_malformed_arguments_resolves_error_not_panic`
- `reply_narration_is_gated_on_speech_toggle`
- `signal_client_tool_call_routes_to_typed_ui_message_with_all_fields` (async_bridge)
- `speech_toggle_icon_and_tooltip_reflect_enabled_state` (input_bar)

All **187 tests pass** (1 pre-existing ignored). `cargo clippy --all-targets -- -D warnings` is clean; my changed files are `rustfmt --edition 2024` clean. No `--no-verify` needed — the pre-push hook ran and passed.

## Security self-review

Adversarial read of the diff:
- **No panic on malformed `say_this` arguments** — `say_this_text` returns `None` (never unwraps) for a non-object / missing / non-string `text`; the handler resolves an `Err` result so the turn completes. Covered by `say_this_with_malformed_arguments_resolves_error_not_panic`.
- **No audio leak while OFF on any path** — `Speak` is only emitted by `apply` when `speech_enabled_for_current()` is true; gated for both narration and `say_this`. Verified by the OFF-path tests asserting no `Speak` effect.
- **No cross-conversation state bleed** — toggle is keyed by conversation id and the active conversation is the gate; verified by the scoping tests.
- **Turn never wedges** — every `ClientToolCall` (known, unknown, or malformed) yields exactly one `SubmitClientToolResult`.

## QA deferred to a human

Visual/audio QA (toggle glyph/tooltip, actually speaking via the embedded engine, the inline downgrade rendering) needs the GUI and an audio device — deferred to dspadea. The behavioral logic is fully unit-tested via the pure `WindowState::apply` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)