### PR TITLE
Port off removed UiMessage::ClientReady / Effect::SetClient (#106)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -830,17 +829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backon"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
-dependencies = [
- "fastrand",
- "gloo-timers",
- "tokio",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,7 +1115,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-client-common",
  "desktop-assistant-api-model",
- "desktop-assistant-client-common",
  "serde",
  "serde_json",
 ]
@@ -1367,19 +1354,9 @@ dependencies = [
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
- "desktop-assistant-core",
+ "desktop-assistant-protocol",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "desktop-assistant-auth-jwt"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "jsonwebtoken",
- "serde",
- "uuid",
 ]
 
 [[package]]
@@ -1403,27 +1380,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "desktop-assistant-core"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "backon",
- "chrono",
- "desktop-assistant-auth-jwt",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "desktop-assistant-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1951,18 +1918,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "gobject-sys"
@@ -2631,24 +2586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "aws-lc-rs",
- "base64",
- "getrandom 0.2.17",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature",
- "simple_asn1",
- "zeroize",
-]
-
-[[package]]
 name = "keyring-core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,16 +3249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,7 +3752,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3972,7 +3899,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4204,15 +4131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,18 +4145,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -4505,7 +4411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4847,12 +4752,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -5872,20 +5771,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
-use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::{Arc, Mutex};
 
 use desktop_assistant_api_model as api;
 #[cfg(test)]
