### PR TITLE
Voice UI: You/Adele dropdowns under the input (replace 3-button phase-2 row) (#80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "adele-gtk"
 version = "0.1.0"
 dependencies = [
+ "adele-voice-core",
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,11 @@ path = "../voice/crates/vad-silero"
 
 [dependencies.adele-voice-stt-whisper]
 path = "../voice/crates/stt-whisper"
+
+# The voice pipeline's pure text helpers — only `SentenceBuffer`, reused to chunk
+# a long reply into one-short-sentence-per-synth pieces so neither the daemon's
+# `SayText` nor the embedded `say` hits the per-synth ~20s timeout. Same
+# `../voice` symlink path-dep; already a transitive dep of the module above, so
+# no new crates enter the graph.
+[dependencies.adele-voice-core]
+path = "../voice/crates/core"

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -885,20 +885,37 @@ mod tests {
         }
     }
 
-    /// Issue #78: the user-driven voice-mode toggle is its own `UiMessage`
-    /// (mirroring `SetSpeechEnabled`); its `Debug` must surface both fields so a
-    /// test panic stays informative.
+    /// Issue #80: the user-driven `You:` (voice input) dropdown is its own
+    /// `UiMessage`; its `Debug` must surface both fields so a test panic stays
+    /// informative.
     #[test]
-    fn set_voice_mode_debug_includes_conversation_and_enabled() {
+    fn set_voice_in_debug_includes_conversation_and_enabled() {
         let dbg = format!(
             "{:?}",
-            UiMessage::SetVoiceMode {
+            UiMessage::SetVoiceIn {
                 conversation_id: "conv-1".to_string(),
                 enabled: true,
             }
         );
-        assert!(dbg.contains("SetVoiceMode"), "got {dbg}");
+        assert!(dbg.contains("SetVoiceIn"), "got {dbg}");
         assert!(dbg.contains("conv-1"), "got {dbg}");
         assert!(dbg.contains("true"), "got {dbg}");
+    }
+
+    /// Issue #80: the user-driven `Adele:` (voice output) dropdown is its own
+    /// `UiMessage` carrying the three-way level; its `Debug` must surface both
+    /// the conversation and the level variant.
+    #[test]
+    fn set_adele_output_debug_includes_conversation_and_level() {
+        let dbg = format!(
+            "{:?}",
+            UiMessage::SetAdeleOutput {
+                conversation_id: "conv-2".to_string(),
+                level: AdeleOutput::Always,
+            }
+        );
+        assert!(dbg.contains("SetAdeleOutput"), "got {dbg}");
+        assert!(dbg.contains("conv-2"), "got {dbg}");
+        assert!(dbg.contains("Always"), "got {dbg}");
     }
 }

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -11,6 +11,30 @@ use tokio::sync::mpsc;
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
+/// The three-way voice-**output** level for a conversation (issue #80), exposed
+/// by the `Adele:` dropdown. A dedicated enum (not two bools) because the level
+/// is genuinely three-valued and the gate logic differs per variant: a bool
+/// pair would admit a nonsensical "both" state and scatter the
+/// Disabled/OnDemand/Always distinction across call sites. Default is
+/// [`AdeleOutput::Disabled`] (never speaks).
+///
+/// Replaces phase-2's two independent toggles, which mapped directly: the
+/// read-aloud toggle was [`AdeleOutput::Always`] and the voice-mode toggle was
+/// [`AdeleOutput::OnDemand`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdeleOutput {
+    /// Never speaks. A `say_this` aside downgrades to inline text.
+    #[default]
+    Disabled,
+    /// Speaks replies only while `You == Enabled` (conversing by voice), shaped
+    /// for the ear; speaks `say_this` asides regardless of `You`. The model's
+    /// `request_voice` selects this.
+    OnDemand,
+    /// Reads every reply aloud in full (made speakable, not shortened) —
+    /// accessibility. Independent of `You`.
+    Always,
+}
+
 fn runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
@@ -151,26 +175,27 @@ pub enum UiMessage {
         conversation_id: String,
     },
 
-    // --- Speech toggle (issue #76) ----------------------------------------
-    /// The user flipped the per-conversation hard "speech enabled" toggle in
-    /// the input bar. Carries the conversation the toggle belongs to (so a
-    /// stale toggle from a since-switched conversation can't bleed) and the new
-    /// state. Default is OFF; while OFF no path produces audio. See issue #76.
-    SetSpeechEnabled {
+    // --- Voice input (`You:` dropdown, issue #80) -------------------------
+    /// The user changed the per-conversation `You:` (voice input) dropdown in
+    /// the input bar. Carries the conversation the setting belongs to (so a
+    /// stale setting from a since-switched conversation can't bleed) and whether
+    /// voice input is Enabled (`true`, push-to-talk available) or Disabled
+    /// (`false`, type only). Default is Disabled. See issue #80.
+    SetVoiceIn {
         conversation_id: String,
         enabled: bool,
     },
 
-    // --- Voice mode (issue #78, phase-2) ----------------------------------
-    /// The user flipped the per-conversation soft-sticky "voice mode" toggle in
+    // --- Voice output (`Adele:` dropdown, issue #80) ----------------------
+    /// The user changed the per-conversation `Adele:` (voice output) dropdown in
     /// the input bar (the model drives the same state via the `request_voice` /
-    /// `stop_voice` client tools). Carries the conversation it belongs to and
-    /// the new state. Default is OFF. When ON, replies are narrated (same
-    /// routing as read-aloud) AND a concise read-aloud `system_refinement` is
-    /// attached on send so replies are shaped for speech. See issue #78.
-    SetVoiceMode {
+    /// `stop_voice` client tools, which select OnDemand / Disabled). Carries the
+    /// conversation it belongs to and the new output level. Default is Disabled.
+    /// The level decides reply narration (with `You`) and the send-time
+    /// `system_refinement`. See issue #80.
+    SetAdeleOutput {
         conversation_id: String,
-        enabled: bool,
+        level: AdeleOutput,
     },
 
     // --- Client-local tool calls (issue #76) ------------------------------
@@ -308,21 +333,21 @@ impl std::fmt::Debug for UiMessage {
                 .debug_struct("ScratchpadChanged")
                 .field("conversation_id", conversation_id)
                 .finish(),
-            UiMessage::SetSpeechEnabled {
+            UiMessage::SetVoiceIn {
                 conversation_id,
                 enabled,
             } => f
-                .debug_struct("SetSpeechEnabled")
+                .debug_struct("SetVoiceIn")
                 .field("conversation_id", conversation_id)
                 .field("enabled", enabled)
                 .finish(),
-            UiMessage::SetVoiceMode {
+            UiMessage::SetAdeleOutput {
                 conversation_id,
-                enabled,
+                level,
             } => f
-                .debug_struct("SetVoiceMode")
+                .debug_struct("SetAdeleOutput")
                 .field("conversation_id", conversation_id)
-                .field("enabled", enabled)
+                .field("level", level)
                 .finish(),
             UiMessage::ClientToolCall {
                 task_id,

--- a/src/voice_client.rs
+++ b/src/voice_client.rs
@@ -153,6 +153,11 @@ pub trait Voice {
     /// matching [`VoiceProxy::push_to_talk`].
     fn push_to_talk_in_conversation(&self, conversation_id: &str) -> zbus::Result<()>;
 
+    /// Speak `text` through the daemon's warm TTS Speaker + audio sink (maps to
+    /// `SayText`). The daemon's `Speaker` is one-shot and applies a per-synth
+    /// timeout, so callers must hand it **one short sentence at a time**.
+    fn say_text(&self, text: &str) -> zbus::Result<()>;
+
     /// Stop any in-progress TTS playback (barge-in).
     fn stop_speaking(&self) -> zbus::Result<()>;
 
@@ -263,6 +268,22 @@ impl VoiceController {
             PttRoute::InConversation(id) => self.push_to_talk_in_conversation(&id).await,
             PttRoute::DaemonSession => self.push_to_talk().await,
         }
+    }
+
+    /// Speak `text` through the daemon's warm Speaker (maps to `SayText`).
+    ///
+    /// Routing narration through the daemon reuses its already-warm models +
+    /// shared audio sink, which is far faster than the in-process embedded
+    /// engine (the live timeout bug). The daemon's `Speaker` is **one-shot** and
+    /// applies a per-synth timeout, so the caller must hand this **one short
+    /// sentence at a time** (see [`crate::voice_embedded::into_speakable_sentences`]).
+    /// Errors (including "daemon absent") surface as `Err(String)` for the caller
+    /// to log/report; a `None` proxy is a graceful "unavailable".
+    pub async fn say(&self, text: String) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.say_text(&text).await.map_err(|e| e.to_string())
     }
 
     /// Stop any in-progress TTS playback (barge-in before re-listening).

--- a/src/voice_embedded.rs
+++ b/src/voice_embedded.rs
@@ -26,12 +26,48 @@
 //! reply-playback hook.
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use adele_voice_core::sentence_buffer::SentenceBuffer;
 use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
 use adele_voice_module::{Dictation, Speaker, TtsBackend, build_dictation, build_speaker};
 use adele_voice_stt_whisper::WhisperStt;
 use adele_voice_vad_silero::SileroVad;
 use tokio::sync::Mutex;
+
+/// Split `text` into the chunks that should be fed to a one-shot synthesizer.
+///
+/// Both the daemon's `SayText` and the embedded [`EmbeddedVoice::say`] are
+/// **one-shot**: they assume a single short sentence and apply a per-synth
+/// timeout (`adele_voice_module`'s `DEFAULT_SYNTH_TIMEOUT`, ~20s). A long reply
+/// fed in one go would blow that timeout, so the *client* must chunk it the same
+/// way the daemon's streaming pipeline does — via [`SentenceBuffer`].
+///
+/// This pushes the whole text through a `SentenceBuffer` (collecting every
+/// complete sentence) and then appends the trailing remainder from `flush()`
+/// (the last sentence has no trailing whitespace, so the buffer holds it back).
+/// If chunking yields nothing — e.g. text with no recognised boundaries that the
+/// buffer somehow drops — it falls back to a single chunk of the original text
+/// when that text is non-blank, and to an empty `Vec` for empty/whitespace
+/// input (nothing to speak).
+///
+/// The timeout passed to the buffer is irrelevant here: this is a synchronous,
+/// one-shot push/flush with no streaming, so the time-based flush never fires.
+pub fn into_speakable_sentences(text: &str) -> Vec<String> {
+    // Timeout is unused on this synchronous push→flush path; any value works.
+    let mut buf = SentenceBuffer::new(Duration::from_millis(500));
+    let mut sentences = buf.push(text);
+    let tail = buf.flush();
+    if !tail.is_empty() {
+        sentences.push(tail);
+    }
+    if sentences.is_empty() && !text.trim().is_empty() {
+        // No boundary produced a chunk but there *is* speakable text — speak it
+        // whole rather than dropping it silently.
+        sentences.push(text.trim().to_string());
+    }
+    sentences
+}
 
 /// The concrete dictation type the config builder wires (Silero VAD + Whisper).
 type EmbeddedDictation = Dictation<SileroVad, WhisperStt>;
@@ -174,5 +210,55 @@ mod tests {
         let clone = engine.clone();
         assert!(!clone.is_playing().await);
         assert!(clone.stop_speaking().await.is_ok());
+    }
+
+    /// A multi-sentence reply splits into one chunk per sentence, in order, so
+    /// no single synth call carries the whole paragraph past its 20s timeout.
+    #[test]
+    fn chunks_multi_sentence_into_sentences() {
+        let chunks = into_speakable_sentences("Hello there. How are you? I am fine.");
+        assert_eq!(chunks, vec!["Hello there.", "How are you?", "I am fine."]);
+    }
+
+    /// A single sentence is one chunk.
+    #[test]
+    fn chunks_single_sentence_into_one() {
+        let chunks = into_speakable_sentences("Just one sentence here.");
+        assert_eq!(chunks, vec!["Just one sentence here."]);
+    }
+
+    /// Text with no trailing punctuation is still spoken — as one chunk (the
+    /// `flush()` tail), not dropped.
+    #[test]
+    fn chunks_text_without_terminal_punctuation_into_one() {
+        let chunks = into_speakable_sentences("no trailing punctuation here");
+        assert_eq!(chunks, vec!["no trailing punctuation here"]);
+    }
+
+    /// Empty / whitespace-only input has nothing to speak → no chunks (so the
+    /// caller makes zero synth calls rather than synthesizing silence).
+    #[test]
+    fn chunks_empty_or_whitespace_into_nothing() {
+        assert!(into_speakable_sentences("").is_empty());
+        assert!(into_speakable_sentences("   \n\t  ").is_empty());
+    }
+
+    /// A long multi-sentence paragraph splits into several chunks (the whole
+    /// point: keep each synth call short enough to beat the per-synth timeout).
+    #[test]
+    fn chunks_long_paragraph_into_multiple() {
+        let paragraph = "The quick brown fox jumps over the lazy dog. \
+             It then trots away to find a quiet spot. \
+             Later, the dog wakes up and stretches lazily. \
+             Neither animal pays the other any further mind. \
+             The afternoon sun warms the empty field.";
+        let chunks = into_speakable_sentences(paragraph);
+        assert!(
+            chunks.len() >= 4,
+            "a five-sentence paragraph should split into several chunks, got {}: {chunks:?}",
+            chunks.len()
+        );
+        // Every chunk must be non-empty (no blank synth calls).
+        assert!(chunks.iter().all(|c| !c.trim().is_empty()));
     }
 }

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -431,56 +431,6 @@ mod tests {
     }
 
     #[test]
-    fn speech_toggle_icon_and_tooltip_reflect_enabled_state() {
-        // Issue #76: the glyph and tooltip must distinguish ON (a speaker that
-        // plays) from OFF (a muted speaker — the master cut-off).
-        assert_ne!(speech_icons_for(true)[0], speech_icons_for(false)[0]);
-        assert_eq!(speech_icons_for(true)[0], "audio-volume-high-symbolic");
-        assert_eq!(speech_icons_for(false)[0], "audio-volume-muted-symbolic");
-        assert!(!speech_icons_for(true).is_empty());
-        assert!(!speech_icons_for(false).is_empty());
-
-        // Issue #78 reframes the toggle to the read-aloud/accessibility framing:
-        // the tooltips now talk about reading replies aloud rather than the raw
-        // "speech enabled" wording, and remain distinct per state.
-        assert_ne!(speech_tooltip_for(true), speech_tooltip_for(false));
-        assert!(
-            speech_tooltip_for(true)
-                .to_lowercase()
-                .contains("read aloud")
-        );
-        assert!(
-            speech_tooltip_for(false)
-                .to_lowercase()
-                .contains("read aloud")
-        );
-    }
-
-    #[test]
-    fn voice_mode_toggle_icon_and_tooltip_reflect_state() {
-        // Issue #78: the voice-mode toggle is a distinct control from read-aloud;
-        // its glyph and tooltip must distinguish ON from OFF, and the ON tooltip
-        // makes clear replies are spoken + shaped for the ear.
-        assert_ne!(
-            voice_mode_icons_for(true)[0],
-            voice_mode_icons_for(false)[0]
-        );
-        assert!(!voice_mode_icons_for(true).is_empty());
-        assert!(!voice_mode_icons_for(false).is_empty());
-        assert_ne!(voice_mode_tooltip_for(true), voice_mode_tooltip_for(false));
-        assert!(
-            voice_mode_tooltip_for(true)
-                .to_lowercase()
-                .contains("voice")
-        );
-        assert!(
-            voice_mode_tooltip_for(false)
-                .to_lowercase()
-                .contains("voice")
-        );
-    }
-
-    #[test]
     fn each_state_maps_to_a_distinct_primary_icon() {
         // The first entry in each chain is the plasmoid glyph; they must differ
         // per state so the button visibly tracks the pipeline.
@@ -506,5 +456,44 @@ mod tests {
         ] {
             assert!(!mic_icons_for(state).is_empty());
         }
+    }
+
+    /// Issue #80: the `You:` dropdown index round-trips the voice-input bool —
+    /// index 0 == Disabled, index 1 == Enabled — and an out-of-range index
+    /// decodes to the safe Disabled default (no capture offered).
+    #[test]
+    fn voice_in_index_round_trips_and_defaults_disabled() {
+        assert_eq!(voice_in_index(false), 0);
+        assert_eq!(voice_in_index(true), 1);
+        assert!(!voice_in_from_index(0));
+        assert!(voice_in_from_index(1));
+        // Out-of-range → Disabled (the safe default).
+        assert!(!voice_in_from_index(99));
+        // The labels exist and match the indices.
+        assert_eq!(VOICE_IN_OPTIONS[0], "Disabled");
+        assert_eq!(VOICE_IN_OPTIONS[1], "Enabled");
+    }
+
+    /// Issue #80: the `Adele:` dropdown index round-trips every output level,
+    /// matching the label order, and an out-of-range index decodes to the safe
+    /// Disabled default (never speaks).
+    #[test]
+    fn adele_output_index_round_trips_and_defaults_disabled() {
+        for level in [
+            AdeleOutput::Disabled,
+            AdeleOutput::OnDemand,
+            AdeleOutput::Always,
+        ] {
+            assert_eq!(adele_output_from_index(adele_output_index(level)), level);
+        }
+        assert_eq!(adele_output_index(AdeleOutput::Disabled), 0);
+        assert_eq!(adele_output_index(AdeleOutput::OnDemand), 1);
+        assert_eq!(adele_output_index(AdeleOutput::Always), 2);
+        // Out-of-range → Disabled (the safe default).
+        assert_eq!(adele_output_from_index(99), AdeleOutput::Disabled);
+        // The labels exist and match the indices.
+        assert_eq!(ADELE_OUTPUT_OPTIONS[0], "Disabled");
+        assert_eq!(ADELE_OUTPUT_OPTIONS[1], "On Demand");
+        assert_eq!(ADELE_OUTPUT_OPTIONS[2], "Always");
     }
 }

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -203,6 +203,12 @@ impl InputBar {
         let voice_row = GtkBox::new(Orientation::Horizontal, 8);
         voice_row.add_css_class("voice-controls-row");
 
+        // Lead-in label so the `You:` / `Adele:` dropdowns read unambiguously as
+        // voice controls rather than free-floating options (issue #80).
+        let voice_leadin = Label::new(Some("Voice:"));
+        voice_leadin.add_css_class("voice-controls-leadin");
+        voice_row.append(&voice_leadin);
+
         let you_label = Label::new(Some("You:"));
         you_label.add_css_class("voice-control-label");
         voice_row.append(&you_label);

--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -3,115 +3,112 @@ use std::rc::Rc;
 
 use gtk4::prelude::*;
 use gtk4::{
-    Box as GtkBox, Button, Image, Orientation, ScrolledWindow, TextView, ToggleButton, WrapMode,
-    glib,
+    Box as GtkBox, Button, DropDown, Image, Label, Orientation, ScrolledWindow, StringList,
+    TextView, WrapMode, glib,
 };
 
+use crate::async_bridge::AdeleOutput;
 use crate::voice_client::VoiceState;
 
-/// Callback fired when the user flips the read-aloud toggle (issue #76/#78). The
-/// bool is the new "read aloud" state for the active conversation.
-type SpeechToggledCb = Box<dyn Fn(bool)>;
+/// Callback fired when the user changes the `You:` (voice input) dropdown (issue
+/// #80). The bool is the new per-conversation voice-input state: `true` =
+/// Enabled (push-to-talk available), `false` = Disabled (type only).
+type VoiceInChangedCb = Box<dyn Fn(bool)>;
 
-/// Callback fired when the user flips the voice-mode toggle (issue #78). The
-/// bool is the new "voice mode" state for the active conversation.
-type VoiceModeToggledCb = Box<dyn Fn(bool)>;
+/// Callback fired when the user changes the `Adele:` (voice output) dropdown
+/// (issue #80). The argument is the new per-conversation output level.
+type AdeleOutputChangedCb = Box<dyn Fn(AdeleOutput)>;
 
-/// Input bar widget with a record/mic button, a text view, and a send button.
+/// Dropdown option labels for `You:` (voice input). Index 0 = Disabled, 1 =
+/// Enabled — the position is the source of truth the callbacks decode (see
+/// [`voice_in_index`] / [`voice_in_from_index`]).
+const VOICE_IN_OPTIONS: &[&str] = &["Disabled", "Enabled"];
+
+/// Dropdown option labels for `Adele:` (voice output). Index 0 = Disabled, 1 =
+/// On Demand, 2 = Always — matching [`AdeleOutput`]'s ordering.
+const ADELE_OUTPUT_OPTIONS: &[&str] = &["Disabled", "On Demand", "Always"];
+
+/// The `You:` dropdown index for a voice-input state. Disabled = 0, Enabled = 1.
+fn voice_in_index(enabled: bool) -> u32 {
+    if enabled { 1 } else { 0 }
+}
+
+/// Decode the `You:` dropdown index back to the voice-input bool. Any
+/// unexpected index (shouldn't happen — the StringList is fixed) falls back to
+/// Disabled, the safe default (no audio capture offered).
+fn voice_in_from_index(index: u32) -> bool {
+    index == 1
+}
+
+/// The `Adele:` dropdown index for an output level, matching
+/// [`ADELE_OUTPUT_OPTIONS`].
+fn adele_output_index(level: AdeleOutput) -> u32 {
+    match level {
+        AdeleOutput::Disabled => 0,
+        AdeleOutput::OnDemand => 1,
+        AdeleOutput::Always => 2,
+    }
+}
+
+/// Decode the `Adele:` dropdown index back to an output level. An unexpected
+/// index falls back to Disabled (the safe default — never speaks).
+fn adele_output_from_index(index: u32) -> AdeleOutput {
+    match index {
+        1 => AdeleOutput::OnDemand,
+        2 => AdeleOutput::Always,
+        _ => AdeleOutput::Disabled,
+    }
+}
+
+/// Input bar widget: a text view + Send button on the top row, and a labeled
+/// voice-controls row underneath (issue #80) with the `You:` (input) and
+/// `Adele:` (output) dropdowns plus a push-to-talk control shown only while
+/// `You == Enabled`.
 pub struct InputBar {
     pub container: GtkBox,
     pub text_view: TextView,
     pub send_button: Button,
-    /// Push-to-talk button: starts a dictation turn on the voice daemon,
-    /// routed into the active conversation (`PushToTalkInConversation`) or the
-    /// daemon's own session (`PushToTalk`) when none is open. Hidden until the
-    /// voice service is found on the bus (graceful degradation — see
-    /// [`InputBar::set_voice_available`]).
+    /// Push-to-talk button (issue #80). Lives in the voice-controls row and is
+    /// shown only when `You == Enabled` AND voice capture is available on this
+    /// machine (the daemon owns its bus name, or the embedded engine is
+    /// active). Clicking it starts a dictation turn routed into the active
+    /// conversation — the same mechanic the removed left mic used. Hidden by
+    /// default (You defaults to Disabled). The window wires its `connect_clicked`
+    /// exactly as it did the old mic button.
     pub mic_button: Button,
-    /// The mic icon, swapped per pipeline state to mirror the plasmoid's glyphs.
+    /// The push-to-talk icon, swapped per pipeline state to mirror the plasmoid.
     mic_image: Image,
-    /// Per-conversation "read aloud" (accessibility) toggle (issue #76, reframed
-    /// in #78). Default OFF. LLM-unaware: when ON every reply auto-routes to the
-    /// Speaker and `say_this` is spoken. The window owns the authoritative
-    /// per-conversation state and drives `set_speech_active` on conversation
-    /// switch; this button is the affordance + write source.
-    pub speech_button: ToggleButton,
-    /// The speaker glyph on the read-aloud toggle, swapped on/off.
-    speech_image: Image,
-    /// User callback for read-aloud toggle flips. Guarded by `suppress` so a
-    /// programmatic `set_speech_active` (on conversation switch) does not echo a
-    /// write back.
-    on_speech_toggled: Rc<RefCell<Option<SpeechToggledCb>>>,
-    /// Per-conversation soft-sticky "voice mode" toggle (issue #78). Default OFF.
-    /// The model drives the same state via `request_voice` / `stop_voice`; this
-    /// button lets the user enter/leave it directly. When ON, replies are
-    /// narrated AND shaped for speech (a read-aloud `system_refinement` on send).
-    pub voice_mode_button: ToggleButton,
-    /// The voice-mode glyph, swapped on/off.
-    voice_mode_image: Image,
-    /// User callback for voice-mode toggle flips. Guarded by `suppress` so a
-    /// programmatic `set_voice_mode_active` (on conversation switch / model
-    /// drive) does not echo a write back.
-    on_voice_mode_toggled: Rc<RefCell<Option<VoiceModeToggledCb>>>,
-    /// Re-entrancy guard shared by `set_speech_active` and
-    /// `set_voice_mode_active`, mirroring `voice_tab`.
+    /// Whether voice capture is available on this machine (the daemon is present
+    /// or the embedded engine is active). Combined with the `You` selection to
+    /// decide whether the push-to-talk button is actually shown — an Enabled
+    /// `You` with no capture backend must not offer a dead control.
+    voice_available: Rc<Cell<bool>>,
+    /// The `You:` (voice input) dropdown. Disabled (type only) / Enabled
+    /// (push-to-talk available). The window owns the authoritative
+    /// per-conversation state and drives `set_voice_in_active` on conversation
+    /// switch; this dropdown is the affordance + write source.
+    pub voice_in_dropdown: DropDown,
+    /// User callback for `You:` dropdown changes. Guarded by `suppress` so a
+    /// programmatic `set_voice_in_active` (on conversation switch) does not echo
+    /// a write back.
+    on_voice_in_changed: Rc<RefCell<Option<VoiceInChangedCb>>>,
+    /// The `Adele:` (voice output) dropdown. Disabled / On Demand / Always. The
+    /// window owns the authoritative per-conversation state and drives
+    /// `set_adele_output_active` on conversation switch and on a model
+    /// `request_voice` / `stop_voice`; this dropdown is the affordance + write
+    /// source.
+    pub adele_output_dropdown: DropDown,
+    /// User callback for `Adele:` dropdown changes. Guarded by `suppress` so a
+    /// programmatic `set_adele_output_active` does not echo a write back.
+    on_adele_output_changed: Rc<RefCell<Option<AdeleOutputChangedCb>>>,
+    /// Re-entrancy guard shared by `set_voice_in_active` and
+    /// `set_adele_output_active`: a programmatic set must not echo a write back
+    /// through its callback.
     suppress: Rc<Cell<bool>>,
-    /// The last pipeline state reflected on the button. The window's click
-    /// handler reads it to decide barge-in (click while `Speaking` →
-    /// `StopSpeaking`, otherwise start a push-to-talk turn).
+    /// The last pipeline state reflected on the push-to-talk button. The
+    /// window's click handler reads it to decide barge-in (click while
+    /// `Speaking` → stop, otherwise start a push-to-talk turn).
     state: Rc<Cell<VoiceState>>,
-}
-
-/// Themed-icon fallback chain for the read-aloud toggle, by enabled state (#76).
-/// ON shows a speaker with sound; OFF shows a muted speaker, mirroring the
-/// "audio never plays while off" cut-off.
-fn speech_icons_for(enabled: bool) -> &'static [&'static str] {
-    if enabled {
-        &["audio-volume-high-symbolic", "audio-volume-high"]
-    } else {
-        &["audio-volume-muted-symbolic", "audio-volume-muted"]
-    }
-}
-
-/// Tooltip for the read-aloud (accessibility) toggle by state (#76, reframed in
-/// #78). Read-aloud auto-narrates every reply when ON; the copy uses the
-/// accessibility framing rather than the raw "speech enabled" wording.
-fn speech_tooltip_for(enabled: bool) -> &'static str {
-    if enabled {
-        "Read aloud — narrate every reply in this conversation. Click to mute."
-    } else {
-        "Read aloud is off — replies are not read aloud in this conversation. Click to enable."
-    }
-}
-
-/// Themed-icon fallback chain for the voice-mode toggle, by state (#78). ON
-/// shows a chat-bubble/voice glyph; OFF shows a muted variant — distinct from
-/// the read-aloud speaker glyphs so the two controls read as separate.
-fn voice_mode_icons_for(enabled: bool) -> &'static [&'static str] {
-    if enabled {
-        &[
-            "user-available-symbolic",
-            "audio-input-microphone-symbolic",
-            "audio-input-microphone",
-        ]
-    } else {
-        &[
-            "user-offline-symbolic",
-            "audio-input-microphone-muted-symbolic",
-            "audio-input-microphone-muted",
-        ]
-    }
-}
-
-/// Tooltip for the voice-mode toggle by state (#78). Voice mode narrates and
-/// shapes replies for speech; entering it is a mode of interaction, so the copy
-/// frames it as talking by voice.
-fn voice_mode_tooltip_for(enabled: bool) -> &'static str {
-    if enabled {
-        "Voice mode on — replies are spoken and kept conversational. Click to go back to text."
-    } else {
-        "Voice mode off — text only. Click to talk by voice (replies spoken and shaped for the ear)."
-    }
 }
 
 /// Themed-icon fallback chain for the **resting (Idle)** mic glyph. The first
@@ -148,9 +145,9 @@ fn mic_icons_for(state: VoiceState) -> &'static [&'static str] {
     }
 }
 
