### PR TITLE
Live sidebar refresh on conversation-list change (#1)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -41,6 +41,14 @@ pub enum UiMessage {
     /// `Arc<TransportClient>`.
     ClientReady(Arc<Connector>),
     ConversationsLoaded(Vec<desktop_assistant_client_common::ConversationSummary>),
+    /// A *list-only* re-fetch of the conversation list, triggered by
+    /// [`UiMessage::ConversationListChanged`] (a conversation was
+    /// created/renamed/deleted/(un)archived elsewhere — #1). Unlike
+    /// [`UiMessage::ConversationsLoaded`], the reducer repaints ONLY the sidebar
+    /// (and re-syncs the selection); it deliberately does NOT reload the open
+    /// conversation's chat or touch the model picker, so a sibling-client change
+    /// never disturbs what the user is reading/typing.
+    ConversationListRefetched(Vec<desktop_assistant_client_common::ConversationSummary>),
     ConversationLoaded(desktop_assistant_client_common::ConversationDetail),
     /// A conversation that is *already open* was re-fetched (on reconnect, or
     /// after a debug/personality refresh). The window refreshes the cached
@@ -96,6 +104,18 @@ pub enum UiMessage {
     TitleChanged {
         conversation_id: String,
         title: String,
+    },
+    /// The user's conversation list changed on another connection — a
+    /// conversation was created, renamed, deleted, or (un)archived by another
+    /// client or the voice daemon (desktop-assistant#1). Carried from
+    /// [`SignalEvent::ConversationListChanged`]; carries only the affected
+    /// `conversation_id`. The reducer responds with a full list re-fetch
+    /// ([`Effect::RefetchConversationList`]) — simplest and correct for every
+    /// change kind — rather than a surgical per-row edit. The refetch result
+    /// arrives as [`UiMessage::ConversationListRefetched`], which repaints only
+    /// the sidebar.
+    ConversationListChanged {
+        conversation_id: String,
     },
     /// A one-time advisory for a conversation emitted as a live signal
     /// (today only `DanglingModelSelection`: the stored model selection no
@@ -237,6 +257,9 @@ impl std::fmt::Debug for UiMessage {
             UiMessage::ConversationsLoaded(v) => {
                 f.debug_tuple("ConversationsLoaded").field(v).finish()
             }
+            UiMessage::ConversationListRefetched(v) => {
+                f.debug_tuple("ConversationListRefetched").field(v).finish()
+            }
             UiMessage::ConversationLoaded(v) => {
                 f.debug_tuple("ConversationLoaded").field(v).finish()
             }
@@ -311,6 +334,10 @@ impl std::fmt::Debug for UiMessage {
                 .debug_struct("TitleChanged")
                 .field("conversation_id", conversation_id)
                 .field("title", title)
+                .finish(),
+            UiMessage::ConversationListChanged { conversation_id } => f
+                .debug_struct("ConversationListChanged")
+                .field("conversation_id", conversation_id)
                 .finish(),
             UiMessage::ConversationWarning {
                 conversation_id,
@@ -779,6 +806,12 @@ fn signal_to_ui_message(signal: SignalEvent) -> UiMessage {
             conversation_id,
             title,
         },
+        // The user's conversation list changed on another connection (#1).
+        // Carry it through to the reducer, which responds with a full list
+        // re-fetch that repaints only the sidebar.
+        SignalEvent::ConversationListChanged { conversation_id } => {
+            UiMessage::ConversationListChanged { conversation_id }
+        }
         SignalEvent::ConversationWarning {
             conversation_id,
             warning,
@@ -1182,6 +1215,23 @@ mod tests {
                 assert_eq!(got, warning);
             }
             other => panic!("expected ConversationWarning, got {other:?}"),
+        }
+    }
+
+    /// Issue #1: a `ConversationListChanged` signal (a sibling client or the
+    /// voice daemon mutated the user's conversation list) must map to the typed
+    /// `UiMessage::ConversationListChanged`, carrying the affected id, so the
+    /// reducer can trigger a sidebar-only re-fetch.
+    #[test]
+    fn signal_conversation_list_changed_maps_to_ui_message() {
+        let msg = signal_to_ui_message(SignalEvent::ConversationListChanged {
+            conversation_id: "conv-42".to_string(),
+        });
+        match msg {
+            UiMessage::ConversationListChanged { conversation_id } => {
+                assert_eq!(conversation_id, "conv-42");
+            }
+            other => panic!("expected ConversationListChanged, got {other:?}"),
         }
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1440,6 +1440,27 @@ fn handle_ui_message(
                     });
                 }
             }
+            Effect::RefetchConversationList => {
+                // A sibling client or the voice daemon changed the user's list
+                // (#1). Re-fetch it over the live transport and deliver it as
+                // `ConversationListRefetched` — a sidebar-only repaint that
+                // leaves the open conversation + model picker untouched (the
+                // reducer deliberately does not reload the chat here). Same RPC
+                // as the connect-time refresh; only the reply variant differs.
+                if let Some(connector) = client.borrow().clone() {
+                    let tx = ui_tx.clone();
+                    crate::async_bridge::spawn_on_runtime(async move {
+                        match connector.client().list_conversations().await {
+                            Ok(convs) => {
+                                let _ = tx.send(UiMessage::ConversationListRefetched(convs));
+                            }
+                            Err(e) => {
+                                tracing::warn!("refetch conversation list failed: {e}");
+                            }
+                        }
+                    });
+                }
+            }
             Effect::ClearChat => {
                 chat_view.borrow_mut().clear();
             }

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -256,6 +256,14 @@ pub(super) enum Effect {
     /// picker — replacing the old new-conversation flow's redundant second fetch
     /// (GTK-10).
     LoadConversation(String),
+    /// Re-fetch the conversation list from the daemon, then deliver it as
+    /// [`UiMessage::ConversationListRefetched`] — a *list-only* refresh used when
+    /// the list changed on another connection (#1). Kept as an effect because it
+    /// needs the live client + ui_tx and spawns an async RPC; the decision to run
+    /// it lives in `apply`. The result repaints only the sidebar (it does NOT
+    /// reload the open conversation or touch the model picker), distinguishing it
+    /// from the connect-time `list_conversations -> ConversationsLoaded` path.
+    RefetchConversationList,
     /// Clear the chat view.
     ClearChat,
     /// Set the chat's transient status line.
@@ -373,6 +381,7 @@ impl std::fmt::Debug for Effect {
                 f.debug_tuple("ReloadConversation").field(id).finish()
             }
             Effect::LoadConversation(id) => f.debug_tuple("LoadConversation").field(id).finish(),
+            Effect::RefetchConversationList => f.write_str("RefetchConversationList"),
             Effect::ClearChat => f.write_str("ClearChat"),
             Effect::SetChatStatus(m) => f.debug_tuple("SetChatStatus").field(m).finish(),
             Effect::ClearChatStatus => f.write_str("ClearChatStatus"),
@@ -593,6 +602,34 @@ impl WindowState {
                     }
                 }
                 vec![Effect::SetConversations(self.conversations.clone())]
+            }
+            UiMessage::ConversationListChanged { conversation_id: _ } => {
+                // The user's list changed on another connection — a conversation
+                // was created/renamed/deleted/(un)archived by another client or
+                // the voice daemon (#1). The signal carries only the affected id;
+                // rather than patch a single row, re-fetch the whole list (correct
+                // for every change kind). The reply lands as
+                // `ConversationListRefetched`, which repaints ONLY the sidebar —
+                // so this never disturbs the open conversation or the model picker.
+                vec![Effect::RefetchConversationList]
+            }
+            UiMessage::ConversationListRefetched(convs) => {
+                // The list-only refresh requested by `ConversationListChanged`.
+                // Store the fresh list and repaint the sidebar; re-sync the
+                // selection via `EnsureActiveConversation` (a no-op beyond
+                // re-selecting the active row when it is still present — see
+                // `ensure_active_conversation`). Deliberately NO
+                // `ReloadConversation`/`LoadConversation`: the open conversation's
+                // chat and the model picker must stay exactly as the user left
+                // them. If the open conversation was the one deleted elsewhere,
+                // it is now absent from the list and `EnsureActiveConversation`
+                // falls back to the first conversation (or creates one), which is
+                // the right thing to show.
+                self.conversations = convs.clone();
+                vec![
+                    Effect::SetConversations(convs),
+                    Effect::EnsureActiveConversation,
+                ]
             }
             UiMessage::PromptSent {
                 task_id: _,
@@ -1673,6 +1710,89 @@ mod tests {
             }
             other => panic!("unexpected effects: {other:?}"),
         }
+    }
+
+    /// Issue #1: a `ConversationListChanged` signal (the list changed on
+    /// another connection) must trigger a full list re-fetch — and nothing else.
+    /// It carries only the affected id; the reducer responds with a single
+    /// `RefetchConversationList` effect rather than patching a row.
+    #[test]
+    fn conversation_list_changed_triggers_a_list_refetch_only() {
+        let mut state = WindowState {
+            conversations: vec![summary("c1", "one", false)],
+            current_conversation_id: Some("c1".to_string()),
+            current_conversation: Some(detail("c1", vec![])),
+            ..Default::default()
+        };
+        let effects = state.apply(UiMessage::ConversationListChanged {
+            conversation_id: "c2".to_string(),
+        });
+        assert!(
+            matches!(effects.as_slice(), [Effect::RefetchConversationList]),
+            "ConversationListChanged must request exactly one list re-fetch: {effects:?}"
+        );
+        // The decision step must not yet mutate the cached list or touch the
+        // open conversation — that waits for the refetch result.
+        assert_eq!(state.conversations.len(), 1);
+        assert_eq!(state.current_conversation_id.as_deref(), Some("c1"));
+        assert!(state.current_conversation.is_some());
+    }
+
+    /// Issue #1: the refetch result repaints ONLY the sidebar (and re-syncs the
+    /// selection via `EnsureActiveConversation`). It must NOT reload the open
+    /// conversation's chat or re-apply the model picker — so a sibling-client
+    /// change never disturbs what the user is reading/typing. Concretely, no
+    /// `ReloadConversation`/`LoadConversation` is emitted even though an open
+    /// conversation is present and cached.
+    #[test]
+    fn conversation_list_refetched_repaints_sidebar_without_disturbing_open_chat() {
+        let mut state = WindowState {
+            conversations: vec![summary("c1", "one", false)],
+            current_conversation_id: Some("c1".to_string()),
+            current_conversation: Some(detail("c1", vec![msg("user", "hi")])),
+            ..Default::default()
+        };
+        // A sibling client added "c2" and renamed "c1".
+        let fresh = vec![
+            summary("c1", "one renamed", false),
+            summary("c2", "two", false),
+        ];
+        let effects = state.apply(UiMessage::ConversationListRefetched(fresh.clone()));
+
+        // The fresh list is stored and the sidebar repainted + re-synced.
+        assert_eq!(state.conversations.len(), 2);
+        assert_eq!(state.conversations[0].title, "one renamed");
+        assert_eq!(state.conversations[1].id, "c2");
+        match effects.as_slice() {
+            [
+                Effect::SetConversations(got),
+                Effect::EnsureActiveConversation,
+            ] => {
+                assert_eq!(got.len(), 2);
+                assert_eq!(got[1].id, "c2");
+            }
+            other => panic!("unexpected effects: {other:?}"),
+        }
+        // The open conversation must be left exactly as the user had it: no
+        // chat reload, no picker re-apply, and the cached detail is untouched.
+        assert!(
+            !effects.iter().any(|e| matches!(
+                e,
+                Effect::ReloadConversation(_)
+                    | Effect::LoadConversation(_)
+                    | Effect::LoadConversationIntoChat(_)
+                    | Effect::SetModelSelection(_)
+            )),
+            "a list-only refetch must not disturb the open chat or picker: {effects:?}"
+        );
+        assert_eq!(state.current_conversation_id.as_deref(), Some("c1"));
+        assert!(
+            state
+                .current_conversation
+                .as_ref()
+                .is_some_and(|c| c.messages.len() == 1),
+            "the open conversation's cached detail must be preserved verbatim"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

When the daemon signals that the user's conversation list changed on another connection, gtk now re-fetches its conversation list and repaints the sidebar live — so a conversation **created / renamed / deleted / (un)archived elsewhere** (by another client or the voice daemon) shows up without a restart.

desktop-assistant added `desktop_assistant_client_common::SignalEvent::ConversationListChanged { conversation_id }`, broadcast to all of a user's connections on any list mutation. gtk already subscribes to this broadcast (it sends `Command::SubscribeBackgroundTasks` on connect), so the event arrives — it was simply dropped before this change.

## How

- **`src/async_bridge.rs`** — `signal_to_ui_message` maps `SignalEvent::ConversationListChanged` to a new `UiMessage::ConversationListChanged { conversation_id }`. Adds `UiMessage::ConversationListRefetched(convs)` to carry the re-fetch result back to the reducer.
- **`src/window/state.rs`** — `ConversationListChanged` reduces to a single new `Effect::RefetchConversationList`. The signal carries only the affected id, so rather than patch one row we re-fetch the whole list (simplest, correct for every change kind). The result, `ConversationListRefetched`, stores the fresh list and emits `SetConversations` + `EnsureActiveConversation` **only**.
- **`src/window/mod.rs`** — the `RefetchConversationList` executor issues the same `list_conversations()` RPC used on connect, delivering the reply as `ConversationListRefetched` (only the reply variant differs from the connect-time refresh).

## Doesn't disturb the open conversation

This repaints **only the sidebar**. Unlike the connect-time `ConversationsLoaded` path, the `ConversationListRefetched` arm deliberately emits **no** `ReloadConversation` / `LoadConversation` — so the open conversation's chat and the model picker are left exactly as the user had them. `EnsureActiveConversation` here only re-selects the active row when it is still present (no chat reload). If the open conversation was the one deleted elsewhere, it is now absent from the list and `EnsureActiveConversation` falls back to the first conversation (or creates one) — the right thing to show.

## Tests

- `conversation_list_changed_triggers_a_list_refetch_only` — the signal reduces to exactly one `RefetchConversationList` effect and mutates nothing yet.
- `conversation_list_refetched_repaints_sidebar_without_disturbing_open_chat` — the result repaints the sidebar + re-syncs selection, emits no chat-reload/picker effect, and preserves the cached open-conversation detail verbatim.
- `signal_conversation_list_changed_maps_to_ui_message` — the signal→UiMessage mapping.

`cargo build`, `cargo test -p adele-gtk` (245 pass), `cargo fmt -p adele-gtk -- --check`, and `cargo clippy -p adele-gtk --all-targets` are all clean.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)