### PR TITLE
Subscribe to the open conversation for live multi-client turn events (#1)

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -810,6 +810,9 @@ impl AdelieWindow {
                         let mut s = state.borrow_mut();
                         if let Some(ref mut conv) = s.current_conversation {
                             conv.messages.push(ChatMessage {
+                                // Optimistic local send: no server id yet (empty
+                                // placeholder); the next reload reconciles it.
+                                id: String::new(),
                                 role: "user".to_string(),
                                 content: text.clone(),
                             });
@@ -1509,6 +1512,26 @@ fn handle_ui_message(
             }
             Effect::TaskCompleted { id } => {
                 tasks_panel.handle_task_completed(id, now_epoch_ms());
+            }
+            Effect::SubscribeConversations(conversation_ids) => {
+                // Tell the daemon which conversations we're viewing so it fans
+                // their turn events to us — including turns started by another
+                // client or the voice daemon (#1). Set-replace, fire-and-forget
+                // (the daemon Acks). Only the command channel (Uds/Ws) carries
+                // this; over D-Bus there's nothing to subscribe to, so skip.
+                if let Some(connector) = client.borrow().clone() {
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        let Some(cmds) = connector.client().as_commands() else {
+                            return;
+                        };
+                        if let Err(e) = cmds
+                            .send_command(api::Command::SubscribeConversations { conversation_ids })
+                            .await
+                        {
+                            tracing::warn!("SubscribeConversations failed: {e}");
+                        }
+                    });
+                }
             }
             Effect::FetchScratchpad(conversation_id) => {
                 if let Some(connector) = client.borrow().clone() {

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -302,6 +302,17 @@ pub(super) enum Effect {
     /// A task completed (terminal).
     TaskCompleted { id: String },
 
+    // --- Live multi-client conversation sync (issue #1) -------------------
+    /// Tell the daemon which conversations this connection is viewing so it
+    /// fans their turn events (`UserMessageAdded`/`AssistantDelta`/
+    /// `AssistantCompleted`/`AssistantError`/`AssistantStatus`) to us —
+    /// including turns started by another client or the voice daemon. Sends
+    /// `api::Command::SubscribeConversations`, which is set-replace: the WHOLE
+    /// viewed set each time it changes (today just the single active
+    /// conversation; a future tabs feature passes several). Emitted when the
+    /// active conversation is loaded/switched, and re-sent on reconnect.
+    SubscribeConversations(Vec<String>),
+
     // --- Conversation side pane (issue #60) -------------------------------
     /// Fetch the scratchpad for the given conversation (async RPC + ui_tx),
     /// mirroring `EnsureActiveConversation`. The reply arrives as
@@ -391,6 +402,9 @@ impl std::fmt::Debug for Effect {
             Effect::TaskCompleted { id } => {
                 f.debug_struct("TaskCompleted").field("id", id).finish()
             }
+            Effect::SubscribeConversations(ids) => {
+                f.debug_tuple("SubscribeConversations").field(ids).finish()
+            }
             Effect::FetchScratchpad(c) => f.debug_tuple("FetchScratchpad").field(c).finish(),
             Effect::SidePaneSetScratchpad(n) => {
                 f.debug_tuple("SidePaneSetScratchpad").field(n).finish()
@@ -459,6 +473,15 @@ impl WindowState {
                 if let Some(id) = self.current_conversation_id.clone()
                     && self.conversations.iter().any(|c| c.id == id)
                 {
+                    // Re-establish the daemon's turn-event subscription for the
+                    // open conversation on (re)connect (#1). A reconnect's
+                    // refresh flows through `ReloadConversation` →
+                    // `ConversationReloaded` (which keeps the model picker, #72)
+                    // and so does NOT pass through `ConversationLoaded`, where
+                    // the switch-time subscribe lives — so subscribe here too,
+                    // covering both the cached-detail reconnect and the
+                    // not-yet-cached path before its `ConversationLoaded` lands.
+                    effects.push(Effect::SubscribeConversations(vec![id.clone()]));
                     let detail_cached = self
                         .current_conversation
                         .as_ref()
@@ -483,6 +506,12 @@ impl WindowState {
                     // Drop any stale context-fill reading from the previous
                     // conversation; the next turn re-establishes it (#341).
                     Effect::SetContextUsage(None),
+                    // Subscribe the daemon to this (now-active) conversation so
+                    // its turn events — including ones started by another client
+                    // or the voice daemon — fan to us for live render (#1). The
+                    // set is replaced wholesale, so passing just the active
+                    // conversation also drops the previously-viewed one.
+                    Effect::SubscribeConversations(vec![id.clone()]),
                     // Rebind the side pane to the new conversation: clear stale
                     // notes until the fetch returns, refresh the filtered task
                     // list, and fetch this conversation's scratchpad.
@@ -624,6 +653,11 @@ impl WindowState {
                     self.pending_turn_external = true;
                     if let Some(ref mut conv) = self.current_conversation {
                         conv.messages.push(ChatMessage {
+                            // Locally-adopted external turn: no server id yet
+                            // (the event carries none). Empty is the sanctioned
+                            // placeholder for a message the daemon hasn't keyed;
+                            // the next reload swaps in the authoritative copy.
+                            id: String::new(),
                             role: "user".to_string(),
                             content: content.clone(),
                         });
@@ -753,6 +787,9 @@ impl WindowState {
                     // The streaming conversation is the one in view: finalize it.
                     if let Some(ref mut conv) = self.current_conversation {
                         conv.messages.push(ChatMessage {
+                            // Locally-finalized reply: no server id in hand
+                            // (empty placeholder); the next reload reconciles.
+                            id: String::new(),
                             role: "assistant".to_string(),
                             content: full_response.clone(),
                         });
@@ -1081,6 +1118,9 @@ impl WindowState {
                         let full = format!("{buffer}\n\n[Connection lost]");
                         if let Some(ref mut conv) = self.current_conversation {
                             conv.messages.push(ChatMessage {
+                                // Local connection-lost stub: no server id
+                                // (empty placeholder).
+                                id: String::new(),
                                 role: "assistant".to_string(),
                                 content: full.clone(),
                             });
@@ -1140,6 +1180,7 @@ mod tests {
 
     fn msg(role: &str, content: &str) -> ChatMessage {
         ChatMessage {
+            id: String::new(),
             role: role.to_string(),
             content: content.to_string(),
         }
@@ -1855,6 +1896,7 @@ mod tests {
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
                 Effect::SetContextUsage(None),
+                Effect::SubscribeConversations(_),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(_),
@@ -1950,6 +1992,7 @@ mod tests {
                 Effect::SetModelSelection(_),
                 Effect::LoadConversationIntoChat(filtered),
                 Effect::SetContextUsage(None),
+                Effect::SubscribeConversations(_),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(_),
@@ -1973,6 +2016,7 @@ mod tests {
                 Effect::SetModelSelection(Some(sel)),
                 Effect::LoadConversationIntoChat(_),
                 Effect::SetContextUsage(None),
+                Effect::SubscribeConversations(_),
                 Effect::SidePaneSetScratchpad(_),
                 Effect::RefreshSidePaneTasks,
                 Effect::FetchScratchpad(conv),
@@ -1983,6 +2027,30 @@ mod tests {
             }
             other => panic!("unexpected effects: {other:?}"),
         }
+    }
+
+    // --- Live multi-client conversation subscription (#1) ----------------
+
+    #[test]
+    fn conversation_loaded_subscribes_to_that_conversation() {
+        // Switching/loading a conversation must tell the daemon we're now
+        // viewing it (set-replace, just the active one) so its turn events —
+        // including ones started by another client or the voice daemon — fan to
+        // this connection for live render.
+        let mut state = WindowState::default();
+        let effects = state.apply(UiMessage::ConversationLoaded(detail(
+            "c7",
+            vec![msg("user", "hi")],
+        )));
+        let subscribed = effects.iter().find_map(|e| match e {
+            Effect::SubscribeConversations(ids) => Some(ids),
+            _ => None,
+        });
+        assert_eq!(
+            subscribed.map(Vec::as_slice),
+            Some(["c7".to_string()].as_slice()),
+            "ConversationLoaded must emit SubscribeConversations([active id]); got {effects:?}"
+        );
     }
 
     // --- Model-picker re-application -------------------------------------
@@ -2051,8 +2119,17 @@ mod tests {
             [
                 Effect::SetConversations(_),
                 Effect::EnsureActiveConversation,
+                // Reconnect re-establishes the daemon's turn-event subscription
+                // for the still-open conversation (#1) — the cached-detail path
+                // refreshes via ReloadConversation, which never passes through
+                // ConversationLoaded where the switch-time subscribe lives, so
+                // the subscribe must be re-sent here too.
+                Effect::SubscribeConversations(ids),
                 Effect::ReloadConversation(id),
-            ] => assert_eq!(id, "c1"),
+            ] => {
+                assert_eq!(ids.as_slice(), ["c1".to_string()]);
+                assert_eq!(id, "c1");
+            }
             other => panic!("unexpected effects: {other:?}"),
         }
     }


### PR DESCRIPTION
## What

Make the GTK client tell the daemon **which conversation it is viewing** so the daemon fans that conversation's turn events to this connection — including turns started by **another client or the voice daemon**. This is the **send** side of the live multi-client sync delivery that just landed in desktop-assistant; #102 already added the **render** side (adopting an external turn into the open conversation). Without this subscription, those events never arrive.

The daemon's new command `Command::SubscribeConversations { conversation_ids }` is **set-replace**: the client sends the WHOLE set of conversations it is currently viewing each time that set changes. For now the set is just the single active conversation; a future tabs feature will pass several.

## How (Elm-style reducer → effect executor)

- New `Effect::SubscribeConversations(Vec<String>)` (+ its `Debug` arm) in `src/window/state.rs`.
- **On load / switch:** emitted from the `UiMessage::ConversationLoaded` reducer arm with the now-active conversation id, so every switch re-points the daemon's fan-out at the conversation in view (and drops the previous one — the set is replaced wholesale).
- **On (re)connect:** re-sent from the `UiMessage::ConversationsLoaded` arm when a conversation is already open. A reconnect's refresh flows through `ReloadConversation` → `ConversationReloaded` (which deliberately keeps the model picker, #72) and so never passes through `ConversationLoaded` where the switch-time subscribe lives — so subscribing in `ConversationsLoaded` covers both the cached-detail reconnect path **and** the not-yet-cached path before its `ConversationLoaded` lands. (A fresh first connect with no open conversation goes `EnsureActiveConversation → ConversationLoaded`, which subscribes there — no empty subscribe is sent.)
- **Executed** in `src/window/mod.rs` by sending `api::Command::SubscribeConversations` over the connector's command channel, mirroring exactly how `SubscribeBackgroundTasks` / `CancelBackgroundTask` are sent: `client.borrow().clone()` → `spawn_on_runtime` → `connector.client().as_commands()` → `send_command(..)`. Fire-and-forget (the daemon Acks), no-ops over D-Bus (the command channel isn't available there).

**Rendering is untouched** — #102 already renders incoming external-turn events; this change only sends the subscription at the right times so those events start arriving.

## Path-dep build fix (companion to the same #1 work)

The daemon's `desktop-assistant-client-common::ChatMessage` (which gtk path-deps) gained a new **required** `id: String` field — the UUIDv7 dedupe/ordering cursor that is part of the same #1 live-sync work. gtk's `main` predates it, so the four local `ChatMessage` construction sites (optimistic send, external-turn adopt, finalize, connection-lost stub) plus the test fixture no longer compiled. They now pass `id: String::new()` — the empty-string placeholder the field documents for a message the daemon hasn't keyed (the next conversation reload swaps in the authoritative copy). This is a build-unblocker for the path-dep, not a rendering change.

## Tests

- New reducer test `conversation_loaded_subscribes_to_that_conversation`: asserts `ConversationLoaded` emits `SubscribeConversations([active id])`.
- `conversations_loaded_on_reconnect_reloads_active_conversation` now also asserts the re-subscribe (id + position).
- Existing exact-slice `ConversationLoaded` effect-order tests updated for the new effect.
- `cargo build` (default/webkit feature), `cargo test` (242 pass), `cargo fmt -p adele-gtk -- --check`, and `cargo clippy -p adele-gtk --all-targets` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)