### PR TITLE
GTK-1: bridge receive loop can exit; window close tears the connection down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "anyhow",
  "cpal",
  "ringbuf",
+ "rubato",
  "tokio",
  "tracing",
 ]

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -7,7 +7,7 @@ use desktop_assistant_client_common::SignalEvent;
 use desktop_assistant_client_common::{AssistantClient, ConnectionConfig, Connector};
 use gtk4::glib;
 use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
@@ -422,8 +422,16 @@ where
 /// Persistent connection lifecycle: connect → forward signals → detect
 /// disconnect → reconnect with exponential backoff.
 ///
-/// Exits when `ui_tx` is closed (GTK window gone).
-pub async fn connection_manager(config: ConnectionConfig, ui_tx: mpsc::UnboundedSender<UiMessage>) {
+/// Exits when `ui_tx` is closed (GTK window gone) or when `shutdown` is
+/// signalled (the window's `close-request` fired, or the window dropped its
+/// shutdown handle). Exiting drops this task's `Arc<Connector>` clone and
+/// `ui_tx` clone, which is what lets the daemon session end and the bridge
+/// channel close (issue: GTK-1).
+pub async fn connection_manager(
+    config: ConnectionConfig,
+    ui_tx: mpsc::UnboundedSender<UiMessage>,
+    _shutdown: watch::Receiver<bool>,
+) {
     const INITIAL_BACKOFF_SECS: u64 = 2;
     const MAX_BACKOFF_SECS: u64 = 30;
 
@@ -689,7 +697,146 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+    use std::time::Duration;
+
     use super::*;
+
+    /// GTK-1 acceptance: the bridge's receive loop must NOT keep its own
+    /// channel alive. Once the `AsyncBridge` (and every sender clone) is
+    /// dropped, the loop has to observe the close, exit, and release the
+    /// handler — which is what releases the widget `Rc`s a real window's
+    /// handler captures. The old code cloned `ui_tx` into the loop itself, so
+    /// the channel could never close and every closed window leaked its whole
+    /// widget tree.
+    #[test]
+    fn bridge_handler_loop_exits_and_releases_handler_when_senders_drop() {
+        // A dedicated context so parallel tests don't fight over the default.
+        let ctx = glib::MainContext::new();
+        ctx.with_thread_default(|| {
+            /// Sets the flag when the handler closure (its owner) is dropped.
+            struct DropFlag(Rc<Cell<bool>>);
+            impl Drop for DropFlag {
+                fn drop(&mut self) {
+                    self.0.set(true);
+                }
+            }
+
+            let handled = Rc::new(Cell::new(0u32));
+            let dropped = Rc::new(Cell::new(false));
+            let guard = DropFlag(Rc::clone(&dropped));
+            let handled_in = Rc::clone(&handled);
+            let bridge = AsyncBridge::new(move |_msg, _tx| {
+                let _ = &guard; // the closure owns the drop guard
+                handled_in.set(handled_in.get() + 1);
+            });
+
+            // Sanity: a message still flows through the loop to the handler.
+            bridge
+                .ui_sender()
+                .send(UiMessage::StatusUpdate("ping".to_string()))
+                .expect("send on live bridge");
+            for _ in 0..100 {
+                if handled.get() > 0 {
+                    break;
+                }
+                ctx.iteration(false);
+            }
+            assert_eq!(handled.get(), 1, "message must reach the handler");
+            assert!(!dropped.get(), "handler must be alive while bridge lives");
+
+            // Drop the last sender; the loop must exit and drop the handler.
+            drop(bridge);
+            for _ in 0..100 {
+                if dropped.get() {
+                    break;
+                }
+                ctx.iteration(false);
+            }
+            assert!(
+                dropped.get(),
+                "receive loop must exit (and release the handler) once all senders drop"
+            );
+        })
+        .expect("acquire test main context");
+    }
+
+    /// GTK-1 acceptance: signalling shutdown makes `connection_manager` return
+    /// promptly — even from its reconnect backoff sleep — instead of
+    /// reconnecting forever after the window closed.
+    #[tokio::test]
+    async fn connection_manager_exits_promptly_when_shutdown_signalled() {
+        // A UDS path that cannot exist → connect fails fast → the manager sits
+        // in its backoff sleep, which shutdown must interrupt.
+        let config = ConnectionConfig {
+            transport_mode: desktop_assistant_client_common::TransportMode::Uds,
+            socket_path: Some(std::path::PathBuf::from(
+                "/nonexistent/adele-gtk-test/never.sock",
+            )),
+            ..Default::default()
+        };
+        let (ui_tx, _ui_rx) = mpsc::unbounded_channel::<UiMessage>();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+        // Let it fail its first connect and enter backoff.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        shutdown_tx.send(true).expect("manager subscribed");
+
+        tokio::time::timeout(Duration::from_secs(1), manager)
+            .await
+            .expect("connection_manager must exit promptly on shutdown")
+            .expect("connection_manager task must not panic");
+    }
+
+    /// GTK-1 unhappy path: the shutdown *sender* being dropped (window torn
+    /// down without an explicit signal) must also stop the manager.
+    #[tokio::test]
+    async fn connection_manager_exits_when_shutdown_sender_dropped() {
+        let config = ConnectionConfig {
+            transport_mode: desktop_assistant_client_common::TransportMode::Uds,
+            socket_path: Some(std::path::PathBuf::from(
+                "/nonexistent/adele-gtk-test/never.sock",
+            )),
+            ..Default::default()
+        };
+        let (ui_tx, _ui_rx) = mpsc::unbounded_channel::<UiMessage>();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(shutdown_tx);
+
+        tokio::time::timeout(Duration::from_secs(1), manager)
+            .await
+            .expect("connection_manager must exit when the shutdown sender drops")
+            .expect("connection_manager task must not panic");
+    }
+
+    /// GTK-1 regression guard: when the UI channel itself closes (receiver
+    /// gone), the manager must still exit on its own — shutdown is an
+    /// *additional* exit, not a replacement for the existing one.
+    #[tokio::test]
+    async fn connection_manager_exits_when_ui_channel_closes() {
+        let config = ConnectionConfig {
+            transport_mode: desktop_assistant_client_common::TransportMode::Uds,
+            socket_path: Some(std::path::PathBuf::from(
+                "/nonexistent/adele-gtk-test/never.sock",
+            )),
+            ..Default::default()
+        };
+        let (ui_tx, ui_rx) = mpsc::unbounded_channel::<UiMessage>();
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        drop(ui_rx); // window's receive loop already gone
+        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+
+        tokio::time::timeout(Duration::from_secs(1), manager)
+            .await
+            .expect("connection_manager must exit when the UI channel closes")
+            .expect("connection_manager task must not panic");
+    }
 
     fn sample_task() -> api::TaskView {
         api::TaskView {

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -385,12 +385,21 @@ impl AsyncBridge {
         F: Fn(UiMessage, &mpsc::UnboundedSender<UiMessage>) + 'static,
     {
         let (ui_tx, mut ui_rx) = mpsc::unbounded_channel::<UiMessage>();
-        let handler_tx = ui_tx.clone();
+        // The loop must NOT hold a strong sender to its own channel (GTK-1):
+        // that made the channel permanently unclosable, so the loop — and the handler's
+        // captured widget Rcs — lived forever after the window closed. A weak
+        // sender is upgraded per message instead; once every strong sender
+        // (the bridge + spawned tasks' clones) is gone, `recv()` returns
+        // `None`, the loop exits, and the handler (with its widgets) drops.
+        let weak_tx = ui_tx.downgrade();
 
         // Spawn a local future on the GLib main context to receive messages
         glib::spawn_future_local(async move {
             while let Some(msg) = ui_rx.recv().await {
-                handler(msg, &handler_tx);
+                // All strong senders gone: nothing can act on follow-ups the
+                // handler would send, so stop draining and exit.
+                let Some(tx) = weak_tx.upgrade() else { break };
+                handler(msg, &tx);
             }
         });
 
@@ -430,7 +439,7 @@ where
 pub async fn connection_manager(
     config: ConnectionConfig,
     ui_tx: mpsc::UnboundedSender<UiMessage>,
-    _shutdown: watch::Receiver<bool>,
+    mut shutdown: watch::Receiver<bool>,
 ) {
     const INITIAL_BACKOFF_SECS: u64 = 2;
     const MAX_BACKOFF_SECS: u64 = 30;
@@ -438,142 +447,27 @@ pub async fn connection_manager(
     let mut backoff_secs = INITIAL_BACKOFF_SECS;
 
     loop {
-        match Connector::connect(&config).await {
+        // Every await in the cycle (connect, the connected session, the
+        // backoff sleep) races the shutdown signal, so a closing window can
+        // interrupt the manager wherever it is.
+        let connect_result = tokio::select! {
+            result = Connector::connect(&config) => result,
+            _ = shutdown_requested(&mut shutdown) => return,
+        };
+
+        match connect_result {
             Ok(connector) => {
                 backoff_secs = INITIAL_BACKOFF_SECS;
-                // Subscribe before issuing any prompt so no early chunk is
-                // lost; the fanout pump inside the `Connector` keeps running as
-                // long as the `Arc<Connector>` is alive (held by the window).
-                let mut signal_rx = connector.subscribe();
-                let connector = Arc::new(connector);
-                // `client()` borrows the transport owned by the `Connector`;
-                // the connector outlives every use below (and the shared
-                // `Arc` clone handed to the GTK thread keeps the pump alive).
-                let transport = connector.client();
-
-                let label = connector.label().to_string();
-                if ui_tx.send(UiMessage::Connected { label }).is_err() {
-                    return;
-                }
-
-                // Hand the connector to the GTK main thread before the
-                // conversation list (which needs it). Same channel, so
-                // delivery stays ordered.
-                if ui_tx
-                    .send(UiMessage::ClientReady(Arc::clone(&connector)))
-                    .is_err()
-                {
-                    return;
-                }
-
-                // Refresh conversation list on connect
-                match transport.list_conversations().await {
-                    Ok(convs) => {
-                        if ui_tx.send(UiMessage::ConversationsLoaded(convs)).is_err() {
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        if ui_tx
-                            .send(UiMessage::Error(format!("Load conversations: {e}")))
-                            .is_err()
-                        {
-                            return;
-                        }
-                    }
-                }
-
-                // Fetch available models when the transport supports it
-                // (the command channel — Uds and Ws; the D-Bus interface
-                // doesn't expose this command).
-                let listings = match transport.as_commands() {
-                    Some(cmds) => cmds
-                        .list_available_models(None, false)
-                        .await
-                        .unwrap_or_else(|e| {
-                            tracing::warn!("list_available_models failed: {e}");
-                            Vec::new()
-                        }),
-                    None => Vec::new(),
+                // Run the connected session; on shutdown the whole session
+                // future (connector, signal stream) is dropped here, which
+                // closes the transport and ends the daemon session.
+                let flow = tokio::select! {
+                    flow = drive_connection(connector, &ui_tx) => flow,
+                    _ = shutdown_requested(&mut shutdown) => return,
                 };
-                if ui_tx.send(UiMessage::ModelsLoaded(listings)).is_err() {
+                if flow.is_break() {
                     return;
                 }
-
-                // Resolve the interactive-purpose default model so the picker
-                // can show a concrete fallback for conversations with no stored
-                // selection (issue #53). Graceful: on failure (or a D-Bus
-                // transport that doesn't carry GetPurposes) we send `None` and
-                // the picker degrades to its last-resort "Model" label.
-                let default_model = match crate::management_client::get_purposes(transport).await {
-                    Ok(purposes) => interactive_default_from_purposes(&purposes),
-                    Err(e) => {
-                        tracing::warn!("get_purposes failed; default model unresolved: {e}");
-                        None
-                    }
-                };
-                if ui_tx
-                    .send(UiMessage::DefaultModelLoaded(default_model))
-                    .is_err()
-                {
-                    return;
-                }
-
-                // Subscribe to background-task events and fetch the initial
-                // snapshot over the command channel (Uds and Ws). The D-Bus
-                // surface does not expose background tasks (issue #116 covers
-                // that path).
-                if let Some(cmds) = transport.as_commands() {
-                    if let Err(e) = cmds
-                        .send_command(api::Command::SubscribeBackgroundTasks)
-                        .await
-                    {
-                        tracing::warn!("SubscribeBackgroundTasks failed: {e}");
-                    }
-                    match cmds
-                        .send_command(api::Command::ListBackgroundTasks {
-                            include_finished: false,
-                            limit: None,
-                        })
-                        .await
-                    {
-                        Ok(api::CommandResult::BackgroundTasks(tasks)) => {
-                            if ui_tx.send(UiMessage::TasksLoaded(tasks)).is_err() {
-                                return;
-                            }
-                        }
-                        Ok(other) => {
-                            tracing::warn!(
-                                "unexpected response for ListBackgroundTasks: {other:?}"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!("ListBackgroundTasks failed: {e}");
-                        }
-                    }
-                }
-
-                // Background-task updates now arrive via the streaming
-                // `SignalEvent::Task*` family below (issue #22 — replaces the
-                // earlier 5 s `ListBackgroundTasks` poll). The initial
-                // `ListBackgroundTasks` snapshot above seeds the panel; the
-                // streaming arms in `match signal` keep it live.
-
-                // Forward signals until disconnect. The `Connector`'s fanout
-                // emits a terminal `SignalEvent::Disconnected` and then closes
-                // this receiver when the underlying stream ends, so the normal
-                // path already delivers a `UiMessage::Disconnected` here.
-                while let Some(signal) = signal_rx.recv().await {
-                    if ui_tx.send(signal_to_ui_message(signal)).is_err() {
-                        return;
-                    }
-                }
-
-                // signal_rx closed without a Disconnected event (shouldn't
-                // happen normally, but handle it defensively)
-                let _ = ui_tx.send(UiMessage::Disconnected {
-                    reason: "Connection lost".to_string(),
-                });
             }
             Err(e) => {
                 if ui_tx
@@ -597,9 +491,172 @@ pub async fn connection_manager(
             return;
         }
 
-        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+            _ = shutdown_requested(&mut shutdown) => return,
+        }
         backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
     }
+}
+
+/// Resolves when window shutdown is requested: the value flipped to `true`
+/// (close-request fired) or the sender dropped (window torn down without an
+/// explicit signal). Never resolves while the window is alive and open.
+async fn shutdown_requested(shutdown: &mut watch::Receiver<bool>) {
+    loop {
+        if *shutdown.borrow_and_update() {
+            return;
+        }
+        if shutdown.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+/// One connected session: hand the connector to the GTK thread, run the
+/// initial fetches, then forward signals until the connection ends.
+///
+/// Returns [`ControlFlow::Break`] when `ui_tx` is closed (the window's receive
+/// loop is gone — the manager must exit) and [`ControlFlow::Continue`] when
+/// the connection dropped (the manager should reconnect).
+async fn drive_connection(
+    connector: Connector,
+    ui_tx: &mpsc::UnboundedSender<UiMessage>,
+) -> std::ops::ControlFlow<()> {
+    use std::ops::ControlFlow::{Break, Continue};
+
+    // Subscribe before issuing any prompt so no early chunk is
+    // lost; the fanout pump inside the `Connector` keeps running as
+    // long as the `Arc<Connector>` is alive (held by the window).
+    let mut signal_rx = connector.subscribe();
+    let connector = Arc::new(connector);
+    // `client()` borrows the transport owned by the `Connector`;
+    // the connector outlives every use below (and the shared
+    // `Arc` clone handed to the GTK thread keeps the pump alive).
+    let transport = connector.client();
+
+    let label = connector.label().to_string();
+    if ui_tx.send(UiMessage::Connected { label }).is_err() {
+        return Break(());
+    }
+
+    // Hand the connector to the GTK main thread before the
+    // conversation list (which needs it). Same channel, so
+    // delivery stays ordered.
+    if ui_tx
+        .send(UiMessage::ClientReady(Arc::clone(&connector)))
+        .is_err()
+    {
+        return Break(());
+    }
+
+    // Refresh conversation list on connect
+    match transport.list_conversations().await {
+        Ok(convs) => {
+            if ui_tx.send(UiMessage::ConversationsLoaded(convs)).is_err() {
+                return Break(());
+            }
+        }
+        Err(e) => {
+            if ui_tx
+                .send(UiMessage::Error(format!("Load conversations: {e}")))
+                .is_err()
+            {
+                return Break(());
+            }
+        }
+    }
+
+    // Fetch available models when the transport supports it
+    // (the command channel — Uds and Ws; the D-Bus interface
+    // doesn't expose this command).
+    let listings = match transport.as_commands() {
+        Some(cmds) => cmds
+            .list_available_models(None, false)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("list_available_models failed: {e}");
+                Vec::new()
+            }),
+        None => Vec::new(),
+    };
+    if ui_tx.send(UiMessage::ModelsLoaded(listings)).is_err() {
+        return Break(());
+    }
+
+    // Resolve the interactive-purpose default model so the picker
+    // can show a concrete fallback for conversations with no stored
+    // selection (issue #53). Graceful: on failure (or a D-Bus
+    // transport that doesn't carry GetPurposes) we send `None` and
+    // the picker degrades to its last-resort "Model" label.
+    let default_model = match crate::management_client::get_purposes(transport).await {
+        Ok(purposes) => interactive_default_from_purposes(&purposes),
+        Err(e) => {
+            tracing::warn!("get_purposes failed; default model unresolved: {e}");
+            None
+        }
+    };
+    if ui_tx
+        .send(UiMessage::DefaultModelLoaded(default_model))
+        .is_err()
+    {
+        return Break(());
+    }
+
+    // Subscribe to background-task events and fetch the initial
+    // snapshot over the command channel (Uds and Ws). The D-Bus
+    // surface does not expose background tasks (issue #116 covers
+    // that path).
+    if let Some(cmds) = transport.as_commands() {
+        if let Err(e) = cmds
+            .send_command(api::Command::SubscribeBackgroundTasks)
+            .await
+        {
+            tracing::warn!("SubscribeBackgroundTasks failed: {e}");
+        }
+        match cmds
+            .send_command(api::Command::ListBackgroundTasks {
+                include_finished: false,
+                limit: None,
+            })
+            .await
+        {
+            Ok(api::CommandResult::BackgroundTasks(tasks)) => {
+                if ui_tx.send(UiMessage::TasksLoaded(tasks)).is_err() {
+                    return Break(());
+                }
+            }
+            Ok(other) => {
+                tracing::warn!("unexpected response for ListBackgroundTasks: {other:?}");
+            }
+            Err(e) => {
+                tracing::warn!("ListBackgroundTasks failed: {e}");
+            }
+        }
+    }
+
+    // Background-task updates now arrive via the streaming
+    // `SignalEvent::Task*` family below (issue #22 — replaces the
+    // earlier 5 s `ListBackgroundTasks` poll). The initial
+    // `ListBackgroundTasks` snapshot above seeds the panel; the
+    // streaming arms in `match signal` keep it live.
+
+    // Forward signals until disconnect. The `Connector`'s fanout
+    // emits a terminal `SignalEvent::Disconnected` and then closes
+    // this receiver when the underlying stream ends, so the normal
+    // path already delivers a `UiMessage::Disconnected` here.
+    while let Some(signal) = signal_rx.recv().await {
+        if ui_tx.send(signal_to_ui_message(signal)).is_err() {
+            return Break(());
+        }
+    }
+
+    // signal_rx closed without a Disconnected event (shouldn't
+    // happen normally, but handle it defensively)
+    let _ = ui_tx.send(UiMessage::Disconnected {
+        reason: "Connection lost".to_string(),
+    });
+    Continue(())
 }
 
 /// The daemon sentinel meaning "inherit from the interactive purpose"; it

--- a/src/window.rs
+++ b/src/window.rs
@@ -898,14 +898,24 @@ impl AdelieWindow {
         tasks_window.set_hide_on_close(true);
         let tasks_window = Rc::new(tasks_window);
 
+        // Window-lifetime shutdown signal (GTK-1). The `connection_manager`
+        // task (spawned below) subscribes to this; `close-request` flips it so
+        // the manager stops reconnecting, drops its `Arc<Connector>` clone
+        // (ending the daemon session), and drops its `ui_tx` clone — the first
+        // domino in letting the bridge channel close and the widget tree free.
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
         // The popup isn't owned by the `Application`, so closing the main window
         // won't reap it on its own. Destroy it when the chat window closes so it
         // never lingers past client exit (`hide_on_close` is bypassed by an
-        // explicit `destroy`).
+        // explicit `destroy`). The same close also signals connection shutdown
+        // (GTK-1) — both for the titlebar close button and the Disconnect menu
+        // item (which routes through `window.close()`).
         window.connect_close_request(glib::clone!(
             #[strong]
             tasks_window,
             move |_| {
+                let _ = shutdown_tx.send(true);
                 tasks_window.destroy();
                 glib::Propagation::Proceed
             }
@@ -1294,10 +1304,12 @@ impl AdelieWindow {
         // Spawn persistent connection manager (connect → forward → reconnect).
         // It now delivers the freshly connected `Connector` to the main thread
         // via `UiMessage::ClientReady` on the same channel as every other UI
-        // message (handled in `handle_ui_message`).
+        // message (handled in `handle_ui_message`). It exits when the window's
+        // `close-request` signals `shutdown_rx` (GTK-1), dropping its connector
+        // and sender clones.
         {
             let ui_tx = bridge.ui_sender();
-            bridge.spawn(connection_manager(config.clone(), ui_tx));
+            bridge.spawn(connection_manager(config.clone(), ui_tx, shutdown_rx));
         }
 
         // Sidebar row activation → load conversation


### PR DESCRIPTION
Closes #82.

From the 2026-06-09 code review (GTK-1, HIGH): the AsyncBridge receive loop held a clone of its own channel's sender, so the channel could never close — `connection_manager`'s documented exit condition was unreachable. Every closed window leaked its widget tree, `WindowState`, a live daemon session, and a 2-30s reconnect loop; a zombie window with `Adele: On Demand/Always` could still play `say_this` audio.

## Fix
- The receive loop now holds only a **weak sender**, upgraded per message; once all strong senders drop, `recv()` returns `None`, the loop exits, and the handler (with its widget Rcs) is released.
- `connection_manager` takes a `watch::Receiver<bool>` shutdown signal wired to the window's `close-request` (covers both the titlebar close and the Disconnect menu item, which routes through `window.close()`). Every await point (connect, the connected session, the backoff sleep) races the signal; a dropped sender also counts as shutdown.
- The connected-session body was extracted into `drive_connection` (returns `ControlFlow`) so it can be raced as one unit — behavior preserved verbatim.

## Tests (TDD — failing first in 2fa48a6)
- `bridge_handler_loop_exits_and_releases_handler_when_senders_drop`
- `connection_manager_exits_promptly_when_shutdown_signalled` (incl. interrupting backoff)
- `connection_manager_exits_when_shutdown_sender_dropped`
- `connection_manager_exits_when_ui_channel_closes` (regression guard)

`just check` green: fmt, clippy -D warnings, build, 209 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)