### PR TITLE
Drop minter_socket (peer-cred local auth) + handle Consolidation purpose

### DIFF
--- a/src/widgets/login_screen.rs
+++ b/src/widgets/login_screen.rs
@@ -428,20 +428,16 @@ pub async fn connect_to_profile(
 ) -> anyhow::Result<desktop_assistant_client_common::ConnectionConfig> {
     use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 
-    // Local socket: skip auth discovery entirely. The UDS handshake's bearer
-    // token is minted by the local `adelie-mint` minter (#101/#316) — NOT the
-    // deprecated D-Bus `generate_ws_jwt` path, which the cutover (#319) removed —
-    // so point `minter_socket` at it and let `connect_transport` dial
-    // `$XDG_RUNTIME_DIR/adelie/sock` (or the explicit path). The minter is only
-    // wired for UDS: it issues tokens the *local* daemon trusts, whereas the WS
-    // paths below authenticate to a (remote) server via OAuth/password.
+    // Local socket: skip auth discovery entirely. The UDS connection is
+    // authenticated by kernel peer-cred (desktop-assistant#407) — no token is
+    // minted — and `connect_transport` dials `$XDG_RUNTIME_DIR/adelie/sock` (or
+    // the explicit path). The WS paths below still authenticate to a (remote)
+    // server via OAuth/password.
     let (ws_url, ws_subject) = match &profile.protocol {
         ProtocolConfig::Local { path } => {
             return Ok(ConnectionConfig {
                 transport_mode: TransportMode::Uds,
                 socket_path: path.clone(),
-                minter_socket: desktop_assistant_client_common::minter::default_minter_socket_path(
-                ),
                 ..Default::default()
             });
         }

--- a/src/widgets/purposes_tab.rs
+++ b/src/widgets/purposes_tab.rs
@@ -27,6 +27,7 @@ fn purpose_label(p: api::PurposeKindApi) -> &'static str {
     match p {
         api::PurposeKindApi::Interactive => "Interactive",
         api::PurposeKindApi::Dreaming => "Dreaming",
+        api::PurposeKindApi::Consolidation => "Consolidation",
         api::PurposeKindApi::Embedding => "Embedding",
         api::PurposeKindApi::Titling => "Titling",
     }
@@ -373,6 +374,7 @@ fn apply_purpose_config(
     let cfg = match purpose {
         api::PurposeKindApi::Interactive => purposes.interactive.as_ref(),
         api::PurposeKindApi::Dreaming => purposes.dreaming.as_ref(),
+        api::PurposeKindApi::Consolidation => purposes.consolidation.as_ref(),
         api::PurposeKindApi::Embedding => purposes.embedding.as_ref(),
         api::PurposeKindApi::Titling => purposes.titling.as_ref(),
     };


### PR DESCRIPTION
## What
The daemon now authenticates local UDS connections by **kernel peer-cred** (desktop-assistant#407) and the `adelie-mint` minter is retired. `client-common` dropped the `minter` module and the `minter_socket` field, so this client stops setting it in the `ProtocolConfig::Local` connect path — the local UDS handshake is now **tokenless**.

Touches `src/widgets/login_screen.rs`.

## Also (unblocks the build)
The protocol's `PurposeKind` gained a **`Consolidation`** variant (desktop-assistant#402), so the non-exhaustive `purpose_label` and config-slot matches no longer compiled against current `client-common`. Surfaced it like the other purposes (`all()` already iterates it) in `src/widgets/purposes_tab.rs`.

## Verified
- `cargo install --path . --force` succeeds (default `linux` feature); `adele-gtk` reinstalled.
- `cargo fmt --check` + `cargo clippy --all-targets` clean.
- Local UDS path is tokenless; live daemon (on merged main) already verified accepting peer-cred connections; the reinstalled bridge confirms the same path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)