### PR TITLE
chat_view: render markdown in the non-WebView fallback pane

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,13 @@ mod context_usage;
 mod credential_store;
 mod management_client;
 // Markdown→sanitized-HTML rendering + the CSP-pinned WebView template. Only the
-// WebView (`linux`) chat path renders HTML; the Label fallback shows plain text.
+// WebView (`linux`) chat path renders HTML.
 #[cfg(feature = "linux")]
 mod markdown;
+// Markdown→`TextView`-tag rendering for the fallback (non-WebView) chat pane,
+// mirroring `markdown` for the `--no-default-features` build.
+#[cfg(not(feature = "linux"))]
+mod markdown_text;
 mod oauth;
 mod profile;
 mod selected_models;

--- a/src/markdown_text.rs
+++ b/src/markdown_text.rs
@@ -1,0 +1,193 @@
+//! Markdown → GTK `TextBuffer` rendering for the non-WebView build
+//! (`--no-default-features`, i.e. platforms without WebKitGTK such as macOS).
+//!
+//! The `linux`/WebView path renders assistant markdown to sanitized HTML (see
+//! [`crate::markdown`]); this module drives the *same* `pulldown-cmark` parser
+//! but emits `TextView` tags instead, so the fallback pane shows formatted text
+//! (bold/italic/inline code/code blocks/headings/lists/links) rather than the
+//! old flat single-`Label` string.
+//!
+//! Scope mirrors the parser's event stream, not a full HTML engine: there is no
+//! table layout or image rendering (a fallback doesn't need them). Raw embedded
+//! HTML is dropped rather than shown — the WebView path sanitizes it with
+//! `ammonia`; here there is nothing to render it into.
+
+use gtk4::pango;
+use gtk4::prelude::*;
+use gtk4::{TextBuffer, TextTag};
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+/// Text tags installed once on a buffer's tag table and reused across renders.
+///
+/// One set is created per [`crate::widgets::chat_view::ChatView`] (each owns its
+/// own buffer, hence its own tag table), so the tag names never collide.
+pub struct MarkdownTags {
+    bold: TextTag,
+    italic: TextTag,
+    strikethrough: TextTag,
+    code: TextTag,
+    code_block: TextTag,
+    heading: TextTag,
+    link: TextTag,
+    /// The "You" / "Adele" speaker header that precedes each message.
+    role: TextTag,
+}
+
+impl MarkdownTags {
+    /// Create and register the tags on `buffer`'s tag table.
+    pub fn install(buffer: &TextBuffer) -> Self {
+        let bold = buffer
+            .create_tag(Some("md-bold"), &[])
+            .expect("create md-bold");
+        bold.set_weight(700);
+
+        let italic = buffer
+            .create_tag(Some("md-italic"), &[])
+            .expect("create md-italic");
+        italic.set_style(pango::Style::Italic);
+
+        let strikethrough = buffer
+            .create_tag(Some("md-strike"), &[])
+            .expect("create md-strike");
+        strikethrough.set_strikethrough(true);
+
+        let code = buffer
+            .create_tag(Some("md-code"), &[])
+            .expect("create md-code");
+        code.set_family(Some("monospace"));
+
+        let code_block = buffer
+            .create_tag(Some("md-codeblock"), &[])
+            .expect("create md-codeblock");
+        code_block.set_family(Some("monospace"));
+        code_block.set_left_margin(24);
+        code_block.set_pixels_above_lines(4);
+        code_block.set_pixels_below_lines(4);
+
+        let heading = buffer
+            .create_tag(Some("md-heading"), &[])
+            .expect("create md-heading");
+        heading.set_weight(700);
+        heading.set_scale(1.3);
+
+        let link = buffer
+            .create_tag(Some("md-link"), &[])
+            .expect("create md-link");
+        link.set_underline(pango::Underline::Single);
+        link.set_foreground(Some("#4ea1ff"));
+
+        let role = buffer
+            .create_tag(Some("md-role"), &[])
+            .expect("create md-role");
+        role.set_weight(700);
+        role.set_scale(1.05);
+        role.set_pixels_above_lines(10);
+        role.set_pixels_below_lines(2);
+
+        Self {
+            bold,
+            italic,
+            strikethrough,
+            code,
+            code_block,
+            heading,
+            link,
+            role,
+        }
+    }
+
+    /// Insert a speaker header ("You" / "Adele") at the end of the buffer.
+    pub fn insert_role(&self, buffer: &TextBuffer, label: &str) {
+        let mut end = buffer.end_iter();
+        buffer.insert_with_tags(&mut end, &format!("{label}\n"), &[&self.role]);
+    }
+}
+
+/// Append `markdown`, rendered with `tags`, at the end of `buffer`.
+///
+/// Partial/streaming input is fine: `pulldown-cmark` treats an unterminated
+/// `**`/`` ` `` run as literal text, so a mid-stream re-render never panics or
+/// leaves a tag "stuck" open across messages (the active-tag stack is local).
+pub fn render(buffer: &TextBuffer, tags: &MarkdownTags, markdown: &str) {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    // Inline/styled tags currently in scope, innermost last. Block nesting in
+    // markdown is well-formed, so push-on-Start / pop-on-End stays balanced.
+    let mut active: Vec<TextTag> = Vec::new();
+    // List nesting: `Some(next_number)` for an ordered list, `None` for a
+    // bulleted one. Depth = stack length, used to indent nested items.
+    let mut lists: Vec<Option<u64>> = Vec::new();
+
+    for event in Parser::new_ext(markdown, options) {
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::Strong => active.push(tags.bold.clone()),
+                Tag::Emphasis => active.push(tags.italic.clone()),
+                Tag::Strikethrough => active.push(tags.strikethrough.clone()),
+                Tag::Heading { .. } => active.push(tags.heading.clone()),
+                Tag::CodeBlock(_) => active.push(tags.code_block.clone()),
+                Tag::Link { .. } => active.push(tags.link.clone()),
+                Tag::List(start) => lists.push(start),
+                Tag::Item => {
+                    let indent = "    ".repeat(lists.len().saturating_sub(1));
+                    let marker = match lists.last_mut() {
+                        Some(Some(n)) => {
+                            let marker = format!("{indent}{n}. ");
+                            *n += 1;
+                            marker
+                        }
+                        _ => format!("{indent}\u{2022} "),
+                    };
+                    insert(buffer, &[], &marker);
+                }
+                _ => {}
+            },
+            Event::End(tag) => match tag {
+                TagEnd::Strong | TagEnd::Emphasis | TagEnd::Strikethrough | TagEnd::Link => {
+                    active.pop();
+                }
+                TagEnd::Heading(_) => {
+                    active.pop();
+                    insert(buffer, &[], "\n\n");
+                }
+                TagEnd::CodeBlock => {
+                    active.pop();
+                    insert(buffer, &[], "\n");
+                }
+                TagEnd::Paragraph => insert(buffer, &[], "\n\n"),
+                TagEnd::Item => insert(buffer, &[], "\n"),
+                TagEnd::List(_) => {
+                    lists.pop();
+                }
+                _ => {}
+            },
+            Event::Text(text) => insert(buffer, &active, &text),
+            Event::Code(text) => {
+                let mut inline = active.clone();
+                inline.push(tags.code.clone());
+                insert(buffer, &inline, &text);
+            }
+            // A single newline in markdown is a soft break, rendered as a space
+            // (matching the WebView/HTML path, where HTML collapses it).
+            Event::SoftBreak => insert(buffer, &active, " "),
+            Event::HardBreak => insert(buffer, &active, "\n"),
+            Event::Rule => insert(buffer, &[], "\u{2014}\u{2014}\u{2014}\n\n"),
+            Event::TaskListMarker(done) => {
+                insert(buffer, &[], if done { "[x] " } else { "[ ] " });
+            }
+            // Raw HTML and anything else (footnotes, math) has no fallback
+            // representation here; drop it rather than dump markup as text.
+            _ => {}
+        }
+    }
+}
+
+/// Insert `text` at the end of `buffer` with every tag in `active` applied.
+fn insert(buffer: &TextBuffer, active: &[TextTag], text: &str) {
+    let refs: Vec<&TextTag> = active.iter().collect();
+    let mut end = buffer.end_iter();
+    buffer.insert_with_tags(&mut end, text, &refs);
+}

