### PR TITLE
Adopt shared adele-voice-client-common crate (drop voice-output dupes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "adele-gtk"
 version = "0.1.0"
 dependencies = [
- "adele-voice-core",
+ "adele-voice-client-common",
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",
@@ -52,10 +52,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "adele-voice-client-common"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+]
+
+[[package]]
 name = "adele-voice-core"
 version = "0.1.0"
 dependencies = [
  "pulldown-cmark",
+ "rubato",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -95,7 +103,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-core",
  "ort",
- "rubato",
  "tokio",
  "tracing",
 ]
@@ -106,7 +113,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-core",
  "anyhow",
- "rubato",
  "tokio",
  "tracing",
 ]
@@ -1371,6 +1377,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "desktop-assistant-api-model",
+ "desktop-assistant-frame-codec",
  "futures",
  "reqwest 0.13.3",
  "rustls",
@@ -1398,6 +1405,13 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "desktop-assistant-frame-codec"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,12 @@ path = "../voice/crates/vad-silero"
 [dependencies.adele-voice-stt-whisper]
 path = "../voice/crates/stt-whisper"
 
-# The voice pipeline's pure text helpers — only `SentenceBuffer`, reused to chunk
-# a long reply into one-short-sentence-per-synth pieces so neither the daemon's
-# `SayText` nor the embedded `say` hits the per-synth ~20s timeout. Same
-# `../voice` symlink path-dep; already a transitive dep of the module above, so
-# no new crates enter the graph.
-[dependencies.adele-voice-core]
-path = "../voice/crates/core"
+# Shared client-side voice-output plumbing (desktop-assistant#274): the
+# `AdeleOutput` level + narration gate, the byte-identical system-refinement
+# constants, and `into_speakable_sentences` (which chunks a long reply into
+# one-short-sentence-per-synth pieces so neither the daemon's `SayText` nor the
+# embedded `say` hits the per-synth ~20s timeout). Owned once here instead of
+# triplicated across the clients; pulls in `adele-voice-core` transitively for
+# its `SentenceBuffer`. Same `../voice` symlink path-dep as the module above.
+[dependencies.adele-voice-client-common]
+path = "../voice/crates/client-voice"

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -12,28 +12,12 @@ use tokio::sync::{mpsc, watch};
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 /// The three-way voice-**output** level for a conversation (issue #80), exposed
-/// by the `Adele:` dropdown. A dedicated enum (not two bools) because the level
-/// is genuinely three-valued and the gate logic differs per variant: a bool
-/// pair would admit a nonsensical "both" state and scatter the
-/// Disabled/OnDemand/Always distinction across call sites. Default is
-/// [`AdeleOutput::Disabled`] (never speaks).
-///
-/// Replaces phase-2's two independent toggles, which mapped directly: the
-/// read-aloud toggle was [`AdeleOutput::Always`] and the voice-mode toggle was
-/// [`AdeleOutput::OnDemand`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AdeleOutput {
-    /// Never speaks. A `say_this` aside downgrades to inline text.
-    #[default]
-    Disabled,
-    /// Speaks replies only while `You == Enabled` (conversing by voice), shaped
-    /// for the ear; speaks `say_this` asides regardless of `You`. The model's
-    /// `request_voice` selects this.
-    OnDemand,
-    /// Reads every reply aloud in full (made speakable, not shortened) —
-    /// accessibility. Independent of `You`.
-    Always,
-}
+/// by the `Adele:` dropdown (`Disabled` / `OnDemand` / `Always`; default
+/// `Disabled`). Now owned by the shared `adele-voice-client-common` crate
+/// (desktop-assistant#274) so the GTK and TUI clients share one definition + the
+/// narration gate; re-exported here so existing `crate::async_bridge::AdeleOutput`
+/// paths keep resolving unchanged.
+pub use adele_voice_client_common::AdeleOutput;
 
 fn runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| {

--- a/src/voice_embedded.rs
+++ b/src/voice_embedded.rs
@@ -26,48 +26,18 @@
 //! reply-playback hook.
 
 use std::sync::Arc;
-use std::time::Duration;
 
-use adele_voice_core::sentence_buffer::SentenceBuffer;
 use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
 use adele_voice_module::{Dictation, Speaker, TtsBackend, build_dictation, build_speaker};
 use adele_voice_stt_whisper::WhisperStt;
 use adele_voice_vad_silero::SileroVad;
 use tokio::sync::Mutex;
 
-/// Split `text` into the chunks that should be fed to a one-shot synthesizer.
-///
-/// Both the daemon's `SayText` and the embedded [`EmbeddedVoice::say`] are
-/// **one-shot**: they assume a single short sentence and apply a per-synth
-/// timeout (`adele_voice_module`'s `DEFAULT_SYNTH_TIMEOUT`, ~20s). A long reply
-/// fed in one go would blow that timeout, so the *client* must chunk it the same
-/// way the daemon's streaming pipeline does — via [`SentenceBuffer`].
-///
-/// This pushes the whole text through a `SentenceBuffer` (collecting every
-/// complete sentence) and then appends the trailing remainder from `flush()`
-/// (the last sentence has no trailing whitespace, so the buffer holds it back).
-/// If chunking yields nothing — e.g. text with no recognised boundaries that the
-/// buffer somehow drops — it falls back to a single chunk of the original text
-/// when that text is non-blank, and to an empty `Vec` for empty/whitespace
-/// input (nothing to speak).
-///
-/// The timeout passed to the buffer is irrelevant here: this is a synchronous,
-/// one-shot push/flush with no streaming, so the time-based flush never fires.
-pub fn into_speakable_sentences(text: &str) -> Vec<String> {
-    // Timeout is unused on this synchronous push→flush path; any value works.
-    let mut buf = SentenceBuffer::new(Duration::from_millis(500));
-    let mut sentences = buf.push(text);
-    let tail = buf.flush();
-    if !tail.is_empty() {
-        sentences.push(tail);
-    }
-    if sentences.is_empty() && !text.trim().is_empty() {
-        // No boundary produced a chunk but there *is* speakable text — speak it
-        // whole rather than dropping it silently.
-        sentences.push(text.trim().to_string());
-    }
-    sentences
-}
+/// The speakable-sentence chunker now lives in the shared `client-voice` crate
+/// (desktop-assistant#274) so the GTK and TUI clients can't drift. Re-exported
+/// at its original path so the in-process speak path keeps calling
+/// `voice_embedded::into_speakable_sentences`.
+pub use adele_voice_client_common::into_speakable_sentences;
 
 /// The concrete dictation type the config builder wires (Silero VAD + Whisper).
 type EmbeddedDictation = Dictation<SileroVad, WhisperStt>;
@@ -212,53 +182,6 @@ mod tests {
         assert!(clone.stop_speaking().await.is_ok());
     }
 
-    /// A multi-sentence reply splits into one chunk per sentence, in order, so
-    /// no single synth call carries the whole paragraph past its 20s timeout.
-    #[test]
-    fn chunks_multi_sentence_into_sentences() {
-        let chunks = into_speakable_sentences("Hello there. How are you? I am fine.");
-        assert_eq!(chunks, vec!["Hello there.", "How are you?", "I am fine."]);
-    }
-
-    /// A single sentence is one chunk.
-    #[test]
-    fn chunks_single_sentence_into_one() {
-        let chunks = into_speakable_sentences("Just one sentence here.");
-        assert_eq!(chunks, vec!["Just one sentence here."]);
-    }
-
-    /// Text with no trailing punctuation is still spoken — as one chunk (the
-    /// `flush()` tail), not dropped.
-    #[test]
-    fn chunks_text_without_terminal_punctuation_into_one() {
-        let chunks = into_speakable_sentences("no trailing punctuation here");
-        assert_eq!(chunks, vec!["no trailing punctuation here"]);
-    }
-
-    /// Empty / whitespace-only input has nothing to speak → no chunks (so the
-    /// caller makes zero synth calls rather than synthesizing silence).
-    #[test]
-    fn chunks_empty_or_whitespace_into_nothing() {
-        assert!(into_speakable_sentences("").is_empty());
-        assert!(into_speakable_sentences("   \n\t  ").is_empty());
-    }
-
-    /// A long multi-sentence paragraph splits into several chunks (the whole
-    /// point: keep each synth call short enough to beat the per-synth timeout).
-    #[test]
-    fn chunks_long_paragraph_into_multiple() {
-        let paragraph = "The quick brown fox jumps over the lazy dog. \
-             It then trots away to find a quiet spot. \
-             Later, the dog wakes up and stretches lazily. \
-             Neither animal pays the other any further mind. \
-             The afternoon sun warms the empty field.";
-        let chunks = into_speakable_sentences(paragraph);
-        assert!(
-            chunks.len() >= 4,
-            "a five-sentence paragraph should split into several chunks, got {}: {chunks:?}",
-            chunks.len()
-        );
-        // Every chunk must be non-empty (no blank synth calls).
-        assert!(chunks.iter().all(|c| !c.trim().is_empty()));
-    }
+    // The `into_speakable_sentences` chunking tests moved with the function to
+    // the shared `adele-voice-client-common` crate (desktop-assistant#274).
 }

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -47,30 +47,6 @@ pub(super) struct WindowState {
     conversation_adele_output: HashMap<String, AdeleOutput>,
 }
 
