### PR TITLE
Context-window fill indicator in the status bar (#341)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -74,6 +74,14 @@ pub enum UiMessage {
         request_id: String,
         message: String,
     },
+    /// Per-turn context-window fill report (desktop-assistant#341). Token
+    /// COUNTS only — drives the read-only fill indicator in the status bar.
+    ContextUsage {
+        conversation_id: String,
+        used_tokens: u64,
+        budget_tokens: u64,
+        compaction_active: bool,
+    },
     TitleChanged {
         conversation_id: String,
         title: String,
@@ -262,6 +270,18 @@ impl std::fmt::Debug for UiMessage {
                 .debug_struct("AssistantStatus")
                 .field("request_id", request_id)
                 .field("message", message)
+                .finish(),
+            UiMessage::ContextUsage {
+                conversation_id,
+                used_tokens,
+                budget_tokens,
+                compaction_active,
+            } => f
+                .debug_struct("ContextUsage")
+                .field("conversation_id", conversation_id)
+                .field("used_tokens", used_tokens)
+                .field("budget_tokens", budget_tokens)
+                .field("compaction_active", compaction_active)
                 .finish(),
             UiMessage::TitleChanged {
                 conversation_id,
@@ -700,6 +720,18 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
             request_id,
             message,
         },
+        SignalEvent::ContextUsage {
+            conversation_id,
+            request_id: _,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        } => UiMessage::ContextUsage {
+            conversation_id,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        },
         SignalEvent::TitleChanged {
             conversation_id,
             title,
@@ -1031,6 +1063,31 @@ mod tests {
                 assert_eq!(chunk, "hello");
             }
             other => panic!("expected StreamChunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signal_context_usage_maps_to_ui_message() {
+        let msg = signal_to_ui_message(SignalEvent::ContextUsage {
+            conversation_id: "c1".to_string(),
+            request_id: "r1".to_string(),
+            used_tokens: 12_000,
+            budget_tokens: 32_000,
+            compaction_active: true,
+        });
+        match msg {
+            UiMessage::ContextUsage {
+                conversation_id,
+                used_tokens,
+                budget_tokens,
+                compaction_active,
+            } => {
+                assert_eq!(conversation_id, "c1");
+                assert_eq!(used_tokens, 12_000);
+                assert_eq!(budget_tokens, 32_000);
+                assert!(compaction_active);
+            }
+            other => panic!("expected ContextUsage, got {other:?}"),
         }
     }
 

--- a/src/context_usage.rs
+++ b/src/context_usage.rs
@@ -1,0 +1,175 @@
+//! Context-window fill indicator model (desktop-assistant#341).
+//!
+//! Mirrors the daemon's `SignalEvent::ContextUsage` (token COUNTS only, never
+//! content) and turns it into a glanceable, read-only `used / budget (pct%)`
+//! readout plus a colour bucket keyed to the proactive-compaction line. The
+//! daemon owns the numbers; this never recomputes a budget — it only formats.
+
+/// The proactive-compaction ratio the daemon uses (`COMPACTION_TOKEN_RATIO`).
+/// Kept in sync deliberately: this is the colour-threshold contract.
+const COMPACTION_RATIO: f64 = 0.85;
+
+/// Colour bucket for the fill indicator. Green below 0.85 of budget, amber
+/// from 0.85 up to budget, red at/over budget (overflow).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextFillLevel {
+    Green,
+    Amber,
+    Red,
+}
+
+impl ContextFillLevel {
+    /// CSS class applied to the indicator label for this level. Styled in
+    /// `style.css` / `style-light.css`.
+    pub fn css_class(self) -> &'static str {
+        match self {
+            ContextFillLevel::Green => "context-fill-green",
+            ContextFillLevel::Amber => "context-fill-amber",
+            ContextFillLevel::Red => "context-fill-red",
+        }
+    }
+
+    /// All classes, so the executor can clear the others before adding one.
+    pub fn all_classes() -> [&'static str; 3] {
+        [
+            "context-fill-green",
+            "context-fill-amber",
+            "context-fill-red",
+        ]
+    }
+}
+
+/// Per-conversation context-window fill. Token COUNTS only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextUsageView {
+    pub used_tokens: u64,
+    pub budget_tokens: u64,
+    pub compaction_active: bool,
+}
+
+impl ContextUsageView {
+    /// Fraction of budget consumed (0.0..). May exceed 1.0 on overflow.
+    /// Returns 0.0 for a zero/unknown budget — no divide-by-zero, renders
+    /// neutrally rather than implying false precision.
+    pub fn fraction(&self) -> f64 {
+        if self.budget_tokens == 0 {
+            0.0
+        } else {
+            self.used_tokens as f64 / self.budget_tokens as f64
+        }
+    }
+
+    pub fn level(&self) -> ContextFillLevel {
+        let f = self.fraction();
+        if f >= 1.0 {
+            ContextFillLevel::Red
+        } else if f >= COMPACTION_RATIO {
+            // Inclusive at exactly 0.85: AT the line is the moment to warn.
+            ContextFillLevel::Amber
+        } else {
+            ContextFillLevel::Green
+        }
+    }
+
+    /// Compact readout, e.g. `12k / 32k (38%)`; a trailing `⟳` marks an
+    /// active windowing/compaction pass.
+    pub fn readout(&self) -> String {
+        let pct = (self.fraction() * 100.0).round() as u64;
+        let mut s = format!(
+            "{} / {} ({pct}%)",
+            abbrev_tokens(self.used_tokens),
+            abbrev_tokens(self.budget_tokens),
+        );
+        if self.compaction_active {
+            s.push_str(" ⟳");
+        }
+        s
+    }
+}
+
+/// Abbreviate a token count for the narrow status bar: `12000 -> "12k"`,
+/// `512 -> "512"`.
+fn abbrev_tokens(n: u64) -> String {
+    if n >= 1_000 {
+        format!("{}k", n / 1_000)
+    } else {
+        n.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage(used: u64, budget: u64, compaction: bool) -> ContextUsageView {
+        ContextUsageView {
+            used_tokens: used,
+            budget_tokens: budget,
+            compaction_active: compaction,
+        }
+    }
+
+    #[test]
+    fn readout_formats_used_over_budget_with_percent() {
+        assert_eq!(usage(12_000, 32_000, false).readout(), "12k / 32k (38%)");
+        assert_eq!(usage(500, 8_000, false).readout(), "500 / 8k (6%)");
+    }
+
+    #[test]
+    fn readout_marks_active_compaction() {
+        assert!(usage(30_000, 32_000, true).readout().ends_with(" ⟳"));
+        assert!(!usage(30_000, 32_000, false).readout().contains('⟳'));
+    }
+
+    #[test]
+    fn zero_used_at_turn_start_is_green_zero_percent() {
+        let u = usage(0, 32_000, false);
+        assert_eq!(u.level(), ContextFillLevel::Green);
+        assert_eq!(u.readout(), "0 / 32k (0%)");
+    }
+
+    #[test]
+    fn below_threshold_is_green() {
+        assert_eq!(
+            usage(26_880, 32_000, false).level(),
+            ContextFillLevel::Green
+        );
+    }
+
+    #[test]
+    fn exactly_at_0_85_is_amber_inclusive() {
+        // 0.85 * 32_000 == 27_200.
+        assert_eq!(
+            usage(27_200, 32_000, false).level(),
+            ContextFillLevel::Amber
+        );
+    }
+
+    #[test]
+    fn between_threshold_and_budget_is_amber() {
+        assert_eq!(
+            usage(30_000, 32_000, false).level(),
+            ContextFillLevel::Amber
+        );
+    }
+
+    #[test]
+    fn at_budget_is_red() {
+        assert_eq!(usage(32_000, 32_000, false).level(), ContextFillLevel::Red);
+    }
+
+    #[test]
+    fn over_budget_overflow_is_red() {
+        let u = usage(40_000, 32_000, false);
+        assert_eq!(u.level(), ContextFillLevel::Red);
+        assert_eq!(u.readout(), "40k / 32k (125%)");
+    }
+
+    #[test]
+    fn zero_budget_renders_neutrally_without_panic() {
+        let u = usage(5_000, 0, false);
+        assert_eq!(u.fraction(), 0.0);
+        assert_eq!(u.level(), ContextFillLevel::Green);
+        assert_eq!(u.readout(), "5k / 0 (0%)");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod async_bridge;
 // (`--no-default-features`) draws plain text and never references them.
 #[cfg(feature = "linux")]
 mod avatars;
+mod context_usage;
 mod credential_store;
 mod management_client;
 // Markdown→sanitized-HTML rendering + the CSP-pinned WebView template. Only the

--- a/src/style-light.css
+++ b/src/style-light.css
@@ -89,6 +89,17 @@ window {
     color: #5b6473;
 }
 
+/* Context-window fill indicator (#341), darkened for the light theme. */
+.context-fill.context-fill-green {
+    color: #2e7d3a;
+}
+.context-fill.context-fill-amber {
+    color: #b8841f;
+}
+.context-fill.context-fill-red {
+    color: #c0392b;
+}
+
 .toast-row {
     background-color: #eceef4;
     color: #1a1d2e;

--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,22 @@ window {
     font-size: 12px;
 }
 
+/* Read-only context-window fill indicator (#341). Colour tracks the
+   proactive-compaction line: green below 0.85, amber up to budget, red over. */
+.context-fill {
+    font-size: 12px;
+    font-weight: bold;
+}
+.context-fill.context-fill-green {
+    color: #7ac884;
+}
+.context-fill.context-fill-amber {
+    color: #e8b860;
+}
+.context-fill.context-fill-red {
+    color: #e86a6a;
+}
+
 /* Advisory toast (e.g. a dangling model selection cleared by the daemon). */
 .toast-row {
     background-color: #2a2e45;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -39,6 +39,8 @@ struct WindowWidgets {
     sidebar: Rc<Sidebar>,
     chat_view: Rc<RefCell<ChatView>>,
     status_label: Rc<Label>,
+    /// Read-only context-window fill indicator (#341).
+    context_label: Rc<Label>,
     client: Rc<RefCell<Option<Arc<Connector>>>>,
     input_bar: Rc<InputBar>,
     model_picker: Rc<ModelPicker>,
@@ -287,6 +289,18 @@ impl AdelieWindow {
         status_label.add_css_class("status-bar");
         status_bar.append(&status_label);
 
+        // Read-only context-window fill indicator (#341). Right-aligned,
+        // before the Debug check. Hidden until the first reading arrives.
+        let context_label = Label::new(None);
+        context_label.set_halign(gtk4::Align::End);
+        context_label.set_margin_end(8);
+        context_label.add_css_class("context-fill");
+        context_label.set_visible(false);
+        context_label.set_tooltip_text(Some(
+            "Context window used / budget. Amber near the compaction line, red at overflow.",
+        ));
+        status_bar.append(&context_label);
+
         let debug_check = CheckButton::with_label("Debug");
         debug_check.set_halign(gtk4::Align::End);
         debug_check.set_margin_end(12);
@@ -330,6 +344,7 @@ impl AdelieWindow {
         let chat_view = Rc::new(RefCell::new(chat_view));
         let input_bar = Rc::new(input_bar);
         let status_label = Rc::new(status_label);
+        let context_label = Rc::new(context_label);
         let model_picker = Rc::new(model_picker);
         let tasks_panel = Rc::new(tasks_panel);
         let side_pane = Rc::new(side_pane);
@@ -381,6 +396,7 @@ impl AdelieWindow {
             sidebar: sidebar.clone(),
             chat_view: chat_view.clone(),
             status_label: status_label.clone(),
+            context_label: context_label.clone(),
             client: client.clone(),
             input_bar: input_bar.clone(),
             model_picker: model_picker.clone(),
@@ -1318,6 +1334,7 @@ fn handle_ui_message(
         sidebar,
         chat_view,
         status_label,
+        context_label,
         client,
         input_bar,
         model_picker,
@@ -1428,6 +1445,24 @@ fn handle_ui_message(
             }
             Effect::ClearChatStatus => {
                 chat_view.borrow().clear_status();
+            }
+            Effect::SetContextUsage(usage) => {
+                // Read-only fill indicator (#341): set text + colour class, or
+                // hide when there is no reading for the open conversation.
+                for class in crate::context_usage::ContextFillLevel::all_classes() {
+                    context_label.remove_css_class(class);
+                }
+                match usage {
+                    Some(u) => {
+                        context_label.set_text(&u.readout());
+                        context_label.add_css_class(u.level().css_class());
+                        context_label.set_visible(true);
+                    }
+                    None => {
+                        context_label.set_text("");
+                        context_label.set_visible(false);
+                    }
+                }
             }
             Effect::ReceiveChunk(chunk) => {
                 chat_view.borrow_mut().receive_chunk(&chunk);

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -247,6 +247,9 @@ pub(super) enum Effect {
     SetChatStatus(String),
     /// Clear the chat's transient status line.
     ClearChatStatus,
+    /// Update the read-only context-window fill indicator (#341). `None`
+    /// clears it (no reading for the open conversation).
+    SetContextUsage(Option<crate::context_usage::ContextUsageView>),
     /// Append a streaming chunk to the chat view.
     ReceiveChunk(String),
     /// Finalize a streaming response in the chat view.
@@ -343,6 +346,7 @@ impl std::fmt::Debug for Effect {
             Effect::ClearChat => f.write_str("ClearChat"),
             Effect::SetChatStatus(m) => f.debug_tuple("SetChatStatus").field(m).finish(),
             Effect::ClearChatStatus => f.write_str("ClearChatStatus"),
+            Effect::SetContextUsage(u) => f.debug_tuple("SetContextUsage").field(u).finish(),
             Effect::ReceiveChunk(c) => f.debug_tuple("ReceiveChunk").field(c).finish(),
             Effect::CompleteStreaming(c) => f.debug_tuple("CompleteStreaming").field(c).finish(),
             Effect::SetModelSelection(s) => f.debug_tuple("SetModelSelection").field(s).finish(),
@@ -456,6 +460,9 @@ impl WindowState {
                 let mut effects = vec![
                     Effect::SetModelSelection(selection),
                     Effect::LoadConversationIntoChat(filtered),
+                    // Drop any stale context-fill reading from the previous
+                    // conversation; the next turn re-establishes it (#341).
+                    Effect::SetContextUsage(None),
                     // Rebind the side pane to the new conversation: clear stale
                     // notes until the fetch returns, refresh the filtered task
                     // list, and fetch this conversation's scratchpad.
@@ -569,6 +576,27 @@ impl WindowState {
                     && self.pending_stream_is_active()
                 {
                     vec![Effect::SetChatStatus(message)]
+                } else {
+                    vec![]
+                }
+            }
+            UiMessage::ContextUsage {
+                conversation_id,
+                used_tokens,
+                budget_tokens,
+                compaction_active,
+            } => {
+                // Only paint the fill indicator for the conversation in view
+                // (#341): a background turn's reading must not mislead the user
+                // about the conversation they are looking at.
+                if self.is_active_conversation(&conversation_id) {
+                    vec![Effect::SetContextUsage(Some(
+                        crate::context_usage::ContextUsageView {
+                            used_tokens,
+                            budget_tokens,
+                            compaction_active,
+                        },
+                    ))]
                 } else {
                     vec![]
                 }
@@ -1737,6 +1765,7 @@ mod tests {
             [
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
+                Effect::SetContextUsage(None),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(_),
@@ -1747,6 +1776,69 @@ mod tests {
             }
             other => panic!("unexpected effects: {other:?}"),
         }
+    }
+
+    // --- Context-usage indicator (#341) ---
+
+    #[test]
+    fn context_usage_for_open_conversation_sets_indicator() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::ContextUsage {
+            conversation_id: "c1".to_string(),
+            used_tokens: 12_000,
+            budget_tokens: 32_000,
+            compaction_active: false,
+        });
+        match effects.as_slice() {
+            [Effect::SetContextUsage(Some(u))] => {
+                assert_eq!(u.used_tokens, 12_000);
+                assert_eq!(u.budget_tokens, 32_000);
+                assert!(!u.compaction_active);
+            }
+            other => panic!("expected SetContextUsage(Some), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn context_usage_for_background_conversation_is_ignored() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        // A reading for a conversation that is not in view must not paint.
+        let effects = state.apply(UiMessage::ContextUsage {
+            conversation_id: "c2".to_string(),
+            used_tokens: 30_000,
+            budget_tokens: 32_000,
+            compaction_active: true,
+        });
+        assert!(
+            effects.is_empty(),
+            "background-conversation usage must produce no effect"
+        );
+    }
+
+    #[test]
+    fn switching_conversation_clears_context_usage_indicator() {
+        let mut state = WindowState {
+            current_conversation_id: Some("c1".to_string()),
+            ..Default::default()
+        };
+        // Loading a (different) conversation must emit SetContextUsage(None)
+        // so a stale fill never bleeds across conversations.
+        let effects = state.apply(UiMessage::ConversationLoaded(detail(
+            "c2",
+            vec![msg("user", "hi")],
+        )));
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetContextUsage(None))),
+            "conversation switch must clear the context-fill indicator"
+        );
     }
 
     #[test]
@@ -1768,6 +1860,7 @@ mod tests {
             [
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
+                Effect::SetContextUsage(None),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(_),
@@ -1790,6 +1883,7 @@ mod tests {
             [
                 Effect::SetModelSelection(Some(sel)),
                 Effect::LoadConversationIntoChat(_),
+                Effect::SetContextUsage(None),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(conv),


### PR DESCRIPTION
## What
gtk client side of #341. A read-only `used / budget (pct%)` context-fill indicator, right-aligned in the status bar, driven by the daemon's `SignalEvent::ContextUsage` (token counts only).

Colour tracks the proactive-compaction line: **green** below 0.85 of budget, **amber** from 0.85 up to budget, **red** at/over budget (overflow). A trailing `⟳` marks an active windowing/compaction pass. Per-conversation: gated to the open conversation in `apply` (background turns produce no effect) and cleared on a conversation switch so a stale fill never bleeds across. Hidden until the first reading arrives.

Follows the existing state/Effect pattern (`Effect::SetContextUsage(Option<_>)`); the pure decision lives in `WindowState::apply`, the thin executor sets the label text + colour class. Light + dark theme classes added. No client-side token counting.

## Testing (named)
`context_usage::{readout_formats_used_over_budget_with_percent, readout_marks_active_compaction, zero_used_at_turn_start_is_green_zero_percent, below_threshold_is_green, exactly_at_0_85_is_amber_inclusive, between_threshold_and_budget_is_amber, at_budget_is_red, over_budget_overflow_is_red, zero_budget_renders_neutrally_without_panic}`; `window::state::{context_usage_for_open_conversation_sets_indicator, context_usage_for_background_conversation_is_ignored, switching_conversation_clears_context_usage_indicator}`; `async_bridge::signal_context_usage_maps_to_ui_message`.

`just check` green; both `--features linux` (WebKit) and `--no-default-features` (Label fallback) build. Depends on the daemon side (desktop-assistant#347, merged; path-dep checkout updated).

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)