-/// The mic button's tooltip for a given state, mirroring the plasmoid: "Stop
-/// speaking" while Speaking (the click barges in), otherwise "Push to talk"
-/// with the in-progress phase appended.
+/// The push-to-talk button's tooltip for a given state, mirroring the plasmoid:
+/// "Stop speaking" while Speaking (the click barges in), otherwise "Push to
+/// talk" with the in-progress phase appended.
 fn mic_tooltip_for(state: VoiceState) -> String {
     match state {
         VoiceState::Speaking => "Stop speaking".to_string(),
@@ -159,25 +156,24 @@ fn mic_tooltip_for(state: VoiceState) -> String {
     }
 }
 
+impl Default for InputBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InputBar {
     pub fn new() -> Self {
-        let container = GtkBox::new(Orientation::Horizontal, 8);
+        // The bar is now vertical: an entry+Send row on top, a labeled
+        // voice-controls row underneath (issue #80).
+        let container = GtkBox::new(Orientation::Vertical, 4);
         container.set_margin_start(8);
         container.set_margin_end(8);
         container.set_margin_top(4);
         container.set_margin_bottom(8);
 
-        // Push-to-talk button, left of the text entry. Starts hidden; the
-        // window reveals it once the voice daemon is found on the bus.
-        let mic_image = Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_IDLE_ICONS));
-        let mic_button = Button::new();
-        mic_button.set_child(Some(&mic_image));
-        mic_button.add_css_class("mic-button");
-        mic_button.set_valign(gtk4::Align::End);
-        mic_button.set_margin_bottom(4);
-        mic_button.set_tooltip_text(Some(&mic_tooltip_for(VoiceState::Idle)));
-        mic_button.set_visible(false);
-        container.append(&mic_button);
+        // --- Top row: text entry + Send ------------------------------------
+        let entry_row = GtkBox::new(Orientation::Horizontal, 8);
 
         let scrolled = ScrolledWindow::new();
         scrolled.set_hexpand(true);
@@ -192,91 +188,112 @@ impl InputBar {
         text_view.set_right_margin(12);
         text_view.add_css_class("input-textview");
         scrolled.set_child(Some(&text_view));
-        container.append(&scrolled);
-
-        // Per-conversation read-aloud toggle (issue #76, reframed in #78),
-        // between the entry and Send. Default OFF; the window sets the active
-        // conversation's state on switch via `set_speech_active`.
-        let speech_image =
-            Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(false)));
-        let speech_button = ToggleButton::new();
-        speech_button.set_child(Some(&speech_image));
-        speech_button.add_css_class("speech-button");
-        speech_button.set_valign(gtk4::Align::End);
-        speech_button.set_margin_bottom(4);
-        speech_button.set_tooltip_text(Some(speech_tooltip_for(false)));
-        container.append(&speech_button);
-
-        // Per-conversation voice-mode toggle (issue #78), beside read-aloud.
-        // Default OFF; the window sets the active conversation's state on switch
-        // (and on a model `request_voice`/`stop_voice`) via
-        // `set_voice_mode_active`.
-        let voice_mode_image = Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(
-            voice_mode_icons_for(false),
-        ));
-        let voice_mode_button = ToggleButton::new();
-        voice_mode_button.set_child(Some(&voice_mode_image));
-        voice_mode_button.add_css_class("voice-mode-button");
-        voice_mode_button.set_valign(gtk4::Align::End);
-        voice_mode_button.set_margin_bottom(4);
-        voice_mode_button.set_tooltip_text(Some(voice_mode_tooltip_for(false)));
-        container.append(&voice_mode_button);
+        entry_row.append(&scrolled);
 
         let send_button = Button::with_label("Send");
         send_button.add_css_class("send-button");
         send_button.set_valign(gtk4::Align::End);
