### PR TITLE
Phase-2 Step 2a: read the open conversation via the core accessor

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -829,7 +829,7 @@ impl AdelieWindow {
                     // Track in local conversation copy
                     {
                         let mut s = state.borrow_mut();
-                        if let Some(ref mut conv) = s.current_conversation {
+                        if let Some(conv) = s.current_conversation_mut() {
                             conv.messages.push(ChatMessage {
                                 // Optimistic local send: no server id yet (empty
                                 // placeholder); the next reload reconciles it.
@@ -1160,8 +1160,7 @@ impl AdelieWindow {
                     let s = state.borrow();
                     let id = s.current_conversation_id.clone();
                     let prefill = s
-                        .current_conversation
-                        .as_ref()
+                        .current_conversation()
                         .and_then(|c| c.conversation_personality);
                     (id, prefill)
                 };


### PR DESCRIPTION
client-ui-common moved the open conversation's detail behind an `open` map; the public `current_conversation` field is gone (client-ui-common#4).

Migrate the two field accesses in `window/mod.rs` to the `current_conversation()` / `current_conversation_mut()` accessors.

Behavior-preserving; builds + **155 tests** green, clippy + fmt clean.

### ⚠️ Atomic landing
Builds only against client-ui-common with the Step 2a API. Lands **together** with **client-ui-common#4** and **adele-tui** `phase2-conversation-model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)