@@ -102,6 +102,10 @@ where
 pub async fn connection_manager(
     config: ConnectionConfig,
     ui_tx: mpsc::UnboundedSender<UiMessage>,
+    // Where each freshly connected `Connector` is handed to the GTK main thread
+    // (#106): `drive_connection` stores it here just before `Connected`. The core
+    // can't carry the handle (wasm), so this gtk-local cell is the seam.
+    pending_connector: Arc<Mutex<Option<Arc<Connector>>>>,
     mut shutdown: watch::Receiver<bool>,
 ) {
     const INITIAL_BACKOFF_SECS: u64 = 2;
@@ -125,7 +129,7 @@ pub async fn connection_manager(
                 // future (connector, signal stream) is dropped here, which
                 // closes the transport and ends the daemon session.
                 let flow = tokio::select! {
-                    flow = drive_connection(connector, &ui_tx) => flow,
+                    flow = drive_connection(connector, &ui_tx, &pending_connector) => flow,
                     _ = shutdown_requested(&mut shutdown) => return,
                 };
                 if flow.is_break() {
@@ -185,6 +189,7 @@ async fn shutdown_requested(shutdown: &mut watch::Receiver<bool>) {
 async fn drive_connection(
     connector: Connector,
     ui_tx: &mpsc::UnboundedSender<UiMessage>,
+    pending_connector: &Arc<Mutex<Option<Arc<Connector>>>>,
 ) -> std::ops::ControlFlow<()> {
     use std::ops::ControlFlow::{Break, Continue};
 
@@ -198,18 +203,16 @@ async fn drive_connection(
     // `Arc` clone handed to the GTK thread keeps the pump alive).
     let transport = connector.client();
 
+    // Hand the connector to the GTK main thread (#106): stash it where the
+    // `Connected` handler drains it, THEN send `Connected`. Storing before the
+    // send preserves the ordering the chat relies on — the connector is in place
+    // before `Connected` (and the later `ConversationsLoaded`, which needs it) is
+    // handled — without routing the handle through the core, which can't name
+    // `Connector` on wasm. Replaces the old `UiMessage::ClientReady` round-trip.
+    *pending_connector.lock().unwrap() = Some(Arc::clone(&connector));
+
     let label = connector.label().to_string();
     if ui_tx.send(UiMessage::Connected { label }).is_err() {
-        return Break(());
-    }
-
-    // Hand the connector to the GTK main thread before the
-    // conversation list (which needs it). Same channel, so
-    // delivery stays ordered.
-    if ui_tx
-        .send(UiMessage::ClientReady(Arc::clone(&connector)))
-        .is_err()
-    {
         return Break(());
     }
 
@@ -406,7 +409,12 @@ mod tests {
         let (ui_tx, _ui_rx) = mpsc::unbounded_channel::<UiMessage>();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+        let manager = tokio::spawn(connection_manager(
+            config,
+            ui_tx,
+            Arc::new(Mutex::new(None)),
+            shutdown_rx,
+        ));
         // Let it fail its first connect and enter backoff.
         tokio::time::sleep(Duration::from_millis(100)).await;
         shutdown_tx.send(true).expect("manager subscribed");
@@ -431,7 +439,12 @@ mod tests {
         let (ui_tx, _ui_rx) = mpsc::unbounded_channel::<UiMessage>();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+        let manager = tokio::spawn(connection_manager(
+            config,
+            ui_tx,
+            Arc::new(Mutex::new(None)),
+            shutdown_rx,
+        ));
         tokio::time::sleep(Duration::from_millis(100)).await;
         drop(shutdown_tx);
 
@@ -457,7 +470,12 @@ mod tests {
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
 
         drop(ui_rx); // window's receive loop already gone
-        let manager = tokio::spawn(connection_manager(config, ui_tx, shutdown_rx));
+        let manager = tokio::spawn(connection_manager(
+            config,
+            ui_tx,
+            Arc::new(Mutex::new(None)),
+            shutdown_rx,
+        ));
 
         tokio::time::timeout(Duration::from_secs(1), manager)
             .await

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_client_common::{AssistantClient, ChatMessage, ConnectionConfig, Connector};
@@ -41,6 +41,14 @@ struct WindowWidgets {
     /// Read-only context-window fill indicator (#341).
     context_label: Rc<Label>,
     client: Rc<RefCell<Option<Arc<Connector>>>>,
+    /// Connector handed from the (tokio) connect task to the GTK main thread
+    /// (#106). The connect task stores it here just before `UiMessage::Connected`;
+    /// the `Connected` handler drains it, registers the voice-mode client tools,
+    /// and moves it into `client`. Replaces the removed `UiMessage::ClientReady`
+    /// / `Effect::SetClient` round-trip — the core no longer names `Connector`
+    /// (wasm) — while keeping the connector's arrival ordered before
+    /// `ConversationsLoaded` (the `Connected` trigger rides the same FIFO channel).
+    pending_connector: Arc<Mutex<Option<Arc<Connector>>>>,
     input_bar: Rc<InputBar>,
     model_picker: Rc<ModelPicker>,
     tasks_panel: Rc<TasksPanel>,
@@ -376,6 +384,13 @@ impl AdelieWindow {
         // `&TransportClient` surface (`as_commands()`, `AssistantClient` RPCs).
         let client: Rc<RefCell<Option<Arc<Connector>>>> = Rc::new(RefCell::new(None));
 
+        // Cross-thread connector hand-off (#106): the tokio connect task stores
+        // the freshly connected `Arc<Connector>` here just before it sends
+        // `UiMessage::Connected`; the `Connected` handler (main thread) drains it.
+        // `Arc<Connector>` is `Send`, so this `Arc<Mutex<…>>` is the seam that
+        // carries the handle across the thread boundary now that the core can't.
+        let pending_connector: Arc<Mutex<Option<Arc<Connector>>>> = Arc::new(Mutex::new(None));
+
         // Handle to the standalone voice daemon (`org.desktopAssistant.Voice`),
         // declared here — *before* the bridge — so the `handle_ui_message`
         // executor can also reach it (issue #80): narration prefers the daemon's
@@ -397,6 +412,7 @@ impl AdelieWindow {
             status_label: status_label.clone(),
             context_label: context_label.clone(),
             client: client.clone(),
+            pending_connector: pending_connector.clone(),
             input_bar: input_bar.clone(),
             model_picker: model_picker.clone(),
             tasks_panel: tasks_panel.clone(),
@@ -493,14 +509,20 @@ impl AdelieWindow {
         ));
 
         // Spawn persistent connection manager (connect → forward → reconnect).
-        // It now delivers the freshly connected `Connector` to the main thread
-        // via `UiMessage::ClientReady` on the same channel as every other UI
-        // message (handled in `handle_ui_message`). It exits when the window's
-        // `close-request` signals `shutdown_rx` (GTK-1), dropping its connector
-        // and sender clones.
+        // It delivers the freshly connected `Connector` to the main thread by
+        // stashing it in `pending_connector` and sending `UiMessage::Connected`;
+        // the `Connected` handler drains it, registers voice-mode tools, and moves
+        // it into `client` (#106 — the core no longer carries the handle, for
+        // wasm). It exits when the window's `close-request` signals `shutdown_rx`
+        // (GTK-1), dropping its connector and sender clones.
         {
             let ui_tx = bridge.ui_sender();
-            bridge.spawn(connection_manager(config.clone(), ui_tx, shutdown_rx));
+            bridge.spawn(connection_manager(
+                config.clone(),
+                ui_tx,
+                pending_connector.clone(),
+                shutdown_rx,
+            ));
         }
 
         // Sidebar row activation → load conversation
@@ -1338,6 +1360,7 @@ fn handle_ui_message(
         status_label,
         context_label,
         client,
+        pending_connector,
         input_bar,
         model_picker,
         tasks_panel,
@@ -1348,31 +1371,19 @@ fn handle_ui_message(
         voice,
     } = widgets;
 
+    // Connector hand-off (#106): the connect task stashes the `Arc<Connector>`
+    // in `pending_connector` just before sending `Connected`. Note it before
+    // `apply` consumes `msg`; the actual adopt happens after the effects below,
+    // matching the old ordering (the connector was stored *after* `Connected`'s
+    // own effects ran, since `ClientReady` followed `Connected` on the channel).
+    let connector_arrived = matches!(&msg, UiMessage::Connected { .. });
+
     // Pure decision: mutate state + compute the effects to perform.
     let effects = state.borrow_mut().apply(msg);
 
     // Thin executor: perform each effect against the real widgets, in order.
     for effect in effects {
         match effect {
-            Effect::SetClient(connector) => {
-                // Advertise gtk's session-scoped voice-mode client tools so the
-                // model can drive voice mode (issue #78). Registered once on
-                // connect; the Connector remembers + replays this set after an
-                // auto-reconnect (#246), so a daemon restart won't drop them.
-                // Socket-only (UDS/WS) — on a D-Bus transport this is a logged
-                // no-op (the daemon has no command channel for client tools),
-                // which is fine: voice mode still works as a local UI toggle.
-                let registration_connector = Arc::clone(&connector);
-                crate::async_bridge::spawn_on_runtime(async move {
-                    if let Err(e) = registration_connector
-                        .register_client_tools(voice_mode_client_tools())
-                        .await
-                    {
-                        tracing::debug!("voice-mode client tools not registered: {e}");
-                    }
-                });
-                *client.borrow_mut() = Some(connector);
-            }
             Effect::ClearClient => {
                 *client.borrow_mut() = None;
             }
@@ -1646,6 +1657,26 @@ fn handle_ui_message(
                 );
             }
         }
+    }
+
+    // Adopt the connector the connect task handed off (#106), now that any
+    // `Connected` effects (status, send-enable) have been applied. Lifted from
+    // the old `Effect::SetClient` arm; the only change is the source — the
+    // `pending_connector` cell instead of a reducer effect.
+    if connector_arrived && let Some(connector) = pending_connector.lock().unwrap().take() {
+        // Advertise gtk's session-scoped voice-mode client tools (issue #78);
+        // socket-only (UDS/WS), a logged no-op on D-Bus. The Connector replays
+        // them after an auto-reconnect (#246), so a daemon restart won't drop them.
+        let registration_connector = Arc::clone(&connector);
+        crate::async_bridge::spawn_on_runtime(async move {
+            if let Err(e) = registration_connector
+                .register_client_tools(voice_mode_client_tools())
+                .await
+            {
+                tracing::debug!("voice-mode client tools not registered: {e}");
+            }
+        });
+        *client.borrow_mut() = Some(connector);
     }
 }
 


### PR DESCRIPTION
Closes the gtk side of **client-ui-common#2** (wasm enablement), which removes `UiMessage::ClientReady(Arc<Connector>)` and `Effect::SetClient(Arc<Connector>)` — the core can't name a native `Connector` on wasm. gtk was the only client using them.

## Change
gtk-local connector hand-off, replacing the reducer round-trip:
- `async_bridge::drive_connection` stashes the `Arc<Connector>` in a shared `pending_connector: Arc<Mutex<…>>` cell just before `UiMessage::Connected` (was `UiMessage::ClientReady`).
- `handle_ui_message`'s `Connected` path drains the cell, registers the voice-mode client tools, and moves the connector into `client` — the old `Effect::SetClient` body, lifted. Arm deleted. `Effect::ClearClient` unchanged.
- **Why the `Connected` trigger** (not the issue's dedicated-channel/wrapper-enum options): the chat relies on the connector arriving *before* `ConversationsLoaded`. Storing in the cell before the existing `Connected` send keeps that ordering on the one FIFO channel — no churn to the other 63 `UiMessage` sends, no second-channel race.

## Verification
Builds + `just check` green (fmt, clippy `-D warnings`, build, **155 tests**) against the combined wasm stack: client-ui-common `feat/wasm-client-core` **+ main's `SendPrompt`**, desktop-assistant `feat/protocol-crate`, voice `feat/client-voice-wasm-optional`.

## ⚠️ Interlock — must land atomically with client-ui-common#2
This branch removes the `Effect::SetClient` match arm, so it does **not** compile against crate-`main` (which still *has* the variant), and crate-`main` lacks `SendPrompt` only on the wasm branch — see the issue comment for the full picture. **Do not merge this to gtk `main` until `client-ui-common#2` is on crate `main`**, and merge both back-to-back (there's a window where gtk `main` is broken if crate#2 lands first and this lags). Details + exact sequence in #106.

Refs #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)