-        send_button.set_margin_bottom(4);
-        container.append(&send_button);
+        entry_row.append(&send_button);
+        container.append(&entry_row);
 
-        let on_speech_toggled: Rc<RefCell<Option<SpeechToggledCb>>> = Rc::new(RefCell::new(None));
-        let on_voice_mode_toggled: Rc<RefCell<Option<VoiceModeToggledCb>>> =
+        // --- Voice-controls row (issue #80) --------------------------------
+        // A labeled row directly under the input: `You:` (input) and `Adele:`
+        // (output) dropdowns, visually matched, plus a push-to-talk button
+        // shown only while `You == Enabled`.
+        let voice_row = GtkBox::new(Orientation::Horizontal, 8);
+        voice_row.add_css_class("voice-controls-row");
+
+        let you_label = Label::new(Some("You:"));
+        you_label.add_css_class("voice-control-label");
+        voice_row.append(&you_label);
+
+        let voice_in_dropdown = DropDown::new(
+            Some(StringList::new(VOICE_IN_OPTIONS)),
+            gtk4::Expression::NONE,
+        );
+        voice_in_dropdown.add_css_class("voice-in-dropdown");
+        voice_in_dropdown.set_tooltip_text(Some(
+            "Voice input — Enabled offers a push-to-talk button to speak your turns.",
+        ));
+        voice_row.append(&voice_in_dropdown);
+
+        // Push-to-talk, right after the `You:` dropdown so it reads as part of
+        // that control. Hidden until `You == Enabled` AND capture is available.
+        let mic_image = Image::from_gicon(&gtk4::gio::ThemedIcon::from_names(MIC_IDLE_ICONS));
+        let mic_button = Button::new();
+        mic_button.set_child(Some(&mic_image));
+        mic_button.add_css_class("mic-button");
+        mic_button.set_tooltip_text(Some(&mic_tooltip_for(VoiceState::Idle)));
+        mic_button.set_visible(false);
+        voice_row.append(&mic_button);
+
+        let adele_label = Label::new(Some("Adele:"));
+        adele_label.add_css_class("voice-control-label");
+        adele_label.set_margin_start(12);
+        voice_row.append(&adele_label);
+
+        let adele_output_dropdown = DropDown::new(
+            Some(StringList::new(ADELE_OUTPUT_OPTIONS)),
+            gtk4::Expression::NONE,
+        );
+        adele_output_dropdown.add_css_class("adele-output-dropdown");
+        adele_output_dropdown.set_tooltip_text(Some(
+            "Voice output — On Demand speaks while you're talking by voice; Always reads every \
+             reply aloud.",
+        ));
+        voice_row.append(&adele_output_dropdown);
+
+        container.append(&voice_row);
+
+        let on_voice_in_changed: Rc<RefCell<Option<VoiceInChangedCb>>> =
             Rc::new(RefCell::new(None));
-        // A single re-entrancy guard for both toggles: a programmatic
+        let on_adele_output_changed: Rc<RefCell<Option<AdeleOutputChangedCb>>> =
+            Rc::new(RefCell::new(None));
+        // A single re-entrancy guard for both dropdowns: a programmatic
         // `set_*_active` must not echo a write back through its callback.
         let suppress = Rc::new(Cell::new(false));
+        let voice_available = Rc::new(Cell::new(false));
 