-/// System refinement attached on send while `Adele == OnDemand` (issue #80).
-/// Replies are spoken only while conversing by voice, so shape them **for the
-/// ear**: brief, conversational, no markdown, symbols/acronyms spelled out.
-/// Deliberately free of markdown markers so it can't itself leak formatting.
-const ON_DEMAND_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be spoken, not read. Keep it brief and \
-     conversational, a few short sentences at most. Use no markdown or formatting of any kind, \
-     and no emoji. Spell out acronyms and abbreviations as full words and avoid symbols that do \
-     not read well aloud (say 'and' not an ampersand, 'percent' not a percent sign, 'dollars' not \
-     a dollar sign). Do not read out URLs, file paths, or email addresses; describe them in words \
-     instead, and write numbers, dates, and times the way you would say them.";
-
-/// System refinement attached on send while `Adele == Always` (issue #80).
-/// Every reply is read aloud for accessibility, so make it **speakable but not
-/// shortened**: keep the full content, just strip formatting and spell out
-/// symbols. Crucially it does NOT ask for brevity (that's the OnDemand job) —
-/// Always reads the whole answer. Free of markdown markers itself.
-const ALWAYS_SYSTEM_REFINEMENT: &str = "This reply will be read aloud in full, so write it to be spoken, not read, without \
-     leaving anything out. Do not shorten or summarize — cover everything you would normally \
-     say, just phrased for the ear. Use no markdown or formatting of any kind, and no emoji. \
-     Spell out acronyms and abbreviations as full words and avoid symbols that do not read well \
-     aloud (say 'and' not an ampersand, 'percent' not a percent sign, 'dollars' not a dollar \
-     sign). Do not read out URLs, file paths, or email addresses; describe them in words instead, \
-     and write numbers, dates, and times the way you would say them.";
-
 impl WindowState {
     /// Whether `You:` (voice input) is Enabled for `conversation` (issue #80).
     /// `false` when it was never set (default Disabled).
@@ -113,13 +89,11 @@ impl WindowState {
     /// Whether a *reply* is spoken for `conversation` (issue #80): `Adele ==
     /// Always` OR (`Adele == OnDemand` AND `You == Enabled`). The gate the
     /// reply-narration path consults — keyed by the *originating*
-    /// conversation (GTK-2); `Disabled` never narrates.
+    /// conversation (GTK-2); `Disabled` never narrates. Delegates to the shared
+    /// gate (desktop-assistant#274).
     fn narrate_for(&self, conversation: &str) -> bool {
-        match self.adele_output_for(conversation) {
-            AdeleOutput::Always => true,
-            AdeleOutput::OnDemand => self.voice_in_for(conversation),
-            AdeleOutput::Disabled => false,
-        }
+        self.adele_output_for(conversation)
+            .narrates_reply(self.voice_in_for(conversation))
     }
 
     /// Whether a *reply* is spoken for the *currently active* conversation —
@@ -137,9 +111,9 @@ impl WindowState {
     /// Whether a `say_this` aside is spoken for `conversation` (issue #80):
     /// spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`) — keyed
     /// by the *call's* conversation (GTK-4). `Disabled` downgrades the aside
-    /// to inline text.
+    /// to inline text. Delegates to the shared gate (desktop-assistant#274).
     fn say_this_spoken_for(&self, conversation: &str) -> bool {
-        !matches!(self.adele_output_for(conversation), AdeleOutput::Disabled)
+        self.adele_output_for(conversation).speaks_aside()
     }
 
     /// Whether a `say_this` aside is spoken for the *currently active*
@@ -177,13 +151,10 @@ impl WindowState {
 /// shorten); `Disabled` → none. Pure decision the send path consults to choose
 /// `send_prompt_with_system_refinement`. Free function (not a method) so the
 /// send closure can call it through a snapshot without holding a `WindowState`
-/// borrow across the await.
+/// borrow across the await. Delegates to the shared per-level refinement
+/// (desktop-assistant#274).
 pub(super) fn refinement_for_send(state: &WindowState) -> Option<&'static str> {
-    match state.adele_output_for_current() {
-        AdeleOutput::OnDemand => Some(ON_DEMAND_SYSTEM_REFINEMENT),
-        AdeleOutput::Always => Some(ALWAYS_SYSTEM_REFINEMENT),
-        AdeleOutput::Disabled => None,
-    }
+    state.adele_output_for_current().send_refinement()
 }
 
 /// The session-scoped client tools this client advertises so the model can
@@ -2763,7 +2734,7 @@ mod tests {
             let state = state_with(voice_in, AdeleOutput::OnDemand);
             assert_eq!(
                 refinement_for_send(&state),
-                Some(ON_DEMAND_SYSTEM_REFINEMENT),
+                Some(adele_voice_client_common::ON_DEMAND_SYSTEM_REFINEMENT),
                 "Adele=OnDemand must attach the brief refinement (You={voice_in})"
             );
         }
@@ -2772,11 +2743,12 @@ mod tests {
             let state = state_with(voice_in, AdeleOutput::Always);
             assert_eq!(
                 refinement_for_send(&state),
-                Some(ALWAYS_SYSTEM_REFINEMENT),
+                Some(adele_voice_client_common::ALWAYS_SYSTEM_REFINEMENT),
                 "Adele=Always must attach the full refinement (You={voice_in})"
             );
         }
         // The two refinements differ, are non-empty, and carry no markdown.
+        use adele_voice_client_common::{ALWAYS_SYSTEM_REFINEMENT, ON_DEMAND_SYSTEM_REFINEMENT};
         assert_ne!(ON_DEMAND_SYSTEM_REFINEMENT, ALWAYS_SYSTEM_REFINEMENT);
         // OnDemand asks for brevity; Always explicitly does not shorten.
         assert!(ON_DEMAND_SYSTEM_REFINEMENT.to_lowercase().contains("brief"));


### PR DESCRIPTION
Part 2 of 3 for desktop-assistant#274 — adopt the shared client-voice crate, deleting gtk's local copies.

## What

Replaces gtk's triplicated client-side voice-output plumbing with `adele-voice-client-common` (added in **voice#102**):

- `AdeleOutput` (in `async_bridge.rs`) → a re-export of the shared enum. Every `crate::async_bridge::AdeleOutput` path resolves unchanged.
- The narration gate (`narrate_for`, `say_this_spoken_for`) and `refinement_for_send` delegate to the shared enum methods (`narrates_reply`, `speaks_aside`, `send_refinement`).
- The two `*_SYSTEM_REFINEMENT` constants are dropped; the gate test references the shared constants.
- `into_speakable_sentences` moves to the shared crate; `voice_embedded` re-exports it at its original path, so the speak path is untouched. Its chunking tests moved with it.

gtk's direct `adele-voice-core` dep is replaced by `adele-voice-client-common` (which pulls `adele-voice-core` transitively for `SentenceBuffer`) — no new crates in the graph.

## Behavior

Preserving. The gtk refinement text was already the canonical version the shared crate adopted, so the prose gtk sends is unchanged. All 220 gtk tests pass; `cargo fmt -p adele-gtk` + `cargo clippy -p adele-gtk --all-targets -- -D warnings` clean.

## Merge order

**Requires voice#102 merged to voice `main` first** — gtk consumes `../voice/crates/*` via a symlink to the voice primary checkout, so the new crate isn't visible until voice main carries it. Verified locally against the voice branch; CI here will go green once voice#102 lands.

Refs desktop-assistant#274 (closed by the tui adoption PR, the last of the set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)