### PR TITLE
Per-conversation composer draft (#2)

### DIFF
--- a/src/widgets/input_bar.rs
+++ b/src/widgets/input_bar.rs
@@ -409,6 +409,17 @@ impl InputBar {
         text
     }
 
+    /// Get the current text content *without* clearing it — a read-only snapshot
+    /// of the composer (issue #2). Used to save the outgoing conversation's
+    /// unsent draft on a switch, where the box is then restored from the incoming
+    /// conversation's draft rather than consumed (cf. [`take_text`](Self::take_text)).
+    pub fn peek_text(&self) -> String {
+        let buffer = self.text_view.buffer();
+        buffer
+            .text(&buffer.start_iter(), &buffer.end_iter(), false)
+            .to_string()
+    }
+
     /// Replace the input's text. Used by the embedded voice path (issue #65) to
     /// drop a dictated transcript into the box before sending it like a typed
     /// message.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1377,6 +1377,31 @@ fn handle_ui_message(
     // own effects ran, since `ClientReady` followed `Connected` on the channel).
     let connector_arrived = matches!(&msg, UiMessage::Connected { .. });
 
+    // Composer draft (#2): a switch to a *different* conversation must save the
+    // outgoing conversation's unsent text and restore the incoming one. Detect
+    // it here — before `apply` repoints `current_conversation_id` — and snapshot
+    // the outgoing draft into the model now (the text view stays the live editor;
+    // the model owns the saved draft). A same-conversation reload
+    // (`ConversationReloaded`, or re-selecting the open conversation) is NOT a
+    // switch, so it leaves the in-progress draft untouched. The matching restore
+    // runs after the effects below, once the new transcript is loaded.
+    let switch_target = if let UiMessage::ConversationLoaded(detail) = &msg {
+        let mut s = state.borrow_mut();
+        match s.current_conversation_id.clone() {
+            // Leaving another conversation: save its draft, then restore ours.
+            Some(outgoing) if outgoing != detail.id => {
+                s.set_composer_draft(&outgoing, input_bar.peek_text());
+                Some(detail.id.clone())
+            }
+            // First load (nothing open yet): nothing to save, still restore ours.
+            None => Some(detail.id.clone()),
+            // Re-selecting the already-open conversation: not a switch.
+            Some(_) => None,
+        }
+    } else {
+        None
+    };
+
     // Pure decision: mutate state + compute the effects to perform.
     let effects = state.borrow_mut().apply(msg);
 
@@ -1656,6 +1681,17 @@ fn handle_ui_message(
                 );
             }
         }
+    }
+
+    // Composer draft (#2): now that the switched-to conversation's transcript is
+    // loaded, restore its saved draft into the live editor (empty if none). Done
+    // here — not in the `LoadConversationIntoChat` effect — because that effect
+    // also fires on a same-conversation reload (reconnect / debug refresh), which
+    // must not overwrite the user's in-progress text. `switch_target` is `Some`
+    // only on a real switch.
+    if let Some(id) = switch_target {
+        let draft = state.borrow().composer_draft(&id).to_string();
+        input_bar.set_text(&draft);
     }
 
     // Adopt the connector the connect task handed off (#106), now that any


### PR DESCRIPTION
## What

The composer was one global `InputBar`, so a half-typed message bled across a conversation switch. This binds the live editor to the shared model's per-conversation draft store: switch away and your draft is saved; switch back and it's restored.

## How

Every switch funnels through the central UI-message dispatch, so save + restore happen there:
- before `apply` repoints `current_conversation_id`, a switch to a *different* conversation snapshots the outgoing `InputBar` text into the model (`set_composer_draft`, via a new read-only `InputBar::peek_text`);
- after the effects run (new transcript loaded), the switched-to conversation's saved draft is restored into the `InputBar`.

Deliberately **not** in the `LoadConversationIntoChat` effect: that also fires on a same-conversation reload (`ConversationReloaded` — reconnect / debug refresh), which must not overwrite the user's in-progress text. Gating on a real switch keeps reloads non-destructive, matching the TUI's `switching` guard. No new `Effect` variant; text only, no cursor tracking.

## Tests

155 pass; clippy + fmt clean. (The widget-dispatch wiring isn't headless-testable — the model logic is covered by client-ui-common's reducer tests.)

## Depends on

client-ui-common#5 (the shared draft store) — merge that first; this branch path-deps it and calls the new accessors. **Live-widget binding wants a manual smoke test.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)