-        speech_button.connect_toggled(glib::clone!(
+        // `You:` dropdown changes: decode the new selection, toggle the
+        // push-to-talk button's visibility, and (unless suppressed) fire the
+        // user callback.
+        voice_in_dropdown.connect_selected_notify(glib::clone!(
             #[strong]
-            on_speech_toggled,
+            on_voice_in_changed,
             #[strong]
             suppress,
+            #[strong]
+            voice_available,
             #[weak]
-            speech_image,
-            move |btn| {
-                let enabled = btn.is_active();
-                // Always reflect the glyph/tooltip, even on a suppressed
-                // (programmatic) flip, so the button never lies about state.
-                speech_image.set_from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(
-                    enabled,
-                )));
-                btn.set_tooltip_text(Some(speech_tooltip_for(enabled)));
+            mic_button,
+            move |dd| {
+                let enabled = voice_in_from_index(dd.selected());
+                // Always reflect the push-to-talk visibility, even on a
+                // suppressed (programmatic) change, so the control never lies.
+                mic_button.set_visible(enabled && voice_available.get());
                 if suppress.get() {
                     return;
                 }
-                if let Some(cb) = on_speech_toggled.borrow().as_ref() {
+                if let Some(cb) = on_voice_in_changed.borrow().as_ref() {
                     cb(enabled);
                 }
             }
         ));
 
-        voice_mode_button.connect_toggled(glib::clone!(
+        // `Adele:` dropdown changes: decode the level and (unless suppressed)
+        // fire the user callback.
+        adele_output_dropdown.connect_selected_notify(glib::clone!(
             #[strong]
-            on_voice_mode_toggled,
+            on_adele_output_changed,
             #[strong]
             suppress,
-            #[weak]
-            voice_mode_image,
-            move |btn| {
-                let enabled = btn.is_active();
-                voice_mode_image.set_from_gicon(&gtk4::gio::ThemedIcon::from_names(
-                    voice_mode_icons_for(enabled),
-                ));
-                btn.set_tooltip_text(Some(voice_mode_tooltip_for(enabled)));
+            move |dd| {
+                let level = adele_output_from_index(dd.selected());
                 if suppress.get() {
                     return;
                 }
-                if let Some(cb) = on_voice_mode_toggled.borrow().as_ref() {
-                    cb(enabled);
+                if let Some(cb) = on_adele_output_changed.borrow().as_ref() {
+                    cb(level);
                 }
             }
         ));
@@ -287,74 +304,70 @@ impl InputBar {
             send_button,
             mic_button,
             mic_image,
-            speech_button,
-            speech_image,
-            on_speech_toggled,
-            voice_mode_button,
-            voice_mode_image,
-            on_voice_mode_toggled,
+            voice_available,
+            voice_in_dropdown,
+            on_voice_in_changed,
+            adele_output_dropdown,
+            on_adele_output_changed,
             suppress,
             state: Rc::new(Cell::new(VoiceState::Idle)),
         }
     }
 
-    /// Register the callback fired when the user flips the read-aloud toggle
-    /// (issue #76). The argument is the new per-conversation "read aloud" state.
-    pub fn connect_speech_toggled<F: Fn(bool) + 'static>(&self, f: F) {
-        *self.on_speech_toggled.borrow_mut() = Some(Box::new(f));
+    /// Register the callback fired when the user changes the `You:` dropdown
+    /// (issue #80). The argument is the new per-conversation voice-input state.
+    pub fn connect_voice_in_changed<F: Fn(bool) + 'static>(&self, f: F) {
+        *self.on_voice_in_changed.borrow_mut() = Some(Box::new(f));
     }
 
-    /// Reflect the active conversation's read-aloud state on the toggle WITHOUT
-    /// echoing a write back (issue #76). Called by the window on conversation
-    /// switch so the button always shows the conversation it belongs to —
-    /// per-conversation state, no cross-conversation bleed.
-    pub fn set_speech_active(&self, enabled: bool) {
+    /// Reflect the active conversation's voice-input state on the `You:`
+    /// dropdown WITHOUT echoing a write back (issue #80). Called by the window
+    /// on conversation switch so the dropdown always shows the conversation it
+    /// belongs to — per-conversation state, no cross-conversation bleed. Also
+    /// re-evaluates the push-to-talk button's visibility.
+    pub fn set_voice_in_active(&self, enabled: bool) {
         self.suppress.set(true);
-        self.speech_button.set_active(enabled);
-        // `connect_toggled` only fires on a *change*; ensure the glyph/tooltip
-        // are correct even when the value didn't change.
-        self.speech_image
-            .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(speech_icons_for(
-                enabled,
-            )));
-        self.speech_button
-            .set_tooltip_text(Some(speech_tooltip_for(enabled)));
+        self.voice_in_dropdown.set_selected(voice_in_index(enabled));
+        // `connect_selected_notify` only fires on a *change*; ensure the
+        // push-to-talk visibility is correct even when the value didn't change.
+        self.mic_button
+            .set_visible(enabled && self.voice_available.get());
         self.suppress.set(false);
     }
 
-    /// Register the callback fired when the user flips the voice-mode toggle
-    /// (issue #78). The argument is the new per-conversation "voice mode" state.
-    pub fn connect_voice_mode_toggled<F: Fn(bool) + 'static>(&self, f: F) {
-        *self.on_voice_mode_toggled.borrow_mut() = Some(Box::new(f));
+    /// Register the callback fired when the user changes the `Adele:` dropdown
+    /// (issue #80). The argument is the new per-conversation output level.
+    pub fn connect_adele_output_changed<F: Fn(AdeleOutput) + 'static>(&self, f: F) {
+        *self.on_adele_output_changed.borrow_mut() = Some(Box::new(f));
     }
 
-    /// Reflect the active conversation's voice-mode state on the toggle WITHOUT
-    /// echoing a write back (issue #78). Called by the window on conversation
-    /// switch and when the model drives voice mode via `request_voice` /
-    /// `stop_voice`, so the button always tracks the conversation's state — no
-    /// cross-conversation bleed.
-    pub fn set_voice_mode_active(&self, enabled: bool) {
+    /// Reflect the active conversation's output level on the `Adele:` dropdown
+    /// WITHOUT echoing a write back (issue #80). Called by the window on
+    /// conversation switch and when the model drives the level via
+    /// `request_voice` / `stop_voice`, so the dropdown always tracks the
+    /// conversation's state — no cross-conversation bleed.
+    pub fn set_adele_output_active(&self, level: AdeleOutput) {
         self.suppress.set(true);
-        self.voice_mode_button.set_active(enabled);
-        self.voice_mode_image
-            .set_from_gicon(&gtk4::gio::ThemedIcon::from_names(voice_mode_icons_for(
-                enabled,
-            )));
-        self.voice_mode_button
-            .set_tooltip_text(Some(voice_mode_tooltip_for(enabled)));
+        self.adele_output_dropdown
+            .set_selected(adele_output_index(level));
         self.suppress.set(false);
     }
 
-    /// Show or hide the mic button based on whether the voice daemon is
-    /// reachable. Hidden when absent so the user isn't offered a dead control
-    /// (graceful degradation per issue #59).
+    /// Record whether voice capture is available on this machine and refresh the
+    /// push-to-talk button's visibility accordingly (issue #80, graceful
+    /// degradation per #59). When capture is unavailable the push-to-talk button
+    /// stays hidden even if `You == Enabled`, so the user is never offered a dead
+    /// control. The `Adele` output dropdown is independent and unaffected.
     pub fn set_voice_available(&self, available: bool) {
-        self.mic_button.set_visible(available);
+        self.voice_available.set(available);
+        // Show push-to-talk only when capture is available AND You == Enabled.
+        let you_enabled = voice_in_from_index(self.voice_in_dropdown.selected());
+        self.mic_button.set_visible(available && you_enabled);
     }
 
-    /// Reflect the voice pipeline state on the mic button: the icon swaps to
-    /// the per-state glyph (mirroring the plasmoid), a CSS class drives the
-    /// accent while a turn is active, and the tooltip explains the current
+    /// Reflect the voice pipeline state on the push-to-talk button: the icon
+    /// swaps to the per-state glyph (mirroring the plasmoid), a CSS class drives
+    /// the accent while a turn is active, and the tooltip explains the current
     /// phase. The state is also cached for the click handler's barge-in check
     /// (see [`InputBar::current_state`]).
     pub fn reflect_voice_state(&self, state: VoiceState) {
@@ -373,9 +386,9 @@ impl InputBar {
             .set_tooltip_text(Some(&mic_tooltip_for(state)));
     }
 
-    /// The last pipeline state reflected on the button. The window's click
-    /// handler uses this to choose barge-in (`Speaking` → `StopSpeaking`) vs.
-    /// starting a push-to-talk turn.
+    /// The last pipeline state reflected on the push-to-talk button. The
+    /// window's click handler uses this to choose barge-in (`Speaking` → stop)
+    /// vs. starting a push-to-talk turn.
     pub fn current_state(&self) -> VoiceState {
         self.state.get()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1155,6 +1155,14 @@ impl AdelieWindow {
         // `&TransportClient` surface (`as_commands()`, `AssistantClient` RPCs).
         let client: Rc<RefCell<Option<Arc<Connector>>>> = Rc::new(RefCell::new(None));
 
+        // Handle to the standalone voice daemon (`org.desktopAssistant.Voice`),
+        // declared here — *before* the bridge — so the `handle_ui_message`
+        // executor can also reach it (issue #80): narration prefers the daemon's
+        // warm Speaker over the slow embedded engine. Populated later by
+        // `wire_voice_controls` (daemon path) once the async connect lands;
+        // until then it's `None` (and `Effect::Speak` falls back to embedded).
+        let voice: Rc<RefCell<Option<VoiceController>>> = Rc::new(RefCell::new(None));
+
         // Set up async bridge with UI message handler
         let bridge = AsyncBridge::new(glib::clone!(
             #[strong]
@@ -1182,6 +1190,8 @@ impl AdelieWindow {
             #[strong]
             embedded_voice,
             #[strong]
+            voice,
+            #[strong]
             voice_reply_pending,
             move |msg, ui_tx| {
                 handle_ui_message(
@@ -1198,6 +1208,7 @@ impl AdelieWindow {
                     &toast_revealer,
                     &toast_label,
                     &embedded_voice,
+                    &voice,
                     &voice_reply_pending,
                     ui_tx,
                 );
@@ -1210,8 +1221,9 @@ impl AdelieWindow {
         // orchestrator transport above. We connect once, share the handle so
         // both the mic button and the Settings → Voice tab can drive it, and
         // gate the UI on the daemon actually owning its bus name (graceful
-        // degradation when it isn't running / models aren't provisioned).
-        let voice: Rc<RefCell<Option<VoiceController>>> = Rc::new(RefCell::new(None));
+        // degradation when it isn't running / models aren't provisioned). The
+        // `voice` handle itself was declared above (before the bridge) so the
+        // `Effect::Speak` executor can prefer the daemon for narration (#80).
         // The daemon controls are wired only on the daemon path. In embedded
         // mode the mic button is driven in-process (wired in the send block
         // below, where it can reuse the send action) and shown immediately,
@@ -2352,6 +2364,61 @@ fn wire_embedded_mic(
     ));
 }
 
+/// Speak `text` aloud, daemon-first and chunked (issue #80).
+///
+/// Single entry point shared by every spoken-output site (reply narration and
+/// `say_this` asides) so routing + chunking live in one place:
+///
+/// 1. **Chunk.** `text` is split into one-short-sentence-per-call pieces via
+///    [`into_speakable_sentences`]. Both backends' synth is one-shot with a
+///    ~20s per-synth timeout, so feeding a long reply whole would blow it — the
+///    live bug this fixes.
+/// 2. **Route, daemon-first.** When a connected voice daemon is available, each
+///    sentence goes to its warm `SayText`; otherwise, if the embedded engine is
+///    present, to `EmbeddedVoice::say`; otherwise nothing is spoken. The backend
+///    is chosen **once** for the whole utterance (not per sentence) so playback
+///    never splits across engines.
+/// 3. **Order.** Sentences are awaited **sequentially**, so the daemon/embedded
+///    sink receives — and plays — them in order; they are never fired unordered.
+///
+/// Errors are reported once (the first failing sentence) via `ui_tx` and the
+/// rest of the utterance is abandoned, matching the prior single-shot behaviour.
+async fn speak_text(
+    voice: Option<VoiceController>,
+    embedded: Option<crate::voice_embedded::EmbeddedVoice>,
+    ui_tx: mpsc::UnboundedSender<UiMessage>,
+    text: String,
+) {
+    let sentences = crate::voice_embedded::into_speakable_sentences(&text);
+    if sentences.is_empty() {
+        return;
+    }
+
+    // Choose the backend once for the whole utterance: a daemon that has
+    // actually connected wins (warm models), else the in-process engine. Probing
+    // availability also avoids handing sentences to a daemon that vanished.
+    let daemon = match voice {
+        Some(controller) if controller.is_available().await => Some(controller),
+        _ => None,
+    };
+
+    for sentence in sentences {
+        let result = if let Some(controller) = &daemon {
+            controller.say(sentence).await
+        } else if let Some(engine) = &embedded {
+            engine.say(&sentence).await
+        } else {
+            // Neither backend present (daemon absent + no embedded engine):
+            // nothing to speak, and nothing more will become available mid-loop.
+            return;
+        };
+        if let Err(e) = result {
+            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
+            return;
+        }
+    }
+}
+
 /// Current wall-clock time in epoch milliseconds. Centralized so the
 /// task-panel callers all use the same units as `TaskView.started_at`.
 fn now_epoch_ms() -> i64 {
@@ -2377,6 +2444,7 @@ fn handle_ui_message(
     toast_revealer: &Rc<Revealer>,
     toast_label: &Rc<Label>,
     embedded_voice: &Rc<Option<crate::voice_embedded::EmbeddedVoice>>,
+    voice: &Rc<RefCell<Option<VoiceController>>>,
     voice_reply_pending: &Rc<Cell<bool>>,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
 ) {
@@ -2476,23 +2544,20 @@ fn handle_ui_message(
             }
             Effect::CompleteStreaming(full) => {
                 chat_view.borrow_mut().complete_streaming(&full);
-                // Embedded voice (issue #65): speak the reply only when this
-                // turn was started by the embedded mic button (so typed
-                // messages stay silent). The flag is consumed here; on the
-                // daemon path `embedded_voice` is `None` and the daemon speaks
-                // its own replies, so this is a no-op.
-                let engine = if voice_reply_pending.replace(false) {
-                    (**embedded_voice).clone()
-                } else {
-                    None
-                };
-                if let Some(engine) = engine {
+                // Voice (issues #65/#80): speak the reply only when this turn was
+                // started by the embedded mic button (so typed messages stay
+                // silent). The flag is consumed here. Narration is routed
+                // daemon-first and chunked through the shared `speak_text` helper
+                // (#80): on the embedded path `voice` is `None` so it uses the
+                // in-process engine; if a daemon is connected it speaks via the
+                // warm `SayText` instead — one short sentence per synth call.
+                if voice_reply_pending.replace(false) {
+                    let voice = voice.borrow().clone();
+                    let embedded = (**embedded_voice).clone();
                     let ui_tx = ui_tx.clone();
                     let reply = full.clone();
                     crate::async_bridge::spawn_on_runtime(async move {
-                        if let Err(e) = engine.say(&reply).await {
-                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
-                        }
+                        speak_text(voice, embedded, ui_tx, reply).await;
                     });
                 }
             }
@@ -2560,20 +2625,20 @@ fn handle_ui_message(
                 side_pane.set_tasks(&rows);
             }
             Effect::Speak(text) => {
-                // Speak via the embedded engine. `apply` only emits this when
-                // the active conversation has speech ON, so this is the spoken
-                // path of both reply narration and a `say_this` aside. No-op on
-                // the daemon path (`embedded_voice` is `None` there — the daemon
-                // narrates its own replies), which keeps the master cut-off:
-                // audio is produced by exactly one engine.
-                if let Some(engine) = (**embedded_voice).clone() {
-                    let ui_tx = ui_tx.clone();
-                    crate::async_bridge::spawn_on_runtime(async move {
-                        if let Err(e) = engine.say(&text).await {
-                            let _ = ui_tx.send(UiMessage::Error(format!("Voice: {e}")));
-                        }
-                    });
-                }
+                // Spoken output, daemon-first + chunked (#80). `apply` only emits
+                // this when the active conversation has speech ON, so this is the
+                // spoken path of both reply narration and a `say_this` aside. The
+                // shared `speak_text` helper prefers a connected voice daemon's
+                // warm `SayText` and otherwise falls back to the embedded engine,
+                // chunking the text into one short sentence per synth call so a
+                // long reply can't trip the per-synth ~20s timeout. Audio is
+                // still produced by exactly one engine (daemon OR embedded).
+                let voice = voice.borrow().clone();
+                let embedded = (**embedded_voice).clone();
+                let ui_tx = ui_tx.clone();
+                crate::async_bridge::spawn_on_runtime(async move {
+                    speak_text(voice, embedded, ui_tx, text).await;
+                });
             }
             Effect::AddInlineNote(note) => {
                 chat_view.borrow_mut().add_inline_note(&note);

--- a/src/window.rs
+++ b/src/window.rs
@@ -3514,10 +3514,10 @@ mod tests {
         assert!(effects.is_empty());
     }
 
-    // --- Speech toggle + client tools (issue #76) ------------------------
+    // --- Voice UI: You/Adele dropdowns + client tools (issue #80) --------
 
-    /// A `say_this` client-tool call (#76). Convenience constructor for the
-    /// tests below.
+    /// A `say_this` client-tool call (#76, still used in #80). Convenience
+    /// constructor for the tests below.
     fn say_this_call(conversation_id: &str, text: &str) -> UiMessage {
         UiMessage::ClientToolCall {
             task_id: "task-1".to_string(),
@@ -3528,53 +3528,70 @@ mod tests {
         }
     }
 
-    /// Acceptance: the hard toggle defaults OFF for a conversation that was
-    /// never touched, so `speech_enabled_for_current` reports `false` and no
-    /// audio path can fire.
+    /// A `request_voice` / `stop_voice` client-tool call (#80). Convenience
+    /// constructor mirroring `say_this_call`.
+    fn voice_tool_call(conversation_id: &str, tool_name: &str) -> UiMessage {
+        UiMessage::ClientToolCall {
+            task_id: "task-v".to_string(),
+            conversation_id: conversation_id.to_string(),
+            tool_call_id: "call-v".to_string(),
+            tool_name: tool_name.to_string(),
+            arguments: serde_json::json!({}),
+        }
+    }
+
+    /// A `WindowState` pinned to conversation `c1` with the given `You:` and
+    /// `Adele:` settings — the common test fixture for the gate tests below.
+    fn state_with(voice_in: bool, adele: AdeleOutput) -> WindowState {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        state.conversation_voice_in.insert("c1".to_string(), voice_in);
+        state.conversation_adele_output.insert("c1".to_string(), adele);
+        state
+    }
+
+    /// A `StreamComplete` for `c1` carrying `full_response`, against a freshly
+    /// pinned pending request — the reply-narration trigger.
+    fn stream_complete_in(state: &mut WindowState, full_response: &str) -> Vec<Effect> {
+        state.pending_request_id = Some("req".to_string());
+        state.current_conversation = Some(detail("c1", vec![]));
+        state.apply(UiMessage::StreamComplete {
+            request_id: "req".to_string(),
+            full_response: full_response.to_string(),
+        })
+    }
+
+    /// Default (You=Disabled, Adele=Disabled): both controls default off for an
+    /// untouched conversation, so no audio path can fire.
     #[test]
-    fn speech_toggle_defaults_off_per_conversation() {
+    fn defaults_are_voice_in_disabled_and_adele_disabled() {
         let state = WindowState {
             current_conversation_id: Some("c1".to_string()),
             ..Default::default()
         };
         assert!(
-            !state.speech_enabled_for_current(),
-            "speech must default OFF for an untouched conversation"
+            !state.voice_in_for_current(),
+            "You must default Disabled for an untouched conversation"
         );
-    }
-
-    /// `SetSpeechEnabled` records the flag per conversation and only affects
-    /// the named conversation — enabling speech in c1 must not enable it in c2
-    /// (no cross-conversation bleed).
-    #[test]
-    fn set_speech_enabled_is_scoped_to_its_conversation() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = state.apply(UiMessage::SetSpeechEnabled {
-            conversation_id: "c1".to_string(),
-            enabled: true,
-        });
-        assert!(effects.is_empty(), "toggling state emits no effects");
-        assert!(state.speech_enabled_for_current());
-        // Switch the active conversation to c2: it inherits the default OFF.
-        state.current_conversation_id = Some("c2".to_string());
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::Disabled,
+            "Adele must default Disabled for an untouched conversation"
+        );
+        assert!(!state.narrate_for_current(), "default gate must be closed");
         assert!(
-            !state.speech_enabled_for_current(),
-            "enabling speech in c1 must not leak into c2"
+            !state.say_this_spoken_for_current(),
+            "default say_this must downgrade to inline"
         );
-        // And back to c1: still ON (sticks per conversation).
-        state.current_conversation_id = Some("c1".to_string());
-        assert!(state.speech_enabled_for_current());
     }
 
-    /// Acceptance: with speech OFF, a `say_this` call produces the inline
-    /// `(speech mode disabled) …` downgrade and ALWAYS a `SubmitClientToolResult`
-    /// — and crucially NO `Speak` effect (the master audio cut-off). The turn
-    /// completes (a result is posted), so it can't hang.
+    /// Default: a `say_this` produces the inline `(speech mode disabled) …`
+    /// downgrade, NO `Speak`, and ALWAYS a `SubmitClientToolResult` (the turn
+    /// completes, can't hang).
     #[test]
-    fn say_this_while_speech_off_renders_inline_and_resolves_without_audio() {
+    fn default_say_this_renders_inline_and_resolves_without_audio() {
         let mut state = WindowState {
             current_conversation_id: Some("c1".to_string()),
             ..Default::default()
@@ -3582,7 +3599,7 @@ mod tests {
         let effects = state.apply(say_this_call("c1", "the aside"));
         assert!(
             !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "speech OFF must never produce a Speak effect: {effects:?}"
+            "Adele Disabled must never produce a Speak effect: {effects:?}"
         );
         let inline = effects.iter().any(
             |e| matches!(e, Effect::AddInlineNote(t) if t == "(speech mode disabled) the aside"),
@@ -3595,34 +3612,47 @@ mod tests {
                     if task_id == "task-1" && tool_call_id == "call-1"
             )
         });
-        assert!(
-            resolved,
-            "say_this must always resolve a result: {effects:?}"
-        );
+        assert!(resolved, "say_this must always resolve a result: {effects:?}");
     }
 
-    /// Acceptance: with speech ON, a `say_this` call speaks the text and
-    /// resolves the result `"spoken"`. No inline downgrade note.
+    /// Adele=Always: every reply is spoken (and finalized), independent of You.
     #[test]
-    fn say_this_while_speech_on_speaks_and_resolves_spoken() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        state
-            .conversation_speech_enabled
-            .insert("c1".to_string(), true);
+    fn adele_always_speaks_every_reply_regardless_of_you() {
+        for voice_in in [false, true] {
+            let mut state = state_with(voice_in, AdeleOutput::Always);
+            assert!(
+                state.narrate_for_current(),
+                "Always must narrate (You={voice_in})"
+            );
+            let effects = stream_complete_in(&mut state, "an answer");
+            assert!(
+                effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::Speak(t) if t == "an answer")),
+                "Always must speak the reply (You={voice_in}): {effects:?}"
+            );
+            assert!(
+                effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::CompleteStreaming(t) if t == "an answer")),
+                "the reply text must still be finalized: {effects:?}"
+            );
+        }
+    }
+
+    /// Adele=Always: a `say_this` aside is spoken (Adele ∈ {OnDemand, Always}).
+    #[test]
+    fn adele_always_speaks_say_this_aside() {
+        let mut state = state_with(false, AdeleOutput::Always);
         let effects = state.apply(say_this_call("c1", "hello aloud"));
         assert!(
             effects
                 .iter()
                 .any(|e| matches!(e, Effect::Speak(t) if t == "hello aloud")),
-            "speech ON must speak the aside: {effects:?}"
+            "Always must speak a say_this aside: {effects:?}"
         );
         assert!(
-            !effects
-                .iter()
-                .any(|e| matches!(e, Effect::AddInlineNote(_))),
+            !effects.iter().any(|e| matches!(e, Effect::AddInlineNote(_))),
             "no inline downgrade when spoken: {effects:?}"
         );
         assert!(
@@ -3634,37 +3664,155 @@ mod tests {
         );
     }
 
-    /// Master cut-off: even a `say_this` for the *active* conversation does not
-    /// speak while that conversation's toggle is OFF — and a `say_this` whose
-    /// conversation_id differs from the active one (stale / concurrent session)
-    /// is judged against the *active* conversation's toggle, never another's.
+    /// Adele=OnDemand + You=Enabled: the reply is spoken (the gate's OnDemand
+    /// arm) and finalized.
     #[test]
-    fn say_this_for_other_conversation_uses_active_toggle_no_bleed() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        // c2 has speech ON, but the active conversation is c1 (OFF). A call
-        // tagged c2 must NOT borrow c2's ON state to play audio on this client.
-        state
-            .conversation_speech_enabled
-            .insert("c2".to_string(), true);
-        let effects = state.apply(say_this_call("c2", "should not play"));
+    fn adele_on_demand_with_you_enabled_speaks_reply() {
+        let mut state = state_with(true, AdeleOutput::OnDemand);
+        assert!(state.narrate_for_current(), "OnDemand + You=Enabled narrates");
+        let effects = stream_complete_in(&mut state, "an answer");
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::Speak(t) if t == "an answer")),
+            "OnDemand + You=Enabled must speak the reply: {effects:?}"
+        );
+    }
+
+    /// Adele=OnDemand + You=Disabled: the reply is NOT spoken (text-only), but a
+    /// `say_this` aside still speaks (asides ignore You).
+    #[test]
+    fn adele_on_demand_with_you_disabled_text_only_but_say_this_speaks() {
+        // Reply NOT narrated.
+        let mut state = state_with(false, AdeleOutput::OnDemand);
+        assert!(
+            !state.narrate_for_current(),
+            "OnDemand + You=Disabled must not narrate replies"
+        );
+        let effects = stream_complete_in(&mut state, "an answer");
         assert!(
             !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "a call for a non-active conversation must not borrow its toggle: {effects:?}"
+            "OnDemand + You=Disabled must not speak the reply: {effects:?}"
         );
         assert!(
             effects
                 .iter()
-                .any(|e| matches!(e, Effect::SubmitClientToolResult { .. })),
-            "still always resolves: {effects:?}"
+                .any(|e| matches!(e, Effect::CompleteStreaming(t) if t == "an answer")),
+            "the reply text must still be finalized: {effects:?}"
+        );
+
+        // say_this aside STILL speaks (independent of You).
+        let mut state = state_with(false, AdeleOutput::OnDemand);
+        let effects = state.apply(say_this_call("c1", "an aside"));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::Speak(t) if t == "an aside")),
+            "OnDemand say_this aside must speak even when You=Disabled: {effects:?}"
+        );
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::AddInlineNote(_))),
+            "no inline downgrade when spoken: {effects:?}"
         );
     }
 
-    /// Acceptance: a non-`say_this` client tool the GTK client can't run still
-    /// ALWAYS gets a result (an `Err`), so the suspended turn resumes rather
-    /// than wedging on a `PendingClientTool`.
+    /// `request_voice` sets Adele=OnDemand for the active conversation, reflects
+    /// the dropdown, and ALWAYS resolves a result (no audio by itself).
+    #[test]
+    fn request_voice_sets_on_demand_reflects_and_resolves() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(voice_tool_call("c1", "request_voice"));
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::OnDemand,
+            "request_voice must set Adele=OnDemand for the active conversation"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetAdeleOutputDropdown(AdeleOutput::OnDemand))),
+            "request_voice must reflect OnDemand on the dropdown: {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Ok(_) }
+                    if task_id == "task-v" && tool_call_id == "call-v"
+            )),
+            "request_voice must resolve an Ok result: {effects:?}"
+        );
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "request_voice itself must not speak: {effects:?}"
+        );
+    }
+
+    /// `stop_voice` sets Adele=Disabled, reflects the dropdown, and ALWAYS
+    /// resolves a result.
+    #[test]
+    fn stop_voice_sets_disabled_reflects_and_resolves() {
+        let mut state = state_with(true, AdeleOutput::Always);
+        let effects = state.apply(voice_tool_call("c1", "stop_voice"));
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::Disabled,
+            "stop_voice must set Adele=Disabled"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetAdeleOutputDropdown(AdeleOutput::Disabled))),
+            "stop_voice must reflect Disabled on the dropdown: {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Ok(_) }
+                    if task_id == "task-v" && tool_call_id == "call-v"
+            )),
+            "stop_voice must resolve an Ok result: {effects:?}"
+        );
+    }
+
+    /// Every client-tool call emits exactly one result (no wedge, no double),
+    /// across say_this / request_voice / stop_voice / an unknown tool.
+    #[test]
+    fn every_client_tool_call_emits_exactly_one_result() {
+        let calls = [
+            say_this_call("c1", "x"),
+            voice_tool_call("c1", "request_voice"),
+            voice_tool_call("c1", "stop_voice"),
+            UiMessage::ClientToolCall {
+                task_id: "t".to_string(),
+                conversation_id: "c1".to_string(),
+                tool_call_id: "tc".to_string(),
+                tool_name: "frobnicate".to_string(),
+                arguments: serde_json::json!({}),
+            },
+        ];
+        for call in calls {
+            let mut state = WindowState {
+                current_conversation_id: Some("c1".to_string()),
+                ..Default::default()
+            };
+            let effects = state.apply(call);
+            let results = effects
+                .iter()
+                .filter(|e| matches!(e, Effect::SubmitClientToolResult { .. }))
+                .count();
+            assert_eq!(
+                results, 1,
+                "exactly one result per client-tool call: {effects:?}"
+            );
+        }
+    }
+
+    /// An unknown client tool the GTK client can't run still ALWAYS gets an
+    /// `Err` result (no audio), so the suspended turn resumes rather than
+    /// wedging.
     #[test]
     fn unknown_client_tool_always_resolves_with_error_result() {
         let mut state = WindowState {
@@ -3693,17 +3841,10 @@ mod tests {
     }
 
     /// Malformed `say_this` arguments (missing/invalid `text`) must not panic
-    /// and must resolve with an `Err` result (never unwrap), so a hostile or
-    /// buggy payload can't wedge or crash the turn.
+    /// and must resolve with an `Err` result (never unwrap), even with Adele on.
     #[test]
     fn say_this_with_malformed_arguments_resolves_error_not_panic() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        state
-            .conversation_speech_enabled
-            .insert("c1".to_string(), true);
+        let mut state = state_with(true, AdeleOutput::Always);
         let effects = state.apply(UiMessage::ClientToolCall {
             task_id: "task-3".to_string(),
             conversation_id: "c1".to_string(),
@@ -3724,239 +3865,8 @@ mod tests {
         );
     }
 
-    /// Acceptance: reply narration is gated on the per-conversation toggle. With
-    /// speech ON, `StreamComplete` additionally emits a `Speak` of the reply;
-    /// with speech OFF it does not (only the normal text effects).
-    #[test]
-    fn reply_narration_is_gated_on_speech_toggle() {
-        // OFF → no Speak.
-        let mut off = WindowState {
-            pending_request_id: Some("req".to_string()),
-            current_conversation: Some(detail("c1", vec![])),
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = off.apply(UiMessage::StreamComplete {
-            request_id: "req".to_string(),
-            full_response: "an answer".to_string(),
-        });
-        assert!(
-            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "speech OFF must not narrate the reply: {effects:?}"
-        );
-
-        // ON → Speak the reply (in addition to the usual text effects).
-        let mut on = WindowState {
-            pending_request_id: Some("req".to_string()),
-            current_conversation: Some(detail("c1", vec![])),
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        on.conversation_speech_enabled
-            .insert("c1".to_string(), true);
-        let effects = on.apply(UiMessage::StreamComplete {
-            request_id: "req".to_string(),
-            full_response: "an answer".to_string(),
-        });
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::Speak(t) if t == "an answer")),
-            "speech ON must narrate the reply: {effects:?}"
-        );
-        // The normal text finalize must still happen.
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::CompleteStreaming(t) if t == "an answer")),
-            "the reply text must still be finalized: {effects:?}"
-        );
-    }
-
-    // --- Voice mode (issue #78, phase-2) ---------------------------------
-
-    /// A `request_voice` / `stop_voice` client-tool call (#78). Convenience
-    /// constructor mirroring `say_this_call`.
-    fn voice_tool_call(conversation_id: &str, tool_name: &str) -> UiMessage {
-        UiMessage::ClientToolCall {
-            task_id: "task-v".to_string(),
-            conversation_id: conversation_id.to_string(),
-            tool_call_id: "call-v".to_string(),
-            tool_name: tool_name.to_string(),
-            arguments: serde_json::json!({}),
-        }
-    }
-
-    /// Acceptance: voice mode defaults OFF for an untouched conversation, so it
-    /// never narrates or shapes a reply until the user/model turns it on.
-    #[test]
-    fn voice_mode_defaults_off_per_conversation() {
-        let state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        assert!(
-            !state.voice_mode_for_current(),
-            "voice mode must default OFF for an untouched conversation"
-        );
-    }
-
-    /// Acceptance: read-aloud OFF + voice-mode OFF → a `StreamComplete` produces
-    /// NO `Speak` effect on any path (the both-off baseline == phase-1 OFF).
-    #[test]
-    fn reply_narration_silent_when_both_controls_off() {
-        let mut state = WindowState {
-            pending_request_id: Some("req".to_string()),
-            current_conversation: Some(detail("c1", vec![])),
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = state.apply(UiMessage::StreamComplete {
-            request_id: "req".to_string(),
-            full_response: "an answer".to_string(),
-        });
-        assert!(
-            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "both controls OFF must never narrate: {effects:?}"
-        );
-    }
-
-    /// Acceptance: with read-aloud OFF but voice-mode ON, the reply is narrated
-    /// (the narration gate is read-aloud OR voice-mode), and the text still
-    /// finalizes.
-    #[test]
-    fn reply_narration_when_voice_mode_on_read_aloud_off() {
-        let mut state = WindowState {
-            pending_request_id: Some("req".to_string()),
-            current_conversation: Some(detail("c1", vec![])),
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        state.conversation_voice_mode.insert("c1".to_string(), true);
-        let effects = state.apply(UiMessage::StreamComplete {
-            request_id: "req".to_string(),
-            full_response: "an answer".to_string(),
-        });
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::Speak(t) if t == "an answer")),
-            "voice-mode ON must narrate the reply: {effects:?}"
-        );
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::CompleteStreaming(t) if t == "an answer")),
-            "the reply text must still be finalized: {effects:?}"
-        );
-    }
-
-    /// Acceptance: `request_voice` turns voice mode ON for the active
-    /// conversation and ALWAYS resolves a result.
-    #[test]
-    fn request_voice_turns_on_voice_mode_and_resolves() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = state.apply(voice_tool_call("c1", "request_voice"));
-        assert!(
-            state.voice_mode_for_current(),
-            "request_voice must turn voice mode ON for the active conversation"
-        );
-        assert!(
-            effects.iter().any(|e| matches!(
-                e,
-                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Ok(_) }
-                    if task_id == "task-v" && tool_call_id == "call-v"
-            )),
-            "request_voice must resolve an Ok result: {effects:?}"
-        );
-        // Entering voice mode produces no audio by itself (only subsequent
-        // replies are narrated).
-        assert!(
-            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "request_voice itself must not speak: {effects:?}"
-        );
-    }
-
-    /// Acceptance: `stop_voice` turns voice mode OFF and ALWAYS resolves a
-    /// result.
-    #[test]
-    fn stop_voice_turns_off_voice_mode_and_resolves() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        state.conversation_voice_mode.insert("c1".to_string(), true);
-        let effects = state.apply(voice_tool_call("c1", "stop_voice"));
-        assert!(
-            !state.voice_mode_for_current(),
-            "stop_voice must turn voice mode OFF"
-        );
-        assert!(
-            effects.iter().any(|e| matches!(
-                e,
-                Effect::SubmitClientToolResult { task_id, tool_call_id, result: Ok(_) }
-                    if task_id == "task-v" && tool_call_id == "call-v"
-            )),
-            "stop_voice must resolve an Ok result: {effects:?}"
-        );
-    }
-
-    /// Acceptance: voice mode is per-conversation — `request_voice` on c1 (the
-    /// active conversation) must not leak into c2, and it sticks for c1.
-    #[test]
-    fn voice_mode_is_scoped_per_conversation() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        state.apply(voice_tool_call("c1", "request_voice"));
-        assert!(state.voice_mode_for_current(), "c1 is in voice mode");
-        // Switch to c2: inherits the default OFF.
-        state.current_conversation_id = Some("c2".to_string());
-        assert!(
-            !state.voice_mode_for_current(),
-            "voice mode in c1 must not leak into c2"
-        );
-        // Back to c1: still ON (sticks per conversation).
-        state.current_conversation_id = Some("c1".to_string());
-        assert!(state.voice_mode_for_current());
-    }
-
-    /// The model gates voice mode against the ACTIVE conversation, mirroring the
-    /// say_this choice: a `request_voice` tagged for a non-active conversation
-    /// must not flip some other conversation's state, but must still resolve.
-    #[test]
-    fn request_voice_for_other_conversation_uses_active_no_bleed() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        // Tagged c2, but c1 is active: the active conversation (c1) is what the
-        // mode applies to — c2's state is never touched by a foreign call.
-        let effects = state.apply(voice_tool_call("c2", "request_voice"));
-        assert!(
-            state.voice_mode_for_current(),
-            "request_voice applies to the active conversation"
-        );
-        assert!(
-            !state.conversation_voice_mode.contains_key("c2"),
-            "a foreign-tagged call must not write c2's state: {:?}",
-            state.conversation_voice_mode
-        );
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::SubmitClientToolResult { .. })),
-            "still always resolves: {effects:?}"
-        );
-    }
-
-    /// Acceptance: every `request_voice` / `stop_voice` call ALWAYS resolves
-    /// exactly one result even with malformed/no arguments — no panic, no wedge.
-    /// (These tools take no arguments, so a junk payload must be ignored.)
+    /// `request_voice` / `stop_voice` with malformed/non-object args still
+    /// resolve exactly one result without panicking (they take no arguments).
     #[test]
     fn voice_tools_with_malformed_args_resolve_without_panic() {
         for tool in ["request_voice", "stop_voice"] {
@@ -3971,126 +3881,192 @@ mod tests {
                 tool_name: tool.to_string(),
                 arguments: serde_json::json!("not-an-object"),
             });
-            let results: Vec<_> = effects
+            let results = effects
                 .iter()
                 .filter(|e| matches!(e, Effect::SubmitClientToolResult { .. }))
-                .collect();
-            assert_eq!(
-                results.len(),
-                1,
-                "{tool} must resolve exactly one result: {effects:?}"
-            );
+                .count();
+            assert_eq!(results, 1, "{tool} must resolve exactly one result: {effects:?}");
         }
     }
 