--- a/src/widgets/chat_view.rs
+++ b/src/widgets/chat_view.rs
@@ -6,21 +6,27 @@ use gtk4::{Box as GtkBox, Orientation};
 use crate::markdown;
 
 #[cfg(not(feature = "linux"))]
-use gtk4::{Label, ScrolledWindow};
+use crate::markdown_text::MarkdownTags;
+#[cfg(not(feature = "linux"))]
+use gtk4::{ScrolledWindow, TextView};
 
 /// Chat view widget that displays messages.
 ///
-/// On Linux with the `linux` feature, uses webkit6::WebView for rich HTML rendering.
-/// Falls back to a simple Label-based view otherwise.
+/// On Linux with the `linux` feature, uses webkit6::WebView for rich HTML
+/// rendering. Otherwise falls back to a `TextView` whose buffer is rendered
+/// from the same markdown via tags (bold/italic/code/headings/lists), so the
+/// non-WebView build still shows formatted text rather than a flat string.
 pub struct ChatView {
     pub container: GtkBox,
     #[cfg(feature = "linux")]
     webview: webkit6::WebView,
     #[cfg(not(feature = "linux"))]
-    content_label: Label,
+    text_view: TextView,
+    #[cfg(not(feature = "linux"))]
+    tags: MarkdownTags,
     /// Messages stored for re-rendering.
     messages: Vec<(String, String)>,
-    /// Partial streaming reply, used only by the Label-based fallback's
+    /// Partial streaming reply, used only by the `TextView` fallback's
     /// `render()`. The `linux`/WebView path appends each chunk incrementally
     /// via JS (`webview::append_chunk`) and never re-renders mid-stream, so it
     /// keeps no buffer here — the authoritative streaming buffer lives in
@@ -53,23 +59,29 @@ impl ChatView {
         };
 
         #[cfg(not(feature = "linux"))]
-        let content_label = {
+        let (text_view, tags) = {
+            let text_view = TextView::new();
+            text_view.set_editable(false);
+            text_view.set_cursor_visible(false);
+            text_view.set_wrap_mode(gtk4::WrapMode::WordChar);
+            text_view.set_hexpand(true);
+            text_view.set_vexpand(true);
+            text_view.set_left_margin(16);
+            text_view.set_right_margin(16);
+            text_view.set_top_margin(16);
+
+            let buffer = text_view.buffer();
+            buffer.set_text("Press '+ New Conversation' to start.");
+            let tags = MarkdownTags::install(&buffer);
+
             let scrolled = ScrolledWindow::new();
             scrolled.set_hexpand(true);
             scrolled.set_vexpand(true);
-
-            let label = Label::new(Some("Press '+ New Conversation' to start."));
-            label.set_wrap(true);
-            label.set_halign(gtk4::Align::Start);
-            label.set_valign(gtk4::Align::Start);
-            label.set_margin_start(16);
-            label.set_margin_end(16);
-            label.set_margin_top(16);
-            scrolled.set_child(Some(&label));
+            scrolled.set_child(Some(&text_view));
             // `scrolled` is parented into `container` (which owns it) and is
-            // never touched again, so only the label is retained for `render()`.
+            // never touched again; only the view + tags are retained for `render()`.
             container.append(&scrolled);
-            label
+            (text_view, tags)
         };
 
         Self {
@@ -77,7 +89,9 @@ impl ChatView {
             #[cfg(feature = "linux")]
             webview,
             #[cfg(not(feature = "linux"))]
-            content_label,
+            text_view,
+            #[cfg(not(feature = "linux"))]
+            tags,
             messages: Vec::new(),
             #[cfg(not(feature = "linux"))]
             streaming_buffer: String::new(),
@@ -178,19 +192,35 @@ impl ChatView {
             } else {
                 Some(self.streaming_buffer.as_str())
             };
-            let mut text = String::new();
+
+            let buffer = self.text_view.buffer();
+            buffer.set_text("");
+
+            if self.messages.is_empty() && streaming.is_none() {
+                buffer.set_text("Press '+ New Conversation' to start.");
+                return;
+            }
+
             for (role, content) in &self.messages {
                 let label = match role.as_str() {
                     "user" => "You",
                     "assistant" => "Adele",
                     _ => "",
                 };
-                text.push_str(&format!("{label}: {content}\n\n"));
+                if !label.is_empty() {
+                    self.tags.insert_role(&buffer, label);
+                }
+                crate::markdown_text::render(&buffer, &self.tags, content);
             }
             if let Some(buf) = streaming {
-                text.push_str(&format!("Adele: {buf}"));
+                self.tags.insert_role(&buffer, "Adele");
+                crate::markdown_text::render(&buffer, &self.tags, buf);
             }
-            self.content_label.set_text(&text);
+
+            // Keep the newest content in view as the transcript grows / streams.
+            let mut end = buffer.end_iter();
+            self.text_view
+                .scroll_to_iter(&mut end, 0.0, false, 0.0, 0.0);
         }
     }
 }


### PR DESCRIPTION
## Why

The `--no-default-features` build (platforms without WebKitGTK — e.g. macOS, now buildable via the Homebrew tap) rendered the entire transcript as a single flat `gtk4::Label` string: every message concatenated as `You: …\n\nAdele: …`, no formatting, and the whole text re-set on each streaming chunk.

## What

Replace it with a read-only `TextView` whose buffer is rendered from the **same `pulldown-cmark` parser the WebView/HTML path already uses** (no new dependency), emitting `TextView` tags instead of HTML:

- bold, italic, strikethrough, inline code
- fenced code blocks (monospace + indent)
- headings (bold + larger)
- ordered / bulleted lists, including nesting
- links (underlined), task-list markers
- bold speaker headers ("You" / "Adele")

New renderer lives in `src/markdown_text.rs` (mirrors `markdown`, which targets HTML), gated `#[cfg(not(feature = "linux"))]`. The view now also scrolls to the newest content.

### Scope / non-goals
Scope is the parser's event stream, not a full HTML engine: no table layout or image rendering, and raw embedded HTML is dropped (nothing to render it into here; the WebView path sanitizes it with `ammonia`). Partial/streaming markdown is safe — `pulldown-cmark` treats an unterminated run as literal text and the active-tag stack is per-render, so a tag never leaks across messages.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets`, and the test suite all clean under **both** the default (linux/webkit6) and `--no-default-features` feature sets (212 tests pass on the fallback set). Not yet visually verified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)