### PR TITLE
Lifecycle/leak + context-menu fixes (GTK-5/6/7/8/9/10)

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -102,16 +102,39 @@ fn color_scheme_prefers_dark(value: u32) -> bool {
     value == 1
 }
 
+thread_local! {
+    /// Displays this process has already installed the theme on. GTK is
+    /// single-threaded and effectively single-display, but tracking the actual
+    /// display(s) keeps the guard correct if a second one ever appears.
+    static THEMED_DISPLAYS: std::cell::RefCell<Vec<gdk::Display>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
 /// Install the app's theme handling for `display`.
 ///
 /// Installs the dark base palette unconditionally and the light overrides only
 /// while the GTK light preference is active, then keeps the choice in sync
 /// with `gtk-application-prefer-dark-theme`.
 ///
-/// Idempotent across windows: each call installs its own providers, but
-/// `style_context_add_provider_for_display` is a set keyed on the provider, so
-/// re-adding from a second window is harmless.
+/// **Idempotent per display (GTK-6):** the first call for a given display
+/// installs the providers and connects the preference-notify handler; later
+/// calls (e.g. from a second window) return immediately. Without this guard
+/// every window stacked a fresh pair of `CssProvider`s and another
+/// never-disconnected `Settings` notify handler on the shared display.
 pub fn install_for_display(display: &gdk::Display) {
+    let already = THEMED_DISPLAYS.with(|seen| {
+        let mut seen = seen.borrow_mut();
+        if seen.iter().any(|d| d == display) {
+            true
+        } else {
+            seen.push(display.clone());
+            false
+        }
+    });
+    if already {
+        return;
+    }
+
     let base_provider = CssProvider::new();
     base_provider.load_from_data(STYLE_CSS);
 

--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -113,8 +113,13 @@ impl LoginScreen {
         let connect_btn = Rc::new(connect_btn);
         let window_ref = window.clone();
 
-        // Use a shared flag so `populate` can schedule itself after a popover closes.
-        // The Rc<dyn Fn()> is built in two steps because the closure references itself.
+        // Use a shared cell so `populate` can re-run itself after a popover
+        // closes. The Rc<dyn Fn()> is built in two steps because the closure
+        // references itself. The self-reference is captured as a **`Weak`**
+        // (GTK-8): a strong capture would make the stored closure own the cell
+        // that owns the closure — a reference cycle that leaks the whole
+        // LoginScreen populate machinery for the process's life. Each
+        // invocation upgrades the weak back to a strong for its own duration.
         // Narrow allow: this self-referential closure cell is a one-off local; a
         // `type` alias would not reduce cognitive load and is out of scope here.
         #[allow(clippy::type_complexity)]
@@ -134,7 +139,7 @@ impl LoginScreen {
                 status_label,
                 #[weak]
                 window_ref,
-                #[strong(rename_to = populate_self)]
+                #[weak(rename_to = populate_self)]
                 populate,
                 move || {
                     // Clear existing rows
@@ -146,7 +151,7 @@ impl LoginScreen {
                     empty_label.set_visible(profs.is_empty());
                     connect_btn.set_sensitive(!profs.is_empty());
 
-                    for (idx, profile) in profs.iter().enumerate() {
+                    for profile in profs.iter() {
                         let row = ListBoxRow::new();
                         let hbox = GtkBox::new(Orientation::Horizontal, 8);
                         hbox.set_margin_start(12);
@@ -174,7 +179,11 @@ impl LoginScreen {
 
                         row.set_child(Some(&hbox));
 
-                        // Right-click context menu
+                        // Right-click context menu. Capture the profile id at
+                        // paint time (GTK-7) so Edit/Delete act on THIS profile
+                        // regardless of any repaint that reorders or drops rows
+                        // while the menu is open.
+                        let profile_id = profile.id.clone();
                         let gesture = GestureClick::new();
                         gesture.set_button(3);
                         gesture.connect_pressed(glib::clone!(
@@ -186,6 +195,8 @@ impl LoginScreen {
                             window_ref,
                             #[strong(rename_to = populate_inner)]
                             populate_self,
+                            #[strong]
+                            profile_id,
                             move |gesture, _n, x, y| {
                                 let Some(widget) = gesture.widget() else {
                                     return;
@@ -194,6 +205,9 @@ impl LoginScreen {
                                 let popover = Popover::new();
                                 popover.add_css_class("context-popover");
                                 popover.set_parent(&widget);
+                                // Unparent on close so the popover is released
+                                // instead of leaking parented to the row (GTK-5).
+                                popover.connect_closed(|p| p.unparent());
                                 popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(
                                     x as i32, y as i32, 1, 1,
                                 )));
@@ -213,11 +227,13 @@ impl LoginScreen {
                                     window_inner,
                                     #[strong(rename_to = populate_edit)]
                                     populate_inner,
+                                    #[strong(rename_to = profile_id_edit)]
+                                    profile_id,
                                     move |_| {
                                         popover.popdown();
                                         let profile = {
                                             let profs = profiles_inner.borrow();
-                                            profs.get(idx).cloned()
+                                            profs.iter().find(|p| p.id == profile_id_edit).cloned()
                                         };
                                         if let Some(profile) = profile {
                                             setup_dialog::show_setup_dialog(
@@ -258,16 +274,21 @@ impl LoginScreen {
                                     status_ref,
                                     #[strong(rename_to = populate_del)]
                                     populate_inner,
+                                    #[strong(rename_to = profile_id_del)]
+                                    profile_id,
                                     move |_| {
                                         popover.popdown();
-                                        let profile_id = {
-                                            let profs = profiles_inner.borrow();
-                                            profs.get(idx).map(|p| p.id.clone())
-                                        };
-                                        if let Some(id) = profile_id {
-                                            let _ = CredentialStore::delete_credentials(&id);
+                                        // Delete the captured profile by id only
+                                        // if it still exists (GTK-7).
+                                        let exists = profiles_inner
+                                            .borrow()
+                                            .iter()
+                                            .any(|p| p.id == profile_id_del);
+                                        if exists {
+                                            let id = &profile_id_del;
+                                            let _ = CredentialStore::delete_credentials(id);
                                             let store = ProfileStore::new();
-                                            let _ = store.delete(&id);
+                                            let _ = store.delete(id);
                                             let new_profiles = store.load().unwrap_or_default();
                                             *profiles_inner.borrow_mut() = new_profiles;
                                             status_inner.set_text("Connection deleted");

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -8,7 +8,11 @@ use gtk4::{
     Orientation, Popover, ScrolledWindow, SelectionMode, glib,
 };
 
-type IndexCallback = Box<dyn Fn(usize)>;
+/// Context-menu callback carrying the **conversation id** the menu was opened
+/// on — never a row index. The gesture captures the id at paint time, so a
+/// repaint that reorders or removes rows while the menu is open can't make the
+/// action target the wrong conversation (GTK-7).
+type IdCallback = Box<dyn Fn(&str)>;
 type ToggleCallback = Box<dyn Fn(bool)>;
 
 /// Sidebar widget displaying the conversation list and a "New" button.
@@ -24,9 +28,9 @@ pub struct Sidebar {
     pub show_archived_check: CheckButton,
     #[allow(dead_code)]
     pub scrolled_window: ScrolledWindow,
-    on_rename: Rc<RefCell<Option<IndexCallback>>>,
-    on_delete: Rc<RefCell<Option<IndexCallback>>>,
-    on_archive: Rc<RefCell<Option<IndexCallback>>>,
+    on_rename: Rc<RefCell<Option<IdCallback>>>,
+    on_delete: Rc<RefCell<Option<IdCallback>>>,
+    on_archive: Rc<RefCell<Option<IdCallback>>>,
     on_show_archived_toggled: Rc<RefCell<Option<ToggleCallback>>>,
 }
 
@@ -121,18 +125,21 @@ impl Sidebar {
         }
     }
 
-    /// Register a callback for when the user chooses "Rename" from the context menu.
-    pub fn connect_rename<F: Fn(usize) + 'static>(&self, f: F) {
+    /// Register a callback for when the user chooses "Rename" from the context
+    /// menu. The callback receives the conversation id (GTK-7), not a row index.
+    pub fn connect_rename<F: Fn(&str) + 'static>(&self, f: F) {
         *self.on_rename.borrow_mut() = Some(Box::new(f));
     }
 
-    /// Register a callback for when the user chooses "Delete" from the context menu.
-    pub fn connect_delete<F: Fn(usize) + 'static>(&self, f: F) {
+    /// Register a callback for when the user chooses "Delete" from the context
+    /// menu. The callback receives the conversation id (GTK-7), not a row index.
+    pub fn connect_delete<F: Fn(&str) + 'static>(&self, f: F) {
         *self.on_delete.borrow_mut() = Some(Box::new(f));
     }
 
-    /// Register a callback for when the user chooses "Archive"/"Unarchive" from the context menu.
-    pub fn connect_archive<F: Fn(usize) + 'static>(&self, f: F) {
+    /// Register a callback for when the user chooses "Archive"/"Unarchive" from
+    /// the context menu. The callback receives the conversation id (GTK-7).
+    pub fn connect_archive<F: Fn(&str) + 'static>(&self, f: F) {
         *self.on_archive.borrow_mut() = Some(Box::new(f));
     }
 
@@ -148,7 +155,7 @@ impl Sidebar {
             self.list_box.remove(&child);
         }
 
-        for (idx, conv) in conversations.iter().enumerate() {
+        for conv in conversations.iter() {
             let row = ListBoxRow::new();
             let hbox = GtkBox::new(Orientation::Horizontal, 8);
             hbox.set_margin_start(12);
@@ -175,6 +182,10 @@ impl Sidebar {
             let gesture = GestureClick::new();
             gesture.set_button(3); // secondary (right) click
             let is_archived = conv.archived;
+            // Capture the conversation id at paint time (GTK-7): the menu acts
+            // on THIS conversation regardless of any repaint that reorders or
+            // drops rows while it's open.
+            let conv_id = conv.id.clone();
             gesture.connect_pressed(glib::clone!(
                 #[strong(rename_to = on_rename)]
                 self.on_rename,
@@ -182,6 +193,8 @@ impl Sidebar {
                 self.on_delete,
                 #[strong(rename_to = on_archive)]
                 self.on_archive,
+                #[strong]
+                conv_id,
                 move |gesture, _n_press, x, y| {
                     let Some(widget) = gesture.widget() else {
                         return;
@@ -190,6 +203,11 @@ impl Sidebar {
                     let popover = Popover::new();
                     popover.add_css_class("context-popover");
                     popover.set_parent(&widget);
+                    // Unparent on close so the popover (and its widget tree) is
+                    // released instead of leaking parented to the row, which also
+                    // raised "finalized while parented" warnings on every
+                    // repaint (GTK-5).
+                    popover.connect_closed(|p| p.unparent());
                     popover.set_pointing_to(Some(&gtk4::gdk::Rectangle::new(
                         x as i32, y as i32, 1, 1,
                     )));
@@ -202,12 +220,14 @@ impl Sidebar {
                     rename_btn.connect_clicked(glib::clone!(
                         #[strong(rename_to = on_rename_inner)]
                         on_rename,
+                        #[strong(rename_to = conv_id_inner)]
+                        conv_id,
                         #[weak]
                         popover,
                         move |_| {
                             popover.popdown();
                             if let Some(ref cb) = *on_rename_inner.borrow() {
-                                cb(idx);
+                                cb(&conv_id_inner);
                             }
                         }
                     ));
@@ -219,12 +239,14 @@ impl Sidebar {
                     archive_btn.connect_clicked(glib::clone!(
                         #[strong(rename_to = on_archive_inner)]
                         on_archive,
+                        #[strong(rename_to = conv_id_inner)]
+                        conv_id,
                         #[weak]
                         popover,
                         move |_| {
                             popover.popdown();
                             if let Some(ref cb) = *on_archive_inner.borrow() {
-                                cb(idx);
+                                cb(&conv_id_inner);
                             }
                         }
                     ));
@@ -236,12 +258,14 @@ impl Sidebar {
                     delete_btn.connect_clicked(glib::clone!(
                         #[strong(rename_to = on_delete_inner)]
                         on_delete,
+                        #[strong(rename_to = conv_id_inner)]
+                        conv_id,
                         #[weak]
                         popover,
                         move |_| {
                             popover.popdown();
                             if let Some(ref cb) = *on_delete_inner.borrow() {
-                                cb(idx);
+                                cb(&conv_id_inner);
                             }
                         }
                     ));

--- a/src/window.rs
+++ b/src/window.rs
@@ -272,6 +272,13 @@ enum Effect {
     /// flows through `ConversationLoaded` and re-applies the picker selection),
     /// a reload must never clobber the user's pick — see issue #72.
     ReloadConversation(String),
+    /// Fetch a conversation as a *fresh switch*: the reply arrives as
+    /// `UiMessage::ConversationLoaded`, which applies the model picker selection.
+    /// Used when the active conversation has no cached detail yet (e.g. a
+    /// just-created conversation) so a single fetch both loads it and sets the
+    /// picker — replacing the old new-conversation flow's redundant second fetch
+    /// (GTK-10).
+    LoadConversation(String),
     /// Clear the chat view.
     ClearChat,
     /// Set the chat's transient status line.
@@ -370,6 +377,7 @@ impl std::fmt::Debug for Effect {
             Effect::ReloadConversation(id) => {
                 f.debug_tuple("ReloadConversation").field(id).finish()
             }
+            Effect::LoadConversation(id) => f.debug_tuple("LoadConversation").field(id).finish(),
             Effect::ClearChat => f.write_str("ClearChat"),
             Effect::SetChatStatus(m) => f.debug_tuple("SetChatStatus").field(m).finish(),
             Effect::ClearChatStatus => f.write_str("ClearChatStatus"),
@@ -524,6 +532,11 @@ impl WindowState {
             }
             UiMessage::ConversationDeleted { id } => {
                 self.conversations.retain(|c| c.id != id);
+                // Prune the deleted conversation's per-conversation voice state
+                // (GTK-9): otherwise the maps grow unbounded and a later id
+                // reuse could inherit a stale `You:`/`Adele:` setting.
+                self.conversation_voice_in.remove(&id);
+                self.conversation_adele_output.remove(&id);
                 let is_active = self.current_conversation_id.as_deref() == Some(&id);
                 if is_active {
                     self.current_conversation_id = None;
@@ -2648,6 +2661,23 @@ fn handle_ui_message(
                     });
                 }
             }
+            Effect::LoadConversation(id) => {
+                // Fresh switch-style load: the reply is `ConversationLoaded`,
+                // which applies the model picker selection (GTK-10).
+                if let Some(connector) = client.borrow().clone() {
+                    let tx = ui_tx.clone();
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        match connector.client().get_conversation(&id).await {
+                            Ok(detail) => {
+                                let _ = tx.send(UiMessage::ConversationLoaded(detail));
+                            }
+                            Err(e) => {
+                                let _ = tx.send(UiMessage::Error(format!("Load conversation: {e}")));
+                            }
+                        }
+                    });
+                }
+            }
             Effect::ClearChat => {
                 chat_view.borrow_mut().clear();
             }
@@ -3336,6 +3366,60 @@ mod tests {
                 ]
             ),
             "no streaming buffer => no CompleteStreaming: {effects:?}"
+        );
+    }
+
+    // --- GTK-10: single load for a freshly-created conversation ----------
+
+    /// GTK-10: when `ConversationsLoaded` arrives for an active conversation
+    /// whose detail is NOT yet cached (a just-created conversation), the reducer
+    /// emits a single picker-setting `LoadConversation` — never a redundant
+    /// `ReloadConversation` on top of a separate explicit fetch.
+    #[test]
+    fn conversations_loaded_for_uncached_active_emits_single_fresh_load() {
+        let mut state = WindowState {
+            current_conversation_id: Some("new".to_string()),
+            // No cached detail for "new" — it was just created.
+            current_conversation: None,
+            ..Default::default()
+        };
+        let convs = vec![summary("new", "New Conversation", false)];
+        let effects = state.apply(UiMessage::ConversationsLoaded(convs));
+        let loads = effects
+            .iter()
+            .filter(|e| matches!(e, Effect::LoadConversation(id) if id == "new"))
+            .count();
+        let reloads = effects
+            .iter()
+            .filter(|e| matches!(e, Effect::ReloadConversation(_)))
+            .count();
+        assert_eq!(loads, 1, "a fresh active conversation gets one LoadConversation: {effects:?}");
+        assert_eq!(reloads, 0, "and no picker-preserving ReloadConversation: {effects:?}");
+    }
+
+    /// GTK-10: a reconnect (`ConversationsLoaded` while the active conversation's
+    /// detail IS cached) still refreshes via the picker-preserving
+    /// `ReloadConversation`, never a fresh `LoadConversation` (#72 must hold).
+    #[test]
+    fn conversations_loaded_for_cached_active_reloads_not_fresh_load() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            current_conversation: Some(detail("c1", vec![msg("user", "hi")])),
+            ..Default::default()
+        };
+        let convs = vec![summary("c1", "one", false)];
+        let effects = state.apply(UiMessage::ConversationsLoaded(convs));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::ReloadConversation(id) if id == "c1")),
+            "reconnect refresh must use ReloadConversation (preserves picker): {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::LoadConversation(_))),
+            "reconnect must not re-apply the picker via LoadConversation: {effects:?}"
         );
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1514,19 +1514,10 @@ impl AdelieWindow {
             client,
             #[strong]
             bridge,
-            #[strong]
-            state,
-            move |idx| {
-                let id = {
-                    let s = state.borrow();
-                    match s.conversations.get(idx) {
-                        Some(conv) => conv.id.clone(),
-                        None => return,
-                    }
-                };
+            move |id: &str| {
                 if let Some(connector) = client.borrow().clone() {
                     let tx = bridge.ui_sender();
-                    let id = id.clone();
+                    let id = id.to_string();
                     bridge.spawn(async move {
                         match connector.client().delete_conversation(&id).await {
                             Ok(()) => {
@@ -1552,10 +1543,10 @@ impl AdelieWindow {
             state,
             #[weak]
             window,
-            move |idx| {
+            move |id: &str| {
                 let (id, current_title) = {
                     let s = state.borrow();
-                    match s.conversations.get(idx) {
+                    match s.conversations.iter().find(|c| c.id == id) {
                         Some(conv) => (conv.id.clone(), conv.title.clone()),
                         None => return,
                     }
@@ -1656,10 +1647,10 @@ impl AdelieWindow {
             bridge,
             #[strong]
             state,
-            move |idx| {
+            move |id: &str| {
                 let (id, archived) = {
                     let s = state.borrow();
-                    match s.conversations.get(idx) {
+                    match s.conversations.iter().find(|c| c.id == id) {
                         Some(conv) => (conv.id.clone(), conv.archived),
                         None => return,
                     }
@@ -3404,6 +3395,54 @@ mod tests {
             ),
             "deleting the active conversation must clear chat + side pane + re-ensure: {effects:?}"
         );
+    }
+
+    /// GTK-9: deleting a conversation prunes its per-conversation voice maps
+    /// (`You:` input + `Adele:` output level) so a recycled/UUID-reused id can't
+    /// inherit a stale voice setting, and the maps don't grow unbounded.
+    #[test]
+    fn deleting_conversation_prunes_its_voice_maps() {
+        let mut state = WindowState {
+            conversations: vec![summary("c1", "one", false), summary("c2", "two", false)],
+            current_conversation_id: Some("c2".to_string()),
+            current_conversation: Some(detail("c2", vec![])),
+            ..Default::default()
+        };
+        // Both conversations carry voice settings.
+        state.conversation_voice_in.insert("c1".to_string(), true);
+        state
+            .conversation_adele_output
+            .insert("c1".to_string(), AdeleOutput::Always);
+        state.conversation_voice_in.insert("c2".to_string(), true);
+        state
+            .conversation_adele_output
+            .insert("c2".to_string(), AdeleOutput::OnDemand);
+
+        // Delete the inactive one.
+        state.apply(UiMessage::ConversationDeleted {
+            id: "c1".to_string(),
+        });
+        assert!(
+            !state.conversation_voice_in.contains_key("c1"),
+            "deleted conversation's You: setting must be pruned"
+        );
+        assert!(
+            !state.conversation_adele_output.contains_key("c1"),
+            "deleted conversation's Adele: level must be pruned"
+        );
+        // The surviving conversation's settings are untouched.
+        assert_eq!(state.conversation_voice_in.get("c2").copied(), Some(true));
+        assert_eq!(
+            state.conversation_adele_output.get("c2").copied(),
+            Some(AdeleOutput::OnDemand)
+        );
+
+        // Deleting the active one prunes it too.
+        state.apply(UiMessage::ConversationDeleted {
+            id: "c2".to_string(),
+        });
+        assert!(state.conversation_voice_in.is_empty());
+        assert!(state.conversation_adele_output.is_empty());
     }
 
     fn note_view(key: &str) -> api::ScratchpadNoteView {

--- a/src/window.rs
+++ b/src/window.rs
@@ -452,20 +452,36 @@ impl WindowState {
                     Effect::SetConversations(convs),
                     Effect::EnsureActiveConversation,
                 ];
-                // On *reconnect* the window still has an active conversation
-                // that is still present. `EnsureActiveConversation` only
-                // re-syncs the sidebar selection in that case (it does not
-                // reload the messages), so re-fetch the conversation to refresh
-                // the cached detail + chat (it may have changed while we were
-                // disconnected) — via `ReloadConversation`, which keeps the
-                // model picker intact. On the first connect there is no active
-                // conversation yet, so the initial load happens through
-                // `EnsureActiveConversation -> ConversationLoaded` (which does
-                // set the picker). See issue #72.
+                // The window already has an active conversation that is still
+                // present (reconnect, or a just-created conversation whose
+                // `ConversationCreated` set the active id). `EnsureActiveConversation`
+                // only re-syncs the sidebar selection in that case — it does not
+                // reload the messages — so fetch the conversation here:
+                //
+                // - detail already cached (a true reconnect refresh): use
+                //   `ReloadConversation`, which keeps the model picker intact
+                //   (issue #72).
+                // - detail NOT cached (a freshly-created conversation): use a
+                //   single `LoadConversation`, which arrives as
+                //   `ConversationLoaded` and sets the picker. This replaces the
+                //   old new-conversation flow that fetched twice — once
+                //   explicitly and once via this reload (GTK-10).
+                //
+                // On the very first connect there is no active conversation yet,
+                // so the initial load still happens through
+                // `EnsureActiveConversation -> ConversationLoaded`.
                 if let Some(id) = self.current_conversation_id.clone()
                     && self.conversations.iter().any(|c| c.id == id)
                 {
-                    effects.push(Effect::ReloadConversation(id));
+                    let detail_cached = self
+                        .current_conversation
+                        .as_ref()
+                        .is_some_and(|c| c.id == id);
+                    if detail_cached {
+                        effects.push(Effect::ReloadConversation(id));
+                    } else {
+                        effects.push(Effect::LoadConversation(id));
+                    }
                 }
                 effects
             }
@@ -1501,14 +1517,14 @@ impl AdelieWindow {
                         let client = connector.client();
                         match client.create_conversation("New Conversation").await {
                             Ok(id) => {
-                                let _ = tx.send(UiMessage::ConversationCreated { id: id.clone() });
-                                // Refresh conversation list
+                                // Set the new conversation active, then refresh
+                                // the list. The reducer's `ConversationsLoaded`
+                                // handler then issues a SINGLE picker-setting
+                                // `LoadConversation` for it (GTK-10) — no
+                                // separate explicit fetch here.
+                                let _ = tx.send(UiMessage::ConversationCreated { id });
                                 if let Ok(convs) = client.list_conversations().await {
                                     let _ = tx.send(UiMessage::ConversationsLoaded(convs));
-                                }
-                                // Load the new conversation
-                                if let Ok(detail) = client.get_conversation(&id).await {
-                                    let _ = tx.send(UiMessage::ConversationLoaded(detail));
                                 }
                             }
                             Err(e) => {
@@ -2672,7 +2688,8 @@ fn handle_ui_message(
                                 let _ = tx.send(UiMessage::ConversationLoaded(detail));
                             }
                             Err(e) => {
-                                let _ = tx.send(UiMessage::Error(format!("Load conversation: {e}")));
+                                let _ =
+                                    tx.send(UiMessage::Error(format!("Load conversation: {e}")));
                             }
                         }
                     });
@@ -2872,12 +2889,13 @@ fn ensure_active_conversation(
                 let client = connector.client();
                 match client.create_conversation("New Conversation").await {
                     Ok(id) => {
-                        let _ = tx.send(UiMessage::ConversationCreated { id: id.clone() });
+                        // Same single-load flow as the New button (GTK-10): set
+                        // it active + refresh the list; the reducer's
+                        // `ConversationsLoaded` issues one picker-setting
+                        // `LoadConversation`.
+                        let _ = tx.send(UiMessage::ConversationCreated { id });
                         if let Ok(convs) = client.list_conversations().await {
                             let _ = tx.send(UiMessage::ConversationsLoaded(convs));
-                        }
-                        if let Ok(detail) = client.get_conversation(&id).await {
-                            let _ = tx.send(UiMessage::ConversationLoaded(detail));
                         }
                     }
                     Err(e) => {
@@ -3393,8 +3411,14 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, Effect::ReloadConversation(_)))
             .count();
-        assert_eq!(loads, 1, "a fresh active conversation gets one LoadConversation: {effects:?}");
-        assert_eq!(reloads, 0, "and no picker-preserving ReloadConversation: {effects:?}");
+        assert_eq!(
+            loads, 1,
+            "a fresh active conversation gets one LoadConversation: {effects:?}"
+        );
+        assert_eq!(
+            reloads, 0,
+            "and no picker-preserving ReloadConversation: {effects:?}"
+        );
     }
 
     /// GTK-10: a reconnect (`ConversationsLoaded` while the active conversation's
@@ -3786,8 +3810,13 @@ mod tests {
         // Issue #72: on reconnect the (still-present) active conversation is
         // re-fetched via ReloadConversation — which refreshes the cache and
         // keeps the picker — instead of ConversationLoaded (which resets it).
+        // A true reconnect has the conversation's detail already cached (it was
+        // open before the link dropped); that cached detail is what selects the
+        // picker-preserving ReloadConversation over a fresh LoadConversation
+        // (GTK-10).
         let mut state = WindowState {
             current_conversation_id: Some("c1".to_string()),
+            current_conversation: Some(detail("c1", vec![msg("user", "earlier")])),
             ..Default::default()
         };
         let effects = state.apply(UiMessage::ConversationsLoaded(vec![summary(


### PR DESCRIPTION
The lifecycle/teardown + context-menu cluster from CODE_REVIEW_2026-06-09 §5.

**Stacked on #91** (`fix/gtk-conv-threading-lifecycle`) to keep `window.rs` out of two PRs at once — review/merge #91 first, then this rebases onto main trivially. The diff *against #91* is GTK-5/6/7/8/9/10 only.

## GTK-5 (#86) — popovers leaked, never unparented
Both context menus (`sidebar.rs`, `login_screen.rs`) `set_parent`ed a fresh `Popover` per right-click but never unparented it — leaking a popover + widget tree and raising "finalized while parented" warnings on every repaint. Now `connect_closed(|p| p.unparent())`.

## GTK-6 (#87) — `theme::install_for_display` stacked providers + handlers
Documented as idempotent but each call built new `CssProvider`s and connected another never-disconnected `Settings` notify handler; multiple windows stacked them on the shared display. Now genuinely idempotent per display via a `THEMED_DISPLAYS` thread-local guard.

## GTK-7 (#88) — stale-index context menus
Gestures captured the row `idx` at paint time; a repaint while a menu was open made Delete/Rename/Archive/Edit hit the wrong row. They now capture the conversation/profile **id** and resolve by id. Sidebar callbacks change `Fn(usize)` → `Fn(&str)`; window.rs handlers take the id directly.

## GTK-8 (#88) — `LoginScreen` populate Rc cycle
The self-scheduling `populate` closure `#[strong]`-captured the same `Rc` cell it was stored on (cycle → leaks the populate machinery forever). Self-capture is now `#[weak]`, upgraded per invocation.

## GTK-9 (#88) — voice maps not pruned on delete
`ConversationDeleted` now prunes the deleted id from both per-conversation voice maps (`You:` + `Adele:`). TDD reducer test.

## GTK-10 (#88) — new conversation loaded twice
The new-conversation flow fetched the conversation twice (explicit `get_conversation` + the `ReloadConversation` that `ConversationsLoaded` triggers). Now sends only `ConversationCreated` + `ConversationsLoaded`; the reducer issues a single picker-setting `LoadConversation` for an uncached active conversation and the picker-preserving `ReloadConversation` only when the detail is cached (reconnect, #72). Same fix in `ensure_active_conversation`'s auto-create path. TDD reducer tests for both branches.

## Tests
New reducer tests (TDD, red-first): GTK-9 prune-on-delete; GTK-10 uncached→single LoadConversation, cached→ReloadConversation. Updated the reconnect test to cache the detail (a real reconnect has it). Full suite: 225 passing.

## Gates
`cargo fmt -p adele-gtk --check`, `cargo clippy -p adele-gtk --all-targets -- -D warnings`, `cargo test` all green.

## Manual QA (dspadea)
- Right-click a conversation/connection row, dismiss the menu: no GTK "finalized while parented" warnings in the log; repeated open/close doesn't leak.
- Open a second window: theme still tracks light/dark; no duplicated provider/handler effects.
- Create a new conversation: it opens once with the default model in the picker (no flicker/double-load).

Closes #86
Closes #87
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)