-    /// `say_this` audio is broadened to (read-aloud OR voice-mode): with
-    /// read-aloud OFF but voice-mode ON, a `say_this` is spoken (not downgraded).
+    /// Both controls are per-conversation and isolated: setting them on c1 must
+    /// not leak into c2, and they stick when switching back.
     #[test]
-    fn say_this_spoken_when_voice_mode_on_read_aloud_off() {
+    fn both_controls_are_per_conversation_isolated() {
         let mut state = WindowState {
             current_conversation_id: Some("c1".to_string()),
             ..Default::default()
         };
-        state.conversation_voice_mode.insert("c1".to_string(), true);
-        let effects = state.apply(say_this_call("c1", "hello aloud"));
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, Effect::Speak(t) if t == "hello aloud")),
-            "voice-mode ON must speak a say_this aside: {effects:?}"
-        );
-        assert!(
-            !effects
-                .iter()
-                .any(|e| matches!(e, Effect::AddInlineNote(_))),
-            "no inline downgrade when spoken: {effects:?}"
-        );
-        assert!(
-            effects.iter().any(|e| matches!(
-                e,
-                Effect::SubmitClientToolResult { result: Ok(r), .. } if r == "spoken"
-            )),
-            "result must be \"spoken\": {effects:?}"
-        );
-    }
-
-    /// With BOTH read-aloud and voice-mode OFF, `say_this` still downgrades to
-    /// the inline note (no audio) — the both-off baseline.
-    #[test]
-    fn say_this_downgrades_when_both_controls_off() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = state.apply(say_this_call("c1", "the aside"));
-        assert!(
-            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
-            "both controls OFF must never speak a say_this: {effects:?}"
-        );
-        assert!(
-            effects.iter().any(
-                |e| matches!(e, Effect::AddInlineNote(t) if t == "(speech mode disabled) the aside")
-            ),
-            "expected the inline downgrade note: {effects:?}"
-        );
-    }
-
-    /// The voice-mode send shaping is a pure decision: when voice mode is ON for
-    /// the active conversation, a non-empty system refinement is used; when OFF,
-    /// none is. This is what the send path consults to choose
-    /// `send_prompt_with_system_refinement`.
-    #[test]
-    fn voice_mode_send_uses_system_refinement_only_when_on() {
-        // OFF → no refinement (plain send path).
-        let off = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        assert!(
-            refinement_for_send(&off).is_none(),
-            "voice mode OFF must not attach a system refinement"
-        );
-
-        // ON → the voice refinement constant is attached.
-        let mut on = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        on.conversation_voice_mode.insert("c1".to_string(), true);
-        assert_eq!(
-            refinement_for_send(&on),
-            Some(VOICE_SYSTEM_REFINEMENT),
-            "voice mode ON must attach the voice system refinement"
-        );
-        // The refinement is non-empty and free of markdown markers, so it can't
-        // leak formatting into a spoken reply.
-        assert!(!VOICE_SYSTEM_REFINEMENT.trim().is_empty());
-        for marker in ['*', '_', '`', '#'] {
-            assert!(
-                !VOICE_SYSTEM_REFINEMENT.contains(marker),
-                "the refinement itself must avoid markdown markers ({marker})"
-            );
-        }
-    }
-
-    /// A user-driven voice-mode flip (the UI button) records the per-conversation
-    /// state and emits no effects, mirroring `SetSpeechEnabled`.
-    #[test]
-    fn set_voice_mode_records_state_scoped_to_conversation() {
-        let mut state = WindowState {
-            current_conversation_id: Some("c1".to_string()),
-            ..Default::default()
-        };
-        let effects = state.apply(UiMessage::SetVoiceMode {
+        state.apply(UiMessage::SetVoiceIn {
             conversation_id: "c1".to_string(),
             enabled: true,
         });
-        assert!(effects.is_empty(), "setting voice mode emits no effects");
-        assert!(state.voice_mode_for_current());
+        state.apply(UiMessage::SetAdeleOutput {
+            conversation_id: "c1".to_string(),
+            level: AdeleOutput::Always,
+        });
+        assert!(state.voice_in_for_current());
+        assert_eq!(state.adele_output_for_current(), AdeleOutput::Always);
+
+        // Switch to c2: both inherit their defaults (no bleed).
+        state.current_conversation_id = Some("c2".to_string());
+        assert!(!state.voice_in_for_current(), "You must not leak c1 → c2");
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::Disabled,
+            "Adele must not leak c1 → c2"
+        );
+
+        // Back to c1: both stick.
+        state.current_conversation_id = Some("c1".to_string());
+        assert!(state.voice_in_for_current());
+        assert_eq!(state.adele_output_for_current(), AdeleOutput::Always);
+    }
+
+    /// A `request_voice` tagged for a non-active conversation applies to the
+    /// ACTIVE conversation (mirrors say_this's gating) and never writes the
+    /// foreign conversation's state — but still resolves.
+    #[test]
+    fn request_voice_for_other_conversation_uses_active_no_bleed() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(voice_tool_call("c2", "request_voice"));
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::OnDemand,
+            "request_voice applies to the active conversation"
+        );
+        assert!(
+            !state.conversation_adele_output.contains_key("c2"),
+            "a foreign-tagged call must not write c2's state: {:?}",
+            state.conversation_adele_output
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SubmitClientToolResult { .. })),
+            "still always resolves: {effects:?}"
+        );
+    }
+
+    /// A `say_this` whose `conversation_id` differs from the active one is judged
+    /// against the *active* conversation's Adele level, never another's (no
+    /// cross-conversation bleed).
+    #[test]
+    fn say_this_for_other_conversation_uses_active_level_no_bleed() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        // c2 has Adele=Always, but the active conversation is c1 (Disabled). A
+        // call tagged c2 must NOT borrow c2's level to play audio on this client.
+        state
+            .conversation_adele_output
+            .insert("c2".to_string(), AdeleOutput::Always);
+        let effects = state.apply(say_this_call("c2", "should not play"));
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "a call for a non-active conversation must not borrow its level: {effects:?}"
+        );
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SubmitClientToolResult { .. })),
+            "still always resolves: {effects:?}"
+        );
+    }
+
+    /// `refinement_for_send` returns the right variant per (Adele level, You):
+    /// Disabled → none; OnDemand → the brief/conversational refinement; Always →
+    /// the speakable-but-full refinement. `You` does not change the refinement
+    /// (it's chosen by the Adele level), and both refinement strings are
+    /// non-empty and free of markdown markers so they can't leak formatting.
+    #[test]
+    fn refinement_for_send_returns_right_variant_per_level() {
+        // Disabled → none (independent of You).
+        for voice_in in [false, true] {
+            let state = state_with(voice_in, AdeleOutput::Disabled);
+            assert!(
+                refinement_for_send(&state).is_none(),
+                "Adele=Disabled must attach no refinement (You={voice_in})"
+            );
+        }
+        // OnDemand → the brief refinement (independent of You).
+        for voice_in in [false, true] {
+            let state = state_with(voice_in, AdeleOutput::OnDemand);
+            assert_eq!(
+                refinement_for_send(&state),
+                Some(ON_DEMAND_SYSTEM_REFINEMENT),
+                "Adele=OnDemand must attach the brief refinement (You={voice_in})"
+            );
+        }
+        // Always → the full refinement (independent of You).
+        for voice_in in [false, true] {
+            let state = state_with(voice_in, AdeleOutput::Always);
+            assert_eq!(
+                refinement_for_send(&state),
+                Some(ALWAYS_SYSTEM_REFINEMENT),
+                "Adele=Always must attach the full refinement (You={voice_in})"
+            );
+        }
+        // The two refinements differ, are non-empty, and carry no markdown.
+        assert_ne!(ON_DEMAND_SYSTEM_REFINEMENT, ALWAYS_SYSTEM_REFINEMENT);
+        // OnDemand asks for brevity; Always explicitly does not shorten.
+        assert!(ON_DEMAND_SYSTEM_REFINEMENT.to_lowercase().contains("brief"));
+        assert!(ALWAYS_SYSTEM_REFINEMENT.to_lowercase().contains("do not shorten"));
+        for refinement in [ON_DEMAND_SYSTEM_REFINEMENT, ALWAYS_SYSTEM_REFINEMENT] {
+            assert!(!refinement.trim().is_empty());
+            for marker in ['*', '_', '`', '#'] {
+                assert!(
+                    !refinement.contains(marker),
+                    "the refinement itself must avoid markdown markers ({marker})"
+                );
+            }
+        }
+    }
+
+    /// A user-driven `SetVoiceIn` records the per-conversation state and emits
+    /// no effects.
+    #[test]
+    fn set_voice_in_records_state_scoped_to_conversation() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::SetVoiceIn {
+            conversation_id: "c1".to_string(),
+            enabled: true,
+        });
+        assert!(effects.is_empty(), "setting You emits no effects");
+        assert!(state.voice_in_for_current());
         state.current_conversation_id = Some("c2".to_string());
         assert!(
-            !state.voice_mode_for_current(),
-            "voice mode set on c1 must not leak into c2"
+            !state.voice_in_for_current(),
+            "You set on c1 must not leak into c2"
+        );
+    }
+
+    /// A user-driven `SetAdeleOutput` records the per-conversation level and
+    /// emits no effects.
+    #[test]
+    fn set_adele_output_records_state_scoped_to_conversation() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::SetAdeleOutput {
+            conversation_id: "c1".to_string(),
+            level: AdeleOutput::OnDemand,
+        });
+        assert!(effects.is_empty(), "setting Adele emits no effects");
+        assert_eq!(state.adele_output_for_current(), AdeleOutput::OnDemand);
+        state.current_conversation_id = Some("c2".to_string());
+        assert_eq!(
+            state.adele_output_for_current(),
+            AdeleOutput::Disabled,
+            "Adele set on c1 must not leak into c2"
         );
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -16,7 +16,7 @@ use gtk4::{
 };
 use tokio::sync::mpsc;
 
-use crate::async_bridge::{AsyncBridge, UiMessage, connection_manager};
+use crate::async_bridge::{AdeleOutput, AsyncBridge, UiMessage, connection_manager};
 use crate::management_client;
 use crate::voice_client::{VoiceController, VoiceState};
 use crate::widgets::chat_view::ChatView;
@@ -35,73 +35,100 @@ struct WindowState {
     pending_request_id: Option<String>,
     streaming_buffer: String,
     debug_enabled: bool,
-    /// Per-conversation "read aloud" (accessibility) toggle (issue #76, reframed
-    /// in #78), keyed by conversation id. Default (absent key) is **OFF**. When
-    /// ON, every reply auto-routes to the Speaker (LLM-unaware). State is
-    /// per-conversation, so enabling it in one conversation never leaks audio
-    /// into another.
-    conversation_speech_enabled: HashMap<String, bool>,
-    /// Per-conversation soft-sticky "voice mode" toggle (issue #78), keyed by
-    /// conversation id. Default (absent key) is **OFF**. Entered by the user
-    /// (UI) or the model (`request_voice`), left via UI or `stop_voice`. When
-    /// ON: replies are narrated (same routing as read-aloud) AND a concise
-    /// read-aloud `system_refinement` is attached on send. Independent of
-    /// read-aloud — either being ON narrates.
-    conversation_voice_mode: HashMap<String, bool>,
+    /// Per-conversation `You:` (voice input) state (issue #80), keyed by
+    /// conversation id. Default (absent key) is **Disabled** (type only). When
+    /// Enabled, the input bar shows a push-to-talk control and — combined with
+    /// `Adele == OnDemand` — gates reply narration. Per-conversation, so
+    /// enabling it in one conversation never affects another.
+    conversation_voice_in: HashMap<String, bool>,
+    /// Per-conversation `Adele:` (voice output) level (issue #80), keyed by
+    /// conversation id. Default (absent key) is **Disabled** (never speaks).
+    /// Set by the user (the dropdown) or the model (`request_voice` → OnDemand,
+    /// `stop_voice` → Disabled). Decides reply narration (with `You`), the
+    /// `say_this` gate, and the send-time `system_refinement`. Replaces phase-2's
+    /// two toggles (read-aloud == Always, voice-mode == OnDemand).
+    conversation_adele_output: HashMap<String, AdeleOutput>,
 }
 
-/// Concise read-aloud system refinement attached on send while voice mode is ON
-/// (issue #78). Mirrors the *essence* of the voice daemon's
-/// `spoken_response_hint` (brief, conversational, no markdown, symbols/acronyms
-/// spelled out, written for the ear) without duplicating its full paragraph.
+/// System refinement attached on send while `Adele == OnDemand` (issue #80).
+/// Replies are spoken only while conversing by voice, so shape them **for the
+/// ear**: brief, conversational, no markdown, symbols/acronyms spelled out.
 /// Deliberately free of markdown markers so it can't itself leak formatting.
-const VOICE_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be spoken, not read. Keep it brief and \
+const ON_DEMAND_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be spoken, not read. Keep it brief and \
      conversational, a few short sentences at most. Use no markdown or formatting of any kind, \
      and no emoji. Spell out acronyms and abbreviations as full words and avoid symbols that do \
      not read well aloud (say 'and' not an ampersand, 'percent' not a percent sign, 'dollars' not \
      a dollar sign). Do not read out URLs, file paths, or email addresses; describe them in words \
      instead, and write numbers, dates, and times the way you would say them.";
 
+/// System refinement attached on send while `Adele == Always` (issue #80).
+/// Every reply is read aloud for accessibility, so make it **speakable but not
+/// shortened**: keep the full content, just strip formatting and spell out
+/// symbols. Crucially it does NOT ask for brevity (that's the OnDemand job) —
+/// Always reads the whole answer. Free of markdown markers itself.
+const ALWAYS_SYSTEM_REFINEMENT: &str = "This reply will be read aloud in full, so write it to be spoken, not read, without \
+     leaving anything out. Do not shorten or summarize — cover everything you would normally \
+     say, just phrased for the ear. Use no markdown or formatting of any kind, and no emoji. \
+     Spell out acronyms and abbreviations as full words and avoid symbols that do not read well \
+     aloud (say 'and' not an ampersand, 'percent' not a percent sign, 'dollars' not a dollar \
+     sign). Do not read out URLs, file paths, or email addresses; describe them in words instead, \
+     and write numbers, dates, and times the way you would say them.";
+
 impl WindowState {
-    /// Whether read-aloud is enabled for the *currently active* conversation.
-    /// `false` when there is no active conversation or the toggle was never set
-    /// (default OFF).
-    fn speech_enabled_for_current(&self) -> bool {
+    /// Whether `You:` (voice input) is Enabled for the *currently active*
+    /// conversation. `false` when there is no active conversation or it was
+    /// never set (default Disabled).
+    fn voice_in_for_current(&self) -> bool {
         self.current_conversation_id
             .as_deref()
-            .and_then(|id| self.conversation_speech_enabled.get(id))
+            .and_then(|id| self.conversation_voice_in.get(id))
             .copied()
             .unwrap_or(false)
     }
 
-    /// Whether voice mode is on for the *currently active* conversation.
-    /// `false` when there is no active conversation or it was never set
-    /// (default OFF).
-    fn voice_mode_for_current(&self) -> bool {
+    /// The `Adele:` (voice output) level for the *currently active*
+    /// conversation. `Disabled` when there is no active conversation or it was
+    /// never set (default Disabled).
+    fn adele_output_for_current(&self) -> AdeleOutput {
         self.current_conversation_id
             .as_deref()
-            .and_then(|id| self.conversation_voice_mode.get(id))
+            .and_then(|id| self.conversation_adele_output.get(id))
             .copied()
-            .unwrap_or(false)
+            .unwrap_or_default()
     }
 
-    /// Whether a reply is spoken for the active conversation: read-aloud OR
-    /// voice mode (issue #78). The single audio gate both reply narration and
-    /// `say_this` consult.
+    /// Whether a *reply* is spoken for the active conversation (issue #80):
+    /// `Adele == Always` OR (`Adele == OnDemand` AND `You == Enabled`). The gate
+    /// the reply-narration path consults; `Disabled` never narrates.
     fn narrate_for_current(&self) -> bool {
-        self.speech_enabled_for_current() || self.voice_mode_for_current()
+        match self.adele_output_for_current() {
+            AdeleOutput::Always => true,
+            AdeleOutput::OnDemand => self.voice_in_for_current(),
+            AdeleOutput::Disabled => false,
+        }
+    }
+
+    /// Whether a `say_this` aside is spoken for the active conversation (issue
+    /// #80): spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`).
+    /// `Disabled` downgrades the aside to inline text.
+    fn say_this_spoken_for_current(&self) -> bool {
+        !matches!(self.adele_output_for_current(), AdeleOutput::Disabled)
     }
 }
 
-/// The read-aloud system refinement to attach on the next send, or `None` when
-/// voice mode is off for the active conversation (issue #78). Pure decision the
-/// send path consults to choose `send_prompt_with_system_refinement`. Free
-/// function (not a method) so the send closure can call it through a snapshot
-/// without holding a `WindowState` borrow across the await.
+/// The system refinement to attach on the next send, or `None` (issue #80),
+/// chosen by the active conversation's `Adele:` level: `OnDemand` →
+/// brief/conversational/speakable; `Always` → speakable-but-full (don't
+/// shorten); `Disabled` → none. Pure decision the send path consults to choose
+/// `send_prompt_with_system_refinement`. Free function (not a method) so the
+/// send closure can call it through a snapshot without holding a `WindowState`
+/// borrow across the await.
 fn refinement_for_send(state: &WindowState) -> Option<&'static str> {
-    state
-        .voice_mode_for_current()
-        .then_some(VOICE_SYSTEM_REFINEMENT)
+    match state.adele_output_for_current() {
+        AdeleOutput::OnDemand => Some(ON_DEMAND_SYSTEM_REFINEMENT),
+        AdeleOutput::Always => Some(ALWAYS_SYSTEM_REFINEMENT),
+        AdeleOutput::Disabled => None,
+    }
 }
 
 /// The session-scoped client tools this client advertises so the model can
@@ -242,12 +269,13 @@ enum Effect {
     /// `(speech mode disabled) …` downgrade when `say_this` arrives with speech
     /// OFF, so the text is shown rather than dropped.
     AddInlineNote(String),
-    /// Reflect the active conversation's voice-mode state on the input-bar
-    /// toggle (issue #78). Emitted when the model drives voice mode via
-    /// `request_voice` / `stop_voice` so the button tracks the model's change
-    /// (the user-driven path needs no echo — the button is its own write
-    /// source). Suppressed inside `set_voice_mode_active`, so it never loops.
-    SetVoiceModeButton(bool),
+    /// Reflect the active conversation's `Adele:` output level on the input-bar
+    /// dropdown (issue #80). Emitted when the model drives the level via
+    /// `request_voice` (→ OnDemand) / `stop_voice` (→ Disabled) so the dropdown
+    /// tracks the model's change (the user-driven path needs no echo — the
+    /// dropdown is its own write source). Suppressed inside
+    /// `set_adele_output_active`, so it never loops.
+    SetAdeleOutputDropdown(AdeleOutput),
     /// Resolve a suspended client-tool call back to the daemon via
     /// `submit_client_tool_result` so the parked turn resumes (issue #76). Every
     /// `ClientToolCall` yields exactly one of these — `Ok` on success, `Err`
@@ -312,7 +340,9 @@ impl std::fmt::Debug for Effect {
             Effect::RefreshSidePaneTasks => f.write_str("RefreshSidePaneTasks"),
             Effect::Speak(t) => f.debug_tuple("Speak").field(t).finish(),
             Effect::AddInlineNote(t) => f.debug_tuple("AddInlineNote").field(t).finish(),
-            Effect::SetVoiceModeButton(b) => f.debug_tuple("SetVoiceModeButton").field(b).finish(),
+            Effect::SetAdeleOutputDropdown(l) => {
+                f.debug_tuple("SetAdeleOutputDropdown").field(l).finish()
+            }
             Effect::SubmitClientToolResult {
                 task_id,
                 tool_call_id,
@@ -491,12 +521,12 @@ impl WindowState {
                             content: full_response.clone(),
                         });
                     }
-                    // Reply narration (issue #76/#78): narrate the finalized
-                    // reply via the embedded `Speaker` when the active
-                    // conversation has read-aloud ON *or* voice mode ON. Gated
-                    // entirely here so the cut-off holds — with both OFF no
-                    // `Speak` effect exists, so no path plays audio. (The
-                    // executor additionally no-ops when there is no embedded
+                    // Reply narration (issue #80): narrate the finalized reply
+                    // via the embedded `Speaker` when the gate holds — `Adele ==
+                    // Always` OR (`Adele == OnDemand` AND `You == Enabled`).
+                    // Gated entirely here so the cut-off holds: when the gate is
+                    // false no `Speak` effect exists, so no path plays audio.
+                    // (The executor additionally no-ops when there is no embedded
                     // engine, e.g. the daemon path, which narrates its own
                     // replies.)
                     let narrate = self.narrate_for_current();
@@ -650,27 +680,27 @@ impl WindowState {
                     vec![]
                 }
             }
-            UiMessage::SetSpeechEnabled {
+            UiMessage::SetVoiceIn {
                 conversation_id,
                 enabled,
             } => {
-                // Record the per-conversation read-aloud toggle. Pure state
-                // change; the button already reflects itself (it is the write
-                // source). Keyed by conversation so it never bleeds across them.
-                self.conversation_speech_enabled
-                    .insert(conversation_id, enabled);
+                // Record the per-conversation `You:` (voice input) setting (issue
+                // #80). Pure state change; the dropdown is the write source here
+                // (the user changed it), so no UI reflection is needed. Keyed by
+                // conversation so it never bleeds across them.
+                self.conversation_voice_in.insert(conversation_id, enabled);
                 vec![]
             }
-            UiMessage::SetVoiceMode {
+            UiMessage::SetAdeleOutput {
                 conversation_id,
-                enabled,
+                level,
             } => {
-                // Record the per-conversation voice-mode toggle (issue #78).
-                // Pure state change; the button is the write source here (the
-                // user clicked it), so no UI reflection is needed. Keyed by
-                // conversation so it never bleeds across them.
-                self.conversation_voice_mode
-                    .insert(conversation_id, enabled);
+                // Record the per-conversation `Adele:` (voice output) level
+                // (issue #80). Pure state change; the dropdown is the write
+                // source here (the user changed it), so no UI reflection is
+                // needed. Keyed by conversation so it never bleeds across them.
+                self.conversation_adele_output
+                    .insert(conversation_id, level);
                 vec![]
             }
             UiMessage::ClientToolCall {
@@ -691,10 +721,11 @@ impl WindowState {
                 // per session; this is the belt-and-braces local guard.
                 match tool_name.as_str() {
                     "say_this" => match say_this_text(&arguments) {
-                        // Audio gate broadened in #78 to (read-aloud OR voice
-                        // mode): speak the aside when either is on for the
-                        // active conversation.
-                        Some(text) if self.narrate_for_current() => vec![
+                        // say_this gate (issue #80): the aside is spoken iff
+                        // `Adele ∈ {OnDemand, Always}` for the active
+                        // conversation — independent of `You`. `Disabled`
+                        // downgrades it to inline text below.
+                        Some(text) if self.say_this_spoken_for_current() => vec![
                             Effect::Speak(text),
                             Effect::SubmitClientToolResult {
                                 task_id,
@@ -703,7 +734,7 @@ impl WindowState {
                             },
                         ],
                         Some(text) => {
-                            // Both controls OFF → show, don't speak. The turn
+                            // Adele == Disabled → show, don't speak. The turn
                             // still completes; no audio on any path.
                             let note = format!("(speech mode disabled) {text}");
                             vec![
@@ -730,18 +761,20 @@ impl WindowState {
                         }
                     },
                     // The model asks to switch this conversation into spoken
-                    // voice mode (issue #78). Applies to the ACTIVE conversation
-                    // (consistent with say_this's active-conversation gating);
-                    // sticks until left. Reflect it on the button so the UI
-                    // tracks the model's change, and always resolve a result.
-                    // `request_voice` / `stop_voice` take no arguments, so a junk
-                    // payload is simply ignored — never a panic.
+                    // voice mode (issue #80): set `Adele = OnDemand`. Applies to
+                    // the ACTIVE conversation (consistent with say_this's
+                    // active-conversation gating); sticks until left. Reflect it
+                    // on the dropdown so the UI tracks the model's change, and
+                    // always resolve a result. `request_voice` / `stop_voice`
+                    // take no arguments, so a junk payload is simply ignored —
+                    // never a panic.
                     "request_voice" => {
                         if let Some(id) = self.current_conversation_id.clone() {
-                            self.conversation_voice_mode.insert(id, true);
+                            self.conversation_adele_output
+                                .insert(id, AdeleOutput::OnDemand);
                         }
                         vec![
-                            Effect::SetVoiceModeButton(true),
+                            Effect::SetAdeleOutputDropdown(AdeleOutput::OnDemand),
                             Effect::SubmitClientToolResult {
                                 task_id,
                                 tool_call_id,
@@ -753,10 +786,11 @@ impl WindowState {
                     }
                     "stop_voice" => {
                         if let Some(id) = self.current_conversation_id.clone() {
-                            self.conversation_voice_mode.insert(id, false);
+                            self.conversation_adele_output
+                                .insert(id, AdeleOutput::Disabled);
                         }
                         vec![
-                            Effect::SetVoiceModeButton(false),
+                            Effect::SetAdeleOutputDropdown(AdeleOutput::Disabled),
                             Effect::SubmitClientToolResult {
                                 task_id,
                                 tool_call_id,
@@ -1074,8 +1108,8 @@ impl AdelieWindow {
             pending_request_id: None,
             streaming_buffer: String::new(),
             debug_enabled: false,
-            conversation_speech_enabled: HashMap::new(),
-            conversation_voice_mode: HashMap::new(),
+            conversation_voice_in: HashMap::new(),
+            conversation_adele_output: HashMap::new(),
         }));
 
         // Wrap widgets in Rc for closures
@@ -1677,14 +1711,14 @@ impl AdelieWindow {
             }
         }
 
-        // Per-conversation speech toggle (issue #76). A user flip routes a
-        // `SetSpeechEnabled` for the *current* conversation through the same
-        // handler as everything else, so the pure `apply` records it. The
-        // `set_speech_active` reflection on conversation switch (below, in the
-        // `LoadConversationIntoChat` effect) is suppressed, so it never echoes
-        // back here. With no active conversation the flip is dropped (the
-        // button is only meaningful against a conversation).
-        input_bar.connect_speech_toggled(glib::clone!(
+        // Per-conversation `You:` (voice input) dropdown (issue #80). A user
+        // change routes a `SetVoiceIn` for the *current* conversation through
+        // the same handler as everything else, so the pure `apply` records it.
+        // The `set_voice_in_active` reflection on conversation switch (below, in
+        // the `LoadConversationIntoChat` effect) is suppressed, so it never
+        // echoes back here. With no active conversation the change is dropped
+        // (the dropdown is only meaningful against a conversation).
+        input_bar.connect_voice_in_changed(glib::clone!(
             #[strong]
             state,
             #[strong]
@@ -1693,30 +1727,31 @@ impl AdelieWindow {
                 let Some(conv_id) = state.borrow().current_conversation_id.clone() else {
                     return;
                 };
-                let _ = bridge.ui_sender().send(UiMessage::SetSpeechEnabled {
+                let _ = bridge.ui_sender().send(UiMessage::SetVoiceIn {
                     conversation_id: conv_id,
                     enabled,
                 });
             }
         ));
 
-        // Per-conversation voice-mode toggle (issue #78). A user flip routes a
-        // `SetVoiceMode` for the *current* conversation through the same handler
-        // so the pure `apply` records it. The `set_voice_mode_active` reflection
-        // on conversation switch / model drive is suppressed, so it never echoes
-        // back here. With no active conversation the flip is dropped.
-        input_bar.connect_voice_mode_toggled(glib::clone!(
+        // Per-conversation `Adele:` (voice output) dropdown (issue #80). A user
+        // change routes a `SetAdeleOutput` for the *current* conversation through
+        // the same handler so the pure `apply` records it. The
+        // `set_adele_output_active` reflection on conversation switch / model
+        // drive is suppressed, so it never echoes back here. With no active
+        // conversation the change is dropped.
+        input_bar.connect_adele_output_changed(glib::clone!(
             #[strong]
             state,
             #[strong]
             bridge,
-            move |enabled| {
+            move |level| {
                 let Some(conv_id) = state.borrow().current_conversation_id.clone() else {
                     return;
                 };
-                let _ = bridge.ui_sender().send(UiMessage::SetVoiceMode {
+                let _ = bridge.ui_sender().send(UiMessage::SetAdeleOutput {
                     conversation_id: conv_id,
-                    enabled,
+                    level,
                 });
             }
         ));
@@ -2396,17 +2431,17 @@ fn handle_ui_message(
             }
             Effect::LoadConversationIntoChat(filtered) => {
                 chat_view.borrow_mut().load_conversation(&filtered);
-                // Reflect the newly-active conversation's read-aloud + voice-mode
-                // toggles on the input bar (issue #76/#78). `apply` has already
+                // Reflect the newly-active conversation's `You:` + `Adele:`
+                // dropdowns on the input bar (issue #80). `apply` has already
                 // pointed `current_conversation_id` at this conversation, so
                 // these read the right per-conversation state. Suppressed inside
                 // each setter, so they don't echo a write back.
-                let (read_aloud, voice_mode) = {
+                let (voice_in, adele_output) = {
                     let s = state.borrow();
-                    (s.speech_enabled_for_current(), s.voice_mode_for_current())
+                    (s.voice_in_for_current(), s.adele_output_for_current())
                 };
-                input_bar.set_speech_active(read_aloud);
-                input_bar.set_voice_mode_active(voice_mode);
+                input_bar.set_voice_in_active(voice_in);
+                input_bar.set_adele_output_active(adele_output);
             }
             Effect::ReloadConversation(id) => {
                 // Re-fetch an already-open conversation (reconnect / debug /
@@ -2543,11 +2578,12 @@ fn handle_ui_message(
             Effect::AddInlineNote(note) => {
                 chat_view.borrow_mut().add_inline_note(&note);
             }
-            Effect::SetVoiceModeButton(enabled) => {
-                // The model drove voice mode (request_voice / stop_voice);
-                // reflect it on the toggle. Suppressed inside, so it doesn't
-                // echo a `SetVoiceMode` write back through the user callback.
-                input_bar.set_voice_mode_active(enabled);
+            Effect::SetAdeleOutputDropdown(level) => {
+                // The model drove the output level (request_voice → OnDemand /
+                // stop_voice → Disabled); reflect it on the dropdown. Suppressed
+                // inside, so it doesn't echo a `SetAdeleOutput` write back
+                // through the user callback.
+                input_bar.set_adele_output_active(level);
             }
             Effect::SubmitClientToolResult {
                 task_id,
@@ -3547,8 +3583,12 @@ mod tests {
             current_conversation_id: Some("c1".to_string()),
             ..Default::default()
         };
-        state.conversation_voice_in.insert("c1".to_string(), voice_in);
-        state.conversation_adele_output.insert("c1".to_string(), adele);
+        state
+            .conversation_voice_in
+            .insert("c1".to_string(), voice_in);
+        state
+            .conversation_adele_output
+            .insert("c1".to_string(), adele);
         state
     }
 
@@ -3612,7 +3652,10 @@ mod tests {
                     if task_id == "task-1" && tool_call_id == "call-1"
             )
         });
-        assert!(resolved, "say_this must always resolve a result: {effects:?}");
+        assert!(
+            resolved,
+            "say_this must always resolve a result: {effects:?}"
+        );
     }
 
     /// Adele=Always: every reply is spoken (and finalized), independent of You.
@@ -3652,7 +3695,9 @@ mod tests {
             "Always must speak a say_this aside: {effects:?}"
         );
         assert!(
-            !effects.iter().any(|e| matches!(e, Effect::AddInlineNote(_))),
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::AddInlineNote(_))),
             "no inline downgrade when spoken: {effects:?}"
         );
         assert!(
@@ -3669,7 +3714,10 @@ mod tests {
     #[test]
     fn adele_on_demand_with_you_enabled_speaks_reply() {
         let mut state = state_with(true, AdeleOutput::OnDemand);
-        assert!(state.narrate_for_current(), "OnDemand + You=Enabled narrates");
+        assert!(
+            state.narrate_for_current(),
+            "OnDemand + You=Enabled narrates"
+        );
         let effects = stream_complete_in(&mut state, "an answer");
         assert!(
             effects
@@ -3711,7 +3759,9 @@ mod tests {
             "OnDemand say_this aside must speak even when You=Disabled: {effects:?}"
         );
         assert!(
-            !effects.iter().any(|e| matches!(e, Effect::AddInlineNote(_))),
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::AddInlineNote(_))),
             "no inline downgrade when spoken: {effects:?}"
         );
     }
@@ -3885,7 +3935,10 @@ mod tests {
                 .iter()
                 .filter(|e| matches!(e, Effect::SubmitClientToolResult { .. }))
                 .count();
-            assert_eq!(results, 1, "{tool} must resolve exactly one result: {effects:?}");
+            assert_eq!(
+                results, 1,
+                "{tool} must resolve exactly one result: {effects:?}"
+            );
         }
     }
 
@@ -4015,7 +4068,11 @@ mod tests {
         assert_ne!(ON_DEMAND_SYSTEM_REFINEMENT, ALWAYS_SYSTEM_REFINEMENT);
         // OnDemand asks for brevity; Always explicitly does not shorten.
         assert!(ON_DEMAND_SYSTEM_REFINEMENT.to_lowercase().contains("brief"));
-        assert!(ALWAYS_SYSTEM_REFINEMENT.to_lowercase().contains("do not shorten"));
+        assert!(
+            ALWAYS_SYSTEM_REFINEMENT
+                .to_lowercase()
+                .contains("do not shorten")
+        );
         for refinement in [ON_DEMAND_SYSTEM_REFINEMENT, ALWAYS_SYSTEM_REFINEMENT] {
             assert!(!refinement.trim().is_empty());
             for marker in ['*', '_', '`', '#'] {


### PR DESCRIPTION
Closes #80

Refactors the deployed phase-2 voice UI (#78, @ 74d5d07) — a left dictation mic + a read-aloud speaker toggle + a voice-mode toggle by Send — into a clean labeled row directly under the input area with two visually-matched, **independent**, **per-conversation** dropdowns. Text input is **always enabled**.

```
You: [ Disabled ▾ ]   🎙   Adele: [ Disabled ▾ ]
```

## What was removed
- The left dictation **mic** button (inline Send row).
- The **read-aloud** `ToggleButton` and the **voice-mode** `ToggleButton` by Send.
- `conversation_speech_enabled` (was "Always") and `conversation_voice_mode` (was "On Demand") state maps; the `SetSpeechEnabled` / `SetVoiceMode` UiMessages; the `SetVoiceModeButton` effect.

## What was added
- **`AdeleOutput { Disabled, OnDemand, Always }`** enum (in `async_bridge.rs`, next to `UiMessage`). Justification: the output level is genuinely three-valued and the gate logic differs per variant — a bool pair would admit a nonsensical "both" state and scatter the distinction across call sites. Default `Disabled`. Phase-2 mapped directly: read-aloud == `Always`, voice-mode == `OnDemand`.
- State now lives in `conversation_voice_in: HashMap<String,bool>` (You, default Disabled) + `conversation_adele_output: HashMap<String,AdeleOutput>` (Adele, default Disabled), both in `WindowState`.
- Input bar: a second row under the entry+Send row with a `You:` `DropDown` [Disabled|Enabled] and an `Adele:` `DropDown` [Disabled|On Demand|Always], `connect_voice_in_changed` / `connect_adele_output_changed` callbacks, and suppress-guarded `set_voice_in_active` / `set_adele_output_active` setters (mirroring the old `set_speech_active`).
- New `SetVoiceIn` / `SetAdeleOutput` UiMessages and a `SetAdeleOutputDropdown(AdeleOutput)` effect. The pure `apply(UiMessage) -> Vec<Effect>` testability is preserved.

## Push-to-talk reuse
The push-to-talk control **reuses the existing dictation mechanic unchanged**: it keeps the `mic_button` field + `reflect_voice_state` / `current_state`, so the window's `wire_voice_controls` (daemon `push_to_talk_routed(active)`, routed into the active conversation) and `wire_embedded_mic` (`EmbeddedVoice::dictate`) handlers bind to it exactly as before. It is moved into the new row and is shown **only when `You == Enabled` AND voice capture is available** (the daemon owns its bus name, or the embedded engine is active) — so an Enabled You with no capture backend never offers a dead control. Voice capture availability gates whether `You: Enabled` actually exposes the talk affordance.

## Semantics / gates
- **Reply narration:** spoken iff `Adele == Always` **OR** (`Adele == OnDemand` **AND** `You == Enabled`).
- **say_this aside:** spoken iff `Adele ∈ {OnDemand, Always}` (independent of You); else inline `(speech mode disabled) <text>`.
- **Model tools:** `request_voice` → `Adele = OnDemand`, `stop_voice` → `Adele = Disabled` (session-scoped, reflected on the dropdown, each **always** returns exactly one `SubmitClientToolResult`).

## Refinement on send (system_refinement, never in chat text)
Two constants, both free of markdown markers:
- **On Demand** → *"This reply will be read aloud, so write it to be spoken, not read. Keep it brief and conversational, a few short sentences at most…"* (brief / conversational / speakable).
- **Always** → *"This reply will be read aloud in full, so write it to be spoken… Do not shorten or summarize — cover everything you would normally say, just phrased for the ear…"* (speakable but **not shortened**).
- **Disabled** → none.

## Tests (TDD: failing-specs commit first, then implementation)
22 new voice tests (200 total pass, 1 pre-existing `#[ignore]`):
- `window`: `defaults_are_voice_in_disabled_and_adele_disabled`, `default_say_this_renders_inline_and_resolves_without_audio`, `adele_always_speaks_every_reply_regardless_of_you`, `adele_always_speaks_say_this_aside`, `adele_on_demand_with_you_enabled_speaks_reply`, `adele_on_demand_with_you_disabled_text_only_but_say_this_speaks`, `request_voice_sets_on_demand_reflects_and_resolves`, `stop_voice_sets_disabled_reflects_and_resolves`, `every_client_tool_call_emits_exactly_one_result`, `unknown_client_tool_always_resolves_with_error_result`, `say_this_with_malformed_arguments_resolves_error_not_panic`, `voice_tools_with_malformed_args_resolve_without_panic`, `both_controls_are_per_conversation_isolated`, `request_voice_for_other_conversation_uses_active_no_bleed`, `say_this_for_other_conversation_uses_active_level_no_bleed`, `refinement_for_send_returns_right_variant_per_level`, `set_voice_in_records_state_scoped_to_conversation`, `set_adele_output_records_state_scoped_to_conversation`.
- `async_bridge`: `set_voice_in_debug_includes_conversation_and_enabled`, `set_adele_output_debug_includes_conversation_and_level`.
- `input_bar`: `voice_in_index_round_trips_and_defaults_disabled`, `adele_output_index_round_trips_and_defaults_disabled` (the dropdown index → visibility/level decode that drives "push-to-talk shown iff You=Enabled"; the live widget-visibility wiring needs a GTK display so it's verified at runtime, not in headless unit tests).

## Quality gates
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings` all clean. No broad `#[allow]` added (the one pre-existing `#[allow(dead_code)]` on `InputBar::text` is carried over unchanged).
- Formatted changed files only (`rustfmt --edition 2024`); `git diff --stat origin/main` = the 3 intended files.
- Pre-push hook (`just check`) passed — **no `--no-verify`**.

## Security note
- No `unwrap`/`expect`/`panic!` on tool-call paths; malformed `say_this` / voice-tool args → `Err` result, never a panic.
- No audio on any path while the gate is false (the `Speak` effect is only emitted when the gate holds, in pure `apply`).
- No cross-conversation bleed: every gate reads the **active** conversation's state; foreign-tagged calls never write another conversation's state.
- Every client-tool call resolves **exactly one** `SubmitClientToolResult` (verified by `every_client_tool_call_emits_exactly_one_result`).
- The send-time refinement travels only as `system_refinement`; the chat view shows only the typed text — the refinement never enters visible chat.

## Needs human QA (dspadea)
Visual/audio only: the new row's layout/spacing and dropdown styling (no CSS added — GTK defaults; `.mic-button`/`.mic-active` carried over); push-to-talk show/hide on `You` toggle with a live capture backend; reply narration + say_this audio across the Disabled/On Demand/